### PR TITLE
docs: restructure PRD — schema redesign, RBAC overhaul, entity unification

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "server",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev:serv"],
+      "port": 3000
+    },
+    {
+      "name": "client",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev:client"],
+      "port": 5173
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md — Project Instructions for Claude Code
+
+## Git & Commits
+
+- **Never add `Co-Authored-By` lines** to commit messages — suppress the default trailer entirely
+- Husky pre-commit rejects mixed commits touching both `apps/nap-client/` and `apps/nap-serv/` — split into separate commits
+- Working branch: `dev`; PRs target `main`
+
+## Project Overview
+
+PERN monorepo for multi-tenant project costing / profitability / payments with double-entry accounting.
+
+| Workspace | Stack | Entry |
+|---|---|---|
+| `apps/nap-serv` | Express 5, pg-schemata, Passport, Redis, Winston | `server.js` |
+| `apps/nap-client` | React 18, Vite, MUI 5, MUI X Data Grid v6, TanStack Query | `src/main.jsx` |
+| `packages/shared` | Shared constants and utilities | — |
+
+## Key Commands
+
+```bash
+# Dev servers (from repo root)
+npm run dev            # both servers
+npm run dev:serv       # backend only (nodemon, 5 s delay)
+npm run dev:client     # Vite HMR
+
+# Lint
+npm run lint           # ESLint 9 flat config, full monorepo
+
+# Tests (nap-serv — Vitest, Node single-thread)
+npm -w apps/nap-serv test              # all suites
+npm -w apps/nap-serv run test:unit
+npm -w apps/nap-serv run test:contract # supertest API tests
+npm -w apps/nap-serv run test:integration
+npm -w apps/nap-serv run test:rbac
+
+# Database
+npm -w apps/nap-serv run setupAdmin:dev   # bootstrap admin schema
+npm -w apps/nap-serv run migrate:dev      # run migrations
+npm -w apps/nap-serv run seed             # seed dev data
+```
+
+## Architecture
+
+- **Multi-tenant**: schema-per-tenant isolation via pg-schemata; admin schema holds `tenants`, `nap_users`
+- **RBAC**: 4-layer model — policies → data scope → state filters → field groups (see `docs/decisions/0013-four-layer-scoped-rbac.md`)
+- **Auth**: Minimal JWT (sub + ph only) in httpOnly cookies; `authRedis` middleware hydrates `req.user` from nap_users + Redis permission cache
+- **Soft delete**: `deactivated_at` column convention; most tables use pg-schemata `softDelete: true`
+- **Audit fields**: `created_by`, `updated_by` (uuid, nullable), `created_at`, `updated_at`
+
+## pg-schemata Conventions
+
+- Schema defaults: use JS values (`default: 'active'`), NOT SQL literals (`default: "'active'"`) — pg-schemata auto-quotes for DDL but uses raw values for INSERT ColumnSet `def`
+- When `userFields.type: 'uuid'`, audit fields (`created_by`/`updated_by`) must be uuid or null — never strings
+- Circular FKs: remove from schema definition, add via `ALTER TABLE` in migration after all tables created
+- `model.update(id, partialDto)` resets all ColumnSet columns to defaults — use raw SQL for single-column updates
+
+## Code Style
+
+- Prettier: single quotes, trailing commas, 144-char lines (80 for markdown), 2-space indent
+- ESLint: unused vars warn with `^_` prefix ignore, console off
+- MUI X Data Grid v6: `valueGetter(params)` accesses `params.row.field` — the `(value, row)` form is v7 only
+- Prefer `layoutTokens.js` for repeating layout patterns and `theme.js` component overrides over inline `sx`
+
+## Environment
+
+- `.env` lives at monorepo root; `db.js` walks up from cwd to find it
+- Databases: dev → `nap_dev`, test → `nap_test`, user → `nap_admin`
+- PG extensions: `pgcrypto`, `uuid-ossp`, `vector`
+- Node ≥ 20 (`.nvmrc`)

--- a/apps/nap-client/src/App.jsx
+++ b/apps/nap-client/src/App.jsx
@@ -16,6 +16,8 @@ import PlaceholderPage from './pages/PlaceholderPage.jsx';
 /* ── Tenant pages (existing) ──────────────────────────────────── */
 import ManageTenantsPage from './pages/Tenant/ManageTenantsPage.jsx';
 import ManageUsersPage from './pages/Tenant/ManageUsersPage.jsx';
+import ManageRolesPage from './pages/Tenant/ManageRolesPage.jsx';
+import ManageEmployeesPage from './pages/Tenant/ManageEmployeesPage.jsx';
 
 /* ── Dashboard pages ──────────────────────────────────────────── */
 import DashboardPage from './pages/Dashboard/DashboardPage.jsx';
@@ -113,7 +115,8 @@ export default function App() {
           {/* Tenants */}
           <Route path="/tenant/manage-tenants" element={<ManageTenantsPage />} />
           <Route path="/tenant/manage-users" element={<ManageUsersPage />} />
-          <Route path="/tenant/settings" element={<PlaceholderPage title="Tenant Settings" />} />
+          <Route path="/tenant/manage-roles" element={<ManageRolesPage />} />
+          <Route path="/tenant/manage-employees" element={<ManageEmployeesPage />} />
 
           {/* User account */}
           <Route path="/profile" element={<PlaceholderPage title="My Profile" />} />

--- a/apps/nap-client/src/components/layout/ImpersonateDialog.jsx
+++ b/apps/nap-client/src/components/layout/ImpersonateDialog.jsx
@@ -1,0 +1,149 @@
+/**
+ * @file ImpersonateDialog — two-step tenant/user impersonation picker
+ * @module nap-client/components/layout/ImpersonateDialog
+ *
+ * Step 1: Select a tenant from the tenant list.
+ * Step 2: Select a user within that tenant.
+ * Optionally enter a reason, then start impersonation.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Autocomplete,
+  TextField,
+  Box,
+  Typography,
+} from '@mui/material';
+import client from '../../services/client.js';
+import { useAuth } from '../../contexts/AuthContext.jsx';
+
+export default function ImpersonateDialog({ open, onClose }) {
+  const { startImpersonation } = useAuth();
+
+  const [tenants, setTenants] = useState([]);
+  const [selectedTenant, setSelectedTenant] = useState(null);
+  const [users, setUsers] = useState([]);
+  const [selectedUser, setSelectedUser] = useState(null);
+  const [reason, setReason] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Fetch tenants when dialog opens
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await client.get('/tenants/v1/admin/schemas');
+        if (!cancelled) setTenants(list);
+      } catch {
+        // ignore
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [open]);
+
+  // Fetch users when tenant is selected
+  useEffect(() => {
+    if (!selectedTenant) {
+      setUsers([]);
+      setSelectedUser(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await client.get(`/tenants/v1/nap-users?tenant_code=${selectedTenant.tenant_code}`);
+        const rows = Array.isArray(list) ? list : list?.rows || [];
+        if (!cancelled) setUsers(rows);
+      } catch {
+        if (!cancelled) setUsers([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [selectedTenant]);
+
+  const handleStart = async () => {
+    if (!selectedUser) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await startImpersonation(selectedUser.id, reason || undefined);
+      handleClose();
+    } catch (err) {
+      setError(err.message || 'Failed to start impersonation');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    setSelectedTenant(null);
+    setSelectedUser(null);
+    setReason('');
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Impersonate User</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <Autocomplete
+            options={tenants}
+            getOptionLabel={(t) => `${t.company || t.tenant_code} (${t.tenant_code?.toUpperCase()})`}
+            value={selectedTenant}
+            onChange={(_, val) => {
+              setSelectedTenant(val);
+              setSelectedUser(null);
+            }}
+            renderInput={(params) => <TextField {...params} label="Select Tenant" size="small" />}
+          />
+
+          <Autocomplete
+            options={users}
+            getOptionLabel={(u) => `${u.user_name || u.email} (${u.email})`}
+            value={selectedUser}
+            onChange={(_, val) => setSelectedUser(val)}
+            disabled={!selectedTenant}
+            renderInput={(params) => <TextField {...params} label="Select User" size="small" />}
+          />
+
+          <TextField
+            label="Reason (optional)"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            size="small"
+            multiline
+            rows={2}
+          />
+
+          {error && (
+            <Typography color="error" variant="body2">
+              {error}
+            </Typography>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          onClick={handleStart}
+          variant="contained"
+          color="warning"
+          disabled={!selectedUser || loading}
+        >
+          {loading ? 'Starting...' : 'Start Impersonation'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/nap-client/src/components/layout/ImpersonationBanner.jsx
+++ b/apps/nap-client/src/components/layout/ImpersonationBanner.jsx
@@ -1,0 +1,47 @@
+/**
+ * @file ImpersonationBanner — sticky warning banner during impersonation
+ * @module nap-client/components/layout/ImpersonationBanner
+ *
+ * Displays an amber warning bar above TenantBar when the current user
+ * is impersonating another user. Includes an "Exit Impersonation" button.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { Box, Typography, Button } from '@mui/material';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { useAuth } from '../../contexts/AuthContext.jsx';
+
+export default function ImpersonationBanner() {
+  const { impersonation, user, endImpersonation } = useAuth();
+
+  if (!impersonation?.active) return null;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        px: 2,
+        py: 0.5,
+        bgcolor: 'warning.main',
+        color: 'warning.contrastText',
+      }}
+    >
+      <WarningAmberIcon fontSize="small" />
+      <Typography variant="body2" fontWeight={600}>
+        Impersonating: {user?.email || user?.user_name} ({user?.tenant_code?.toUpperCase()})
+      </Typography>
+      <Button
+        size="small"
+        variant="outlined"
+        onClick={endImpersonation}
+        sx={{ color: 'inherit', borderColor: 'inherit', textTransform: 'none', py: 0 }}
+      >
+        Exit Impersonation
+      </Button>
+    </Box>
+  );
+}

--- a/apps/nap-client/src/components/layout/LayoutShell.jsx
+++ b/apps/nap-client/src/components/layout/LayoutShell.jsx
@@ -14,6 +14,7 @@ import { Box, CircularProgress } from '@mui/material';
 import Sidebar from './Sidebar.jsx';
 import TenantBar from './TenantBar.jsx';
 import ModuleBar from './ModuleBar.jsx';
+import ImpersonationBanner from './ImpersonationBanner.jsx';
 import ChangePasswordDialog from '../shared/ChangePasswordDialog.jsx';
 import { useAuth } from '../../contexts/AuthContext.jsx';
 
@@ -48,6 +49,7 @@ export default function LayoutShell() {
 
       {/* Main content area — TenantBar + ModuleBar + Data Viewport */}
       <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
+        <ImpersonationBanner />
         <TenantBar />
         <ModuleBar />
 

--- a/apps/nap-client/src/components/layout/TenantBar.jsx
+++ b/apps/nap-client/src/components/layout/TenantBar.jsx
@@ -26,9 +26,12 @@ import PersonIcon from '@mui/icons-material/Person';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LockResetIcon from '@mui/icons-material/LockReset';
 import LogoutIcon from '@mui/icons-material/Logout';
+import SupervisorAccountIcon from '@mui/icons-material/SupervisorAccount';
 import { useAuth } from '../../contexts/AuthContext.jsx';
 import { tenantBarSx } from '../../config/layoutTokens.js';
 import ChangePasswordDialog from '../shared/ChangePasswordDialog.jsx';
+import TenantPicker from './TenantPicker.jsx';
+import ImpersonateDialog from './ImpersonateDialog.jsx';
 
 function userInitials(user) {
   if (!user) return '?';
@@ -39,10 +42,11 @@ function userInitials(user) {
 }
 
 export default function TenantBar() {
-  const { user, logout, tenant } = useAuth();
+  const { user, logout, tenant, isNapSoftUser, impersonation } = useAuth();
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState(null);
   const [changePwOpen, setChangePwOpen] = useState(false);
+  const [impersonateOpen, setImpersonateOpen] = useState(false);
 
   const handleMenuOpen = (e) => setAnchorEl(e.currentTarget);
   const handleMenuClose = () => setAnchorEl(null);
@@ -61,12 +65,16 @@ export default function TenantBar() {
       <Toolbar variant="dense" sx={{ px: 2, justifyContent: 'space-between' }}>
         {/* Left: Tenant context */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Chip
-            label={tenant?.tenant_code?.toUpperCase() || 'NO TENANT'}
-            size="small"
-            color="primary"
-            variant="outlined"
-          />
+          {isNapSoftUser && !impersonation?.active ? (
+            <TenantPicker />
+          ) : (
+            <Chip
+              label={tenant?.tenant_code?.toUpperCase() || 'NO TENANT'}
+              size="small"
+              color="primary"
+              variant="outlined"
+            />
+          )}
         </Box>
 
         {/* Right: User avatar */}
@@ -135,6 +143,23 @@ export default function TenantBar() {
             Change Password
           </MenuItem>
 
+          {isNapSoftUser && !impersonation?.active && (
+            <>
+              <Divider />
+              <MenuItem
+                onClick={() => {
+                  handleMenuClose();
+                  setImpersonateOpen(true);
+                }}
+              >
+                <ListItemIcon>
+                  <SupervisorAccountIcon fontSize="small" />
+                </ListItemIcon>
+                Impersonate User...
+              </MenuItem>
+            </>
+          )}
+
           <Divider />
 
           <MenuItem onClick={handleSignOut}>
@@ -150,6 +175,11 @@ export default function TenantBar() {
         open={changePwOpen}
         onClose={() => setChangePwOpen(false)}
         onSuccess={() => setChangePwOpen(false)}
+      />
+
+      <ImpersonateDialog
+        open={impersonateOpen}
+        onClose={() => setImpersonateOpen(false)}
       />
     </AppBar>
   );

--- a/apps/nap-client/src/components/layout/TenantPicker.jsx
+++ b/apps/nap-client/src/components/layout/TenantPicker.jsx
@@ -1,0 +1,78 @@
+/**
+ * @file TenantPicker — tenant context switcher for NapSoft users
+ * @module nap-client/components/layout/TenantPicker
+ *
+ * Fetches available tenants from the admin/schemas endpoint and renders
+ * a compact Select dropdown. Only rendered for NapSoft users.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useEffect } from 'react';
+import { Select, MenuItem, Chip } from '@mui/material';
+import client from '../../services/client.js';
+import { useAuth } from '../../contexts/AuthContext.jsx';
+
+export default function TenantPicker() {
+  const { tenant, user, assumeTenant, exitAssumption, assumedTenant } = useAuth();
+  const [tenants, setTenants] = useState([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await client.get('/tenants/v1/admin/schemas');
+        if (!cancelled) setTenants(list);
+      } catch {
+        // ignore — user may not have permission
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const currentCode = assumedTenant?.tenant_code?.toLowerCase() || user?.tenant_code?.toLowerCase() || '';
+
+  const handleChange = (e) => {
+    const code = e.target.value;
+    if (code === '__exit__') {
+      exitAssumption();
+      return;
+    }
+    const selected = tenants.find((t) => t.tenant_code?.toLowerCase() === code);
+    if (selected) {
+      assumeTenant(selected);
+    }
+  };
+
+  if (!tenants.length) {
+    return (
+      <Chip
+        label={tenant?.tenant_code?.toUpperCase() || 'NO TENANT'}
+        size="small"
+        color="primary"
+        variant="outlined"
+      />
+    );
+  }
+
+  return (
+    <Select
+      value={currentCode}
+      onChange={handleChange}
+      size="small"
+      variant="outlined"
+      sx={{ minWidth: 160, height: 32, fontSize: '0.8125rem' }}
+    >
+      {tenants.map((t) => (
+        <MenuItem key={t.id} value={t.tenant_code?.toLowerCase()}>
+          {t.company || t.tenant_code?.toUpperCase()}
+        </MenuItem>
+      ))}
+      {assumedTenant && (
+        <MenuItem value="__exit__" sx={{ fontStyle: 'italic', color: 'text.secondary' }}>
+          Exit Assumed Tenant
+        </MenuItem>
+      )}
+    </Select>
+  );
+}

--- a/apps/nap-client/src/config/navigationConfig.js
+++ b/apps/nap-client/src/config/navigationConfig.js
@@ -17,7 +17,7 @@ import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import PointOfSaleIcon from '@mui/icons-material/PointOfSale';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import AssessmentIcon from '@mui/icons-material/Assessment';
-import ApartmentIcon from '@mui/icons-material/Apartment';
+import SettingsIcon from '@mui/icons-material/Settings';
 
 export const NAV_ITEMS = [
   {
@@ -102,12 +102,12 @@ export const NAV_ITEMS = [
     ],
   },
   {
-    label: 'Tenants',
-    icon: ApartmentIcon,
+    label: 'Settings',
+    icon: SettingsIcon,
     children: [
       { label: 'Manage Tenants', path: '/tenant/manage-tenants', capability: 'tenants::' },
-      { label: 'Manage Users', path: '/tenant/manage-users', capability: 'tenants::' },
-      { label: 'Settings', path: '/tenant/settings' },
+      { label: 'Manage Employees', path: '/tenant/manage-employees', capability: 'core::employees' },
+      { label: 'Manage Roles', path: '/tenant/manage-roles', capability: 'core::roles' },
     ],
   },
 ];

--- a/apps/nap-client/src/config/navigationConfig.js
+++ b/apps/nap-client/src/config/navigationConfig.js
@@ -17,7 +17,7 @@ import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import PointOfSaleIcon from '@mui/icons-material/PointOfSale';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import AssessmentIcon from '@mui/icons-material/Assessment';
-import SettingsIcon from '@mui/icons-material/Settings';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 
 export const NAV_ITEMS = [
   {
@@ -102,12 +102,19 @@ export const NAV_ITEMS = [
     ],
   },
   {
-    label: 'Settings',
-    icon: SettingsIcon,
+    label: 'Admin',
+    icon: AdminPanelSettingsIcon,
     children: [
-      { label: 'Manage Tenants', path: '/tenant/manage-tenants', capability: 'tenants::' },
       { label: 'Manage Employees', path: '/tenant/manage-employees', capability: 'core::employees' },
-      { label: 'Manage Roles', path: '/tenant/manage-roles', capability: 'core::roles' },
+      { label: 'Roles', path: '/tenant/manage-roles', capability: 'core::roles' },
+      {
+        label: 'Tenants',
+        capability: 'tenants::',
+        children: [
+          { label: 'Manage Tenants', path: '/tenant/manage-tenants', capability: 'tenants::' },
+          { label: 'Manage Users', path: '/tenant/manage-users', capability: 'tenants::' },
+        ],
+      },
     ],
   },
 ];

--- a/apps/nap-client/src/contexts/AuthContext.jsx
+++ b/apps/nap-client/src/contexts/AuthContext.jsx
@@ -1,8 +1,8 @@
 /**
- * @file Auth context — user session, login/logout, tenant resolution
+ * @file Auth context — user session, login/logout, tenant resolution, impersonation
  * @module nap-client/contexts/AuthContext
  *
- * Provides { user, loading, login, logout, tenant } to the component tree.
+ * Provides { user, loading, login, logout, tenant, impersonation, ... } to the component tree.
  * On mount, hydrates the session from the httpOnly cookie via getMe().
  *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
@@ -10,12 +10,17 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import authApi from '../services/authApi.js';
+import client, { setAssumedTenant } from '../services/client.js';
+
+const NAPSOFT_TENANT = (import.meta.env.VITE_NAPSOFT_TENANT || 'nap').toLowerCase();
 
 const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [assumedTenant, setAssumedTenantState] = useState(null);
+  const [impersonation, setImpersonation] = useState({ active: false });
 
   // Hydrate session on mount
   useEffect(() => {
@@ -23,7 +28,12 @@ export function AuthProvider({ children }) {
     (async () => {
       try {
         const data = await authApi.getMe();
-        if (!cancelled) setUser(data.user ?? null);
+        if (!cancelled) {
+          const u = data.user ?? null;
+          if (u?.tenant_code) setAssumedTenant(u.tenant_code);
+          setUser(u);
+          setImpersonation(data.impersonation ?? { active: false });
+        }
       } catch {
         if (!cancelled) setUser(null);
       } finally {
@@ -37,13 +47,12 @@ export function AuthProvider({ children }) {
 
   const login = useCallback(async (email, password) => {
     const loginRes = await authApi.login(email, password);
-    // Skip hydrating user when a forced password change is required so the
-    // caller can show the change-password dialog without the early-redirect
-    // (user === truthy) kicking in.  The httpOnly cookie is already set, so
-    // the /change-password endpoint will still authenticate.
     if (!loginRes?.forcePasswordChange) {
       const data = await authApi.getMe();
-      setUser(data.user ?? null);
+      const u = data.user ?? null;
+      if (u?.tenant_code) setAssumedTenant(u.tenant_code);
+      setUser(u);
+      setImpersonation(data.impersonation ?? { active: false });
     }
     return loginRes;
   }, []);
@@ -51,6 +60,7 @@ export function AuthProvider({ children }) {
   const refreshUser = useCallback(async () => {
     const data = await authApi.getMe();
     setUser(data.user ?? null);
+    setImpersonation(data.impersonation ?? { active: false });
   }, []);
 
   const logout = useCallback(async () => {
@@ -59,20 +69,78 @@ export function AuthProvider({ children }) {
     } catch {
       // best-effort
     }
+    setAssumedTenant(null);
+    setAssumedTenantState(null);
+    setImpersonation({ active: false });
     setUser(null);
   }, []);
 
-  const tenant = useMemo(
-    () =>
-      user
-        ? { tenant_code: user.tenant_code, schema_name: user.schema_name }
-        : null,
+  // ── Cross-tenant assumption (NapSoft users only) ─────────────────
+  const assumeTenant = useCallback(async (tenantObj) => {
+    setAssumedTenant(tenantObj.tenant_code);
+    setAssumedTenantState(tenantObj);
+    await refreshUser();
+  }, [refreshUser]);
+
+  const exitAssumption = useCallback(async () => {
+    setAssumedTenant(null);
+    setAssumedTenantState(null);
+    await refreshUser();
+  }, [refreshUser]);
+
+  // ── Impersonation (NapSoft users only) ───────────────────────────
+  const startImpersonation = useCallback(async (targetUserId, reason) => {
+    const result = await client.post('/tenants/v1/admin/impersonate', {
+      target_user_id: targetUserId,
+      reason,
+    });
+    await refreshUser();
+    return result;
+  }, [refreshUser]);
+
+  const endImpersonation = useCallback(async () => {
+    await client.post('/tenants/v1/admin/exit-impersonation');
+    await refreshUser();
+  }, [refreshUser]);
+
+  const isNapSoftUser = useMemo(
+    () => user?.tenant_code?.toLowerCase() === NAPSOFT_TENANT || user?.home_tenant?.toLowerCase() === NAPSOFT_TENANT,
     [user],
   );
 
+  const tenant = useMemo(
+    () => {
+      if (!user) return null;
+      if (assumedTenant) {
+        return {
+          tenant_code: assumedTenant.tenant_code,
+          schema_name: assumedTenant.schema_name || assumedTenant.tenant_code,
+          company: assumedTenant.company,
+          is_assumed: true,
+        };
+      }
+      return { tenant_code: user.tenant_code, schema_name: user.schema_name };
+    },
+    [user, assumedTenant],
+  );
+
   const value = useMemo(
-    () => ({ user, loading, login, logout, refreshUser, tenant }),
-    [user, loading, login, logout, refreshUser, tenant],
+    () => ({
+      user,
+      loading,
+      login,
+      logout,
+      refreshUser,
+      tenant,
+      isNapSoftUser,
+      assumedTenant,
+      assumeTenant,
+      exitAssumption,
+      impersonation,
+      startImpersonation,
+      endImpersonation,
+    }),
+    [user, loading, login, logout, refreshUser, tenant, isNapSoftUser, assumedTenant, assumeTenant, exitAssumption, impersonation, startImpersonation, endImpersonation],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/nap-client/src/hooks/useEmployees.js
+++ b/apps/nap-client/src/hooks/useEmployees.js
@@ -1,0 +1,67 @@
+/**
+ * @file React Query hooks for tenant-scope employees
+ * @module nap-client/hooks/useEmployees
+ *
+ * Provides query and mutation hooks that wrap employeeApi methods.
+ * All mutations invalidate the ['employees'] query key on success.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { employeeApi } from '../services/employeeApi.js';
+
+const EMPLOYEES_KEY = ['employees'];
+
+/** Fetch employees with cursor-based pagination. */
+export function useEmployees(params = { limit: 200, includeDeactivated: 'true' }) {
+  return useQuery({
+    queryKey: [...EMPLOYEES_KEY, params],
+    queryFn: () => employeeApi.list(params),
+  });
+}
+
+/** Fetch a single employee by UUID. */
+export function useEmployee(id) {
+  return useQuery({
+    queryKey: [...EMPLOYEES_KEY, id],
+    queryFn: () => employeeApi.getById(id),
+    enabled: !!id,
+  });
+}
+
+/** Create a new employee. */
+export function useCreateEmployee() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body) => employeeApi.create(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: EMPLOYEES_KEY }),
+  });
+}
+
+/** Update employee fields. Expects { filter: {id}, changes: {...} }. */
+export function useUpdateEmployee() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ filter, changes }) => employeeApi.update(filter, changes),
+    onSuccess: () => qc.invalidateQueries({ queryKey: EMPLOYEES_KEY }),
+  });
+}
+
+/** Archive (soft-delete) an employee. Expects filter: {id}. */
+export function useArchiveEmployee() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (filter) => employeeApi.archive(filter),
+    onSuccess: () => qc.invalidateQueries({ queryKey: EMPLOYEES_KEY }),
+  });
+}
+
+/** Restore (reactivate) an employee. Expects filter: {id}. */
+export function useRestoreEmployee() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (filter) => employeeApi.restore(filter),
+    onSuccess: () => qc.invalidateQueries({ queryKey: EMPLOYEES_KEY }),
+  });
+}

--- a/apps/nap-client/src/hooks/useRbac.js
+++ b/apps/nap-client/src/hooks/useRbac.js
@@ -1,0 +1,141 @@
+/**
+ * @file React Query hooks for RBAC data (roles, members, policies, catalog)
+ * @module nap-client/hooks/useRbac
+ *
+ * Provides query and mutation hooks that wrap rbacApi methods.
+ * Mutations invalidate the appropriate query keys on success.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { rolesApi, roleMembersApi, policiesApi, policyCatalogApi } from '../services/rbacApi.js';
+
+const ROLES_KEY = ['roles'];
+const MEMBERS_KEY = ['role-members'];
+const POLICIES_KEY = ['policies'];
+const CATALOG_KEY = ['policy-catalog'];
+
+// ── Roles ───────────────────────────────────────────────────────────────────
+
+/** Fetch all roles with cursor-based pagination. */
+export function useRoles(params = { limit: 200, includeDeactivated: 'true' }) {
+  return useQuery({
+    queryKey: [...ROLES_KEY, params],
+    queryFn: () => rolesApi.list(params),
+  });
+}
+
+/** Fetch a single role by UUID. */
+export function useRole(id) {
+  return useQuery({
+    queryKey: [...ROLES_KEY, id],
+    queryFn: () => rolesApi.getById(id),
+    enabled: !!id,
+  });
+}
+
+/** Create a new role. */
+export function useCreateRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body) => rolesApi.create(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
+  });
+}
+
+/** Update role fields. Expects { filter: {id}, changes: {...} }. */
+export function useUpdateRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ filter, changes }) => rolesApi.update(filter, changes),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
+  });
+}
+
+/** Archive (soft-delete) a role. Expects filter: {id}. */
+export function useArchiveRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (filter) => rolesApi.archive(filter),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
+  });
+}
+
+/** Restore (reactivate) a role. Expects filter: {id}. */
+export function useRestoreRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (filter) => rolesApi.restore(filter),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
+  });
+}
+
+// ── Role Members ────────────────────────────────────────────────────────────
+
+/** Fetch members for a specific role. */
+export function useRoleMembers(roleId) {
+  return useQuery({
+    queryKey: [...MEMBERS_KEY, roleId],
+    queryFn: () => roleMembersApi.list({ role_id: roleId }),
+    enabled: !!roleId,
+  });
+}
+
+/** Sync all members for a role. Expects { role_id, user_ids }. */
+export function useSyncRoleMembers() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body) => roleMembersApi.sync(body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: MEMBERS_KEY });
+      qc.invalidateQueries({ queryKey: ROLES_KEY });
+    },
+  });
+}
+
+/** Remove a single member from a role. Expects { role_id, user_id }. */
+export function useRemoveRoleMember() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params) => roleMembersApi.remove(params),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: MEMBERS_KEY });
+      qc.invalidateQueries({ queryKey: ROLES_KEY });
+    },
+  });
+}
+
+// ── Policies ────────────────────────────────────────────────────────────────
+
+/** Fetch policies for a specific role. */
+export function usePolicies(roleId) {
+  return useQuery({
+    queryKey: [...POLICIES_KEY, roleId],
+    queryFn: () => policiesApi.list({ role_id: roleId }),
+    enabled: !!roleId,
+  });
+}
+
+/** Sync all policies for a role. Expects { role_id, policies }. */
+export function useSyncPolicies() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body) => policiesApi.syncForRole(body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: POLICIES_KEY });
+      qc.invalidateQueries({ queryKey: ROLES_KEY });
+    },
+  });
+}
+
+// ── Policy Catalog ──────────────────────────────────────────────────────────
+
+/** Fetch the full policy catalog (cached aggressively — reference data). */
+export function usePolicyCatalog() {
+  return useQuery({
+    queryKey: CATALOG_KEY,
+    queryFn: () => policyCatalogApi.list({ limit: 500 }),
+    staleTime: Infinity,
+  });
+}

--- a/apps/nap-client/src/pages/Tenant/ManageEmployeesPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageEmployeesPage.jsx
@@ -1,0 +1,417 @@
+/**
+ * @file Manage Employees page — DataGrid list with create / edit / archive / restore
+ * @module nap-client/pages/Tenant/ManageEmployeesPage
+ *
+ * Employees are the source of truth for app access. The is_app_user toggle
+ * drives creation/archival of the linked nap_users login record server-side.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import MenuItem from '@mui/material/MenuItem';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { DataGrid } from '@mui/x-data-grid';
+
+import StatusBadge from '../../components/shared/StatusBadge.jsx';
+import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
+import FormDialog from '../../components/shared/FormDialog.jsx';
+import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
+import {
+  useEmployees,
+  useCreateEmployee,
+  useUpdateEmployee,
+  useArchiveEmployee,
+  useRestoreEmployee,
+} from '../../hooks/useEmployees.js';
+import {
+  pageContainerSx,
+  formGridSx,
+  formFullSpanSx,
+} from '../../config/layoutTokens.js';
+import {
+  buildMutualExclusionHandler,
+  deriveSelectionState,
+} from '../../utils/selectionUtils.js';
+
+/* ── Empty form shapes ────────────────────────────────────────── */
+
+const BLANK_CREATE = {
+  first_name: '',
+  last_name: '',
+  email: '',
+  code: '',
+  position: '',
+  department: '',
+  is_app_user: false,
+};
+
+const BLANK_EDIT = {
+  first_name: '',
+  last_name: '',
+  email: '',
+  code: '',
+  position: '',
+  department: '',
+  is_app_user: false,
+};
+
+const DEPARTMENT_OPTS = ['Engineering', 'Finance', 'Operations', 'Sales', 'HR', 'Admin', 'Other'];
+
+/* ── Column definitions ───────────────────────────────────────── */
+
+const columns = [
+  { field: 'first_name', headerName: 'First Name', width: 140 },
+  { field: 'last_name', headerName: 'Last Name', width: 140 },
+  { field: 'email', headerName: 'Email', flex: 1, minWidth: 200 },
+  { field: 'code', headerName: 'Code', width: 100 },
+  { field: 'position', headerName: 'Position', width: 140 },
+  { field: 'department', headerName: 'Department', width: 130 },
+  {
+    field: 'is_app_user',
+    headerName: 'App User',
+    width: 100,
+    renderCell: ({ value }) =>
+      value ? <Chip label="Yes" color="primary" size="small" /> : <Chip label="No" size="small" variant="outlined" />,
+  },
+  {
+    field: 'deactivated_at',
+    headerName: 'Active',
+    width: 90,
+    valueGetter: (params) => (params.row.deactivated_at ? 'No' : 'Yes'),
+  },
+];
+
+/* ── Component ────────────────────────────────────────────────── */
+
+export default function ManageEmployeesPage() {
+  /* ── queries ─────────────────────────────────────────────── */
+  const { data: employeesRes, isLoading } = useEmployees();
+  const allRows = employeesRes?.rows ?? [];
+
+  /* ── view filter ─────────────────────────────────────────── */
+  const [viewFilter, setViewFilter] = useState('active');
+  const rows = useMemo(() => {
+    if (viewFilter === 'active') return allRows.filter((r) => !r.deactivated_at);
+    if (viewFilter === 'archived') return allRows.filter((r) => !!r.deactivated_at);
+    return allRows;
+  }, [allRows, viewFilter]);
+
+  /* ── mutations ───────────────────────────────────────────── */
+  const createMut = useCreateEmployee();
+  const updateMut = useUpdateEmployee();
+  const archiveMut = useArchiveEmployee();
+  const restoreMut = useRestoreEmployee();
+
+  /* ── selection ───────────────────────────────────────────── */
+  const [selectionModel, setSelectionModel] = useState([]);
+
+  const {
+    selectedRows,
+    selected,
+    isSingle,
+    hasSelection,
+    allActive,
+    allArchived,
+  } = deriveSelectionState(selectionModel, rows);
+
+  const handleSelectionChange = buildMutualExclusionHandler({
+    rows,
+    prevModel: selectionModel,
+    setModel: setSelectionModel,
+  });
+
+  /* ── dialog state ────────────────────────────────────────── */
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const [restoreOpen, setRestoreOpen] = useState(false);
+
+  /* ── form state ──────────────────────────────────────────── */
+  const [createForm, setCreateForm] = useState(BLANK_CREATE);
+  const [editForm, setEditForm] = useState(BLANK_EDIT);
+
+  /* ── snackbar ────────────────────────────────────────────── */
+  const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
+  const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
+  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
+
+  /* ── field change factories ──────────────────────────────── */
+  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
+  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
+
+  /* ── open edit → populate from selected row ──────────────── */
+  const openEdit = useCallback(() => {
+    if (!selected) return;
+    setEditForm({
+      first_name: selected.first_name ?? '',
+      last_name: selected.last_name ?? '',
+      email: selected.email ?? '',
+      code: selected.code ?? '',
+      position: selected.position ?? '',
+      department: selected.department ?? '',
+      is_app_user: !!selected.is_app_user,
+    });
+    setEditOpen(true);
+  }, [selected]);
+
+  /* ── CRUD handlers ───────────────────────────────────────── */
+  const handleCreate = async () => {
+    if (createForm.is_app_user && !createForm.email) {
+      toast('Email is required when granting app access', 'error');
+      return;
+    }
+    try {
+      await createMut.mutateAsync(createForm);
+      toast('Employee created');
+      setCreateOpen(false);
+      setCreateForm(BLANK_CREATE);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (editForm.is_app_user && !editForm.email) {
+      toast('Email is required when granting app access', 'error');
+      return;
+    }
+    try {
+      await updateMut.mutateAsync({ filter: { id: selected.id }, changes: editForm });
+      toast('Employee updated');
+      setEditOpen(false);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  const handleArchive = async () => {
+    try {
+      const targets = selectedRows.filter((r) => !r.deactivated_at);
+      for (const row of targets) {
+        await archiveMut.mutateAsync({ id: row.id });
+      }
+      toast(targets.length === 1 ? 'Employee archived' : `${targets.length} employees archived`);
+      setArchiveOpen(false);
+      setSelectionModel([]);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  const handleRestore = async () => {
+    try {
+      const targets = selectedRows.filter((r) => !!r.deactivated_at);
+      for (const row of targets) {
+        await restoreMut.mutateAsync({ id: row.id });
+      }
+      toast(targets.length === 1 ? 'Employee restored' : `${targets.length} employees restored`);
+      setRestoreOpen(false);
+      setSelectionModel([]);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  /* ── toolbar registration ────────────────────────────────── */
+  const toolbar = useMemo(
+    () => ({
+      tabs: [
+        { value: 'active', label: 'Active', selected: viewFilter === 'active', onClick: () => { setViewFilter('active'); setSelectionModel([]); } },
+        { value: 'all', label: 'All', selected: viewFilter === 'all', onClick: () => { setViewFilter('all'); setSelectionModel([]); } },
+        { value: 'archived', label: 'Archived', selected: viewFilter === 'archived', onClick: () => { setViewFilter('archived'); setSelectionModel([]); } },
+      ],
+      filters: [],
+      primaryActions: [
+        {
+          label: 'Create Employee',
+          variant: 'contained',
+          color: 'primary',
+          onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+        },
+        { label: 'Edit Employee', variant: 'outlined', disabled: !isSingle, onClick: openEdit },
+        {
+          label: selectedRows.length > 1 ? `Archive (${selectedRows.length})` : 'Archive',
+          variant: 'outlined',
+          color: 'error',
+          disabled: !hasSelection || !allActive,
+          onClick: () => setArchiveOpen(true),
+        },
+        {
+          label: selectedRows.length > 1 ? `Restore (${selectedRows.length})` : 'Restore',
+          variant: 'outlined',
+          color: 'success',
+          disabled: !hasSelection || !allArchived,
+          onClick: () => setRestoreOpen(true),
+        },
+      ],
+    }),
+    [selected, isSingle, hasSelection, allActive, allArchived, selectedRows.length, viewFilter, openEdit],
+  );
+  useModuleToolbarRegistration(toolbar);
+
+  /* ── render ──────────────────────────────────────────────── */
+  return (
+    <Box sx={pageContainerSx}>
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        getRowId={(r) => r.id}
+        loading={isLoading}
+        checkboxSelection
+        rowSelectionModel={selectionModel}
+        onRowSelectionModelChange={handleSelectionChange}
+        pageSizeOptions={[25, 50, 100]}
+        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
+        getRowClassName={(params) => (params.row.deactivated_at ? 'row-archived' : '')}
+      />
+
+      {/* ── Create Dialog ────────────────────────────────────── */}
+      <FormDialog
+        open={createOpen}
+        title="Create Employee"
+        maxWidth="sm"
+        submitLabel="Create"
+        loading={createMut.isPending}
+        onSubmit={handleCreate}
+        onCancel={() => setCreateOpen(false)}
+      >
+        <Box sx={formGridSx}>
+          <TextField label="First Name" required value={createForm.first_name} onChange={onCreateField('first_name')} />
+          <TextField label="Last Name" required value={createForm.last_name} onChange={onCreateField('last_name')} />
+          <TextField label="Email" type="email" value={createForm.email} onChange={onCreateField('email')} />
+          <TextField label="Employee Code" value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
+          <TextField label="Position" value={createForm.position} onChange={onCreateField('position')} />
+          <TextField label="Department" select value={createForm.department} onChange={onCreateField('department')}>
+            <MenuItem value="">None</MenuItem>
+            {DEPARTMENT_OPTS.map((d) => <MenuItem key={d} value={d}>{d}</MenuItem>)}
+          </TextField>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={createForm.is_app_user}
+                onChange={(e) => setCreateForm((p) => ({ ...p, is_app_user: e.target.checked }))}
+              />
+            }
+            label="Grant app access"
+            sx={formFullSpanSx}
+          />
+          {createForm.is_app_user && (
+            <Typography variant="caption" color="text.secondary" sx={formFullSpanSx}>
+              A login account will be created with an initial &quot;invited&quot; status.
+              The employee must change their password on first login.
+              {!createForm.email && (
+                <Typography component="span" variant="caption" color="error.main"> Email is required.</Typography>
+              )}
+            </Typography>
+          )}
+        </Box>
+      </FormDialog>
+
+      {/* ── Edit Dialog ────────────────────────────────────── */}
+      <FormDialog
+        open={editOpen}
+        title="Edit Employee"
+        maxWidth="sm"
+        submitLabel="Save Changes"
+        loading={updateMut.isPending}
+        onSubmit={handleUpdate}
+        onCancel={() => setEditOpen(false)}
+      >
+        <Box sx={formGridSx}>
+          <TextField label="First Name" required value={editForm.first_name} onChange={onEditField('first_name')} />
+          <TextField label="Last Name" required value={editForm.last_name} onChange={onEditField('last_name')} />
+          <TextField label="Email" type="email" value={editForm.email} onChange={onEditField('email')} />
+          <TextField label="Employee Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
+          <TextField label="Position" value={editForm.position} onChange={onEditField('position')} />
+          <TextField label="Department" select value={editForm.department} onChange={onEditField('department')}>
+            <MenuItem value="">None</MenuItem>
+            {DEPARTMENT_OPTS.map((d) => <MenuItem key={d} value={d}>{d}</MenuItem>)}
+          </TextField>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={editForm.is_app_user}
+                onChange={(e) => setEditForm((p) => ({ ...p, is_app_user: e.target.checked }))}
+              />
+            }
+            label="Grant app access"
+            sx={formFullSpanSx}
+          />
+          {editForm.is_app_user && !selected?.is_app_user && (
+            <Typography variant="caption" color="text.secondary" sx={formFullSpanSx}>
+              A login account will be created (or restored) with &quot;invited&quot; status.
+              {!editForm.email && (
+                <Typography component="span" variant="caption" color="error.main"> Email is required.</Typography>
+              )}
+            </Typography>
+          )}
+          {!editForm.is_app_user && selected?.is_app_user && (
+            <Typography variant="caption" color="warning.main" sx={formFullSpanSx}>
+              The linked login account will be archived. The employee will no longer be able to log in.
+            </Typography>
+          )}
+        </Box>
+      </FormDialog>
+
+      {/* ── Archive Confirmation ────────────────────────────── */}
+      <ConfirmDialog
+        open={archiveOpen}
+        title="Archive Employee"
+        message={
+          hasSelection
+            ? selectedRows.length === 1
+              ? `Are you sure you want to archive "${selectedRows[0].first_name} ${selectedRows[0].last_name}"? If they have app access, their login will also be archived.`
+              : `Are you sure you want to archive ${selectedRows.length} employees? Any linked login accounts will also be archived.`
+            : ''
+        }
+        confirmLabel="Archive"
+        confirmColor="error"
+        loading={archiveMut.isPending}
+        onConfirm={handleArchive}
+        onCancel={() => setArchiveOpen(false)}
+      />
+
+      {/* ── Restore Confirmation ────────────────────────────── */}
+      <ConfirmDialog
+        open={restoreOpen}
+        title="Restore Employee"
+        message={
+          hasSelection
+            ? selectedRows.length === 1
+              ? `Restore "${selectedRows[0].first_name} ${selectedRows[0].last_name}"? If they had app access, their login will also be restored.`
+              : `Restore ${selectedRows.length} employees? Any linked login accounts will also be restored.`
+            : ''
+        }
+        confirmLabel="Restore"
+        confirmColor="success"
+        loading={restoreMut.isPending}
+        onConfirm={handleRestore}
+        onCancel={() => setRestoreOpen(false)}
+      />
+
+      {/* ── Snackbar ───────────────────────────────────────── */}
+      <Snackbar
+        open={snack.open}
+        autoHideDuration={4000}
+        onClose={() => setSnack((s) => ({ ...s, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={snack.sev}
+          variant="filled"
+          onClose={() => setSnack((s) => ({ ...s, open: false }))}
+        >
+          {snack.msg}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
@@ -1,0 +1,713 @@
+/**
+ * @file Manage Roles page — RBAC role management with members and policies
+ * @module nap-client/pages/Tenant/ManageRolesPage
+ *
+ * Three-area layout:
+ *   Left  — Roles DataGrid (CRUD)
+ *   Right — Detail panel with Members and Policies tabs (shown on single select)
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import MenuItem from '@mui/material/MenuItem';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Autocomplete from '@mui/material/Autocomplete';
+import { DataGrid } from '@mui/x-data-grid';
+
+import StatusBadge from '../../components/shared/StatusBadge.jsx';
+import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
+import FormDialog from '../../components/shared/FormDialog.jsx';
+import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
+import {
+  useRoles,
+  useCreateRole,
+  useUpdateRole,
+  useArchiveRole,
+  useRestoreRole,
+  useRoleMembers,
+  useSyncRoleMembers,
+  useRemoveRoleMember,
+  usePolicies,
+  useSyncPolicies,
+  usePolicyCatalog,
+} from '../../hooks/useRbac.js';
+import { useUsers } from '../../hooks/useUsers.js';
+import { pageContainerSx, formGridSx } from '../../config/layoutTokens.js';
+import { deriveSelectionState } from '../../utils/selectionUtils.js';
+
+/* ── Enums ────────────────────────────────────────────────────── */
+
+const SCOPE_OPTS = [
+  { value: 'all_projects', label: 'All Projects' },
+  { value: 'assigned_companies', label: 'Assigned Companies' },
+  { value: 'assigned_projects', label: 'Assigned Projects' },
+];
+
+const LEVEL_OPTS = [
+  { value: '', label: '\u2014' },
+  { value: 'none', label: 'None' },
+  { value: 'view', label: 'View' },
+  { value: 'full', label: 'Full' },
+];
+
+/* ── Empty form shapes ────────────────────────────────────────── */
+
+const BLANK_ROLE = {
+  code: '',
+  name: '',
+  description: '',
+  scope: 'all_projects',
+};
+
+/* ── Helpers ──────────────────────────────────────────────────── */
+
+const cap = (s) =>
+  s ? s.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') : '';
+
+/**
+ * Build a tree structure from flat catalog entries for the policy editor.
+ * Groups by module → router → action.
+ */
+function buildCatalogTree(catalogRows) {
+  const modules = new Map();
+
+  for (const entry of catalogRows) {
+    if (!modules.has(entry.module)) {
+      modules.set(entry.module, { label: entry.label, routers: new Map() });
+    }
+    const mod = modules.get(entry.module);
+
+    if (entry.router === null && entry.action === null) {
+      // Module-level entry — update label
+      mod.label = entry.label;
+      continue;
+    }
+
+    if (!mod.routers.has(entry.router)) {
+      mod.routers.set(entry.router, { label: entry.label, actions: [] });
+    }
+    const rtr = mod.routers.get(entry.router);
+
+    if (entry.action === null) {
+      // Router-level entry — update label
+      rtr.label = entry.label;
+    } else {
+      rtr.actions.push({ action: entry.action, label: entry.label });
+    }
+  }
+
+  return modules;
+}
+
+/**
+ * Build a lookup key for a policy: module::router::action
+ */
+function policyKey(module, router, action) {
+  return `${module}::${router || ''}::${action || ''}`;
+}
+
+/* ── Roles column definitions ─────────────────────────────────── */
+
+const rolesColumns = [
+  { field: 'code', headerName: 'Code', width: 140 },
+  { field: 'name', headerName: 'Name', flex: 1, minWidth: 160 },
+  {
+    field: 'scope',
+    headerName: 'Scope',
+    width: 160,
+    renderCell: ({ value }) => <StatusBadge status={value} />,
+  },
+  {
+    field: 'is_system',
+    headerName: 'System',
+    width: 80,
+    renderCell: ({ value }) => (value ? <Chip label="Yes" size="small" color="info" /> : ''),
+  },
+  {
+    field: 'deactivated_at',
+    headerName: 'Active',
+    width: 80,
+    valueGetter: (params) => (params.row.deactivated_at ? 'No' : 'Yes'),
+  },
+];
+
+/* ── Members column definitions ───────────────────────────────── */
+
+const membersColumns = [
+  { field: 'user_name', headerName: 'User Name', width: 150 },
+  { field: 'email', headerName: 'Email', flex: 1, minWidth: 200 },
+  { field: 'full_name', headerName: 'Full Name', width: 160 },
+  {
+    field: 'is_primary',
+    headerName: 'Primary',
+    width: 80,
+    renderCell: ({ value }) => (value ? <Chip label="Yes" size="small" color="primary" /> : ''),
+  },
+];
+
+/* ── Component ────────────────────────────────────────────────── */
+
+export default function ManageRolesPage() {
+  /* ── queries ─────────────────────────────────────────────── */
+  const { data: rolesRes, isLoading: rolesLoading } = useRoles();
+  const allRoles = rolesRes?.rows ?? [];
+
+  const { data: usersRes } = useUsers();
+  const allUsers = usersRes?.rows ?? [];
+
+  /* ── view filter ─────────────────────────────────────────── */
+  const [viewFilter, setViewFilter] = useState('active');
+  const roles = useMemo(() => {
+    if (viewFilter === 'active') return allRoles.filter((r) => !r.deactivated_at);
+    if (viewFilter === 'archived') return allRoles.filter((r) => !!r.deactivated_at);
+    return allRoles;
+  }, [allRoles, viewFilter]);
+
+  /* ── mutations ───────────────────────────────────────────── */
+  const createMut = useCreateRole();
+  const updateMut = useUpdateRole();
+  const archiveMut = useArchiveRole();
+  const restoreMut = useRestoreRole();
+  const syncMembersMut = useSyncRoleMembers();
+  const removeMemberMut = useRemoveRoleMember();
+  const syncPoliciesMut = useSyncPolicies();
+
+  /* ── role selection ──────────────────────────────────────── */
+  const [selectionModel, setSelectionModel] = useState([]);
+  const { selectedRows, selected, isSingle, hasSelection, allActive, allArchived } =
+    deriveSelectionState(selectionModel, roles, 'role');
+
+  /* ── detail panel state ──────────────────────────────────── */
+  const [detailTab, setDetailTab] = useState(0);
+
+  /* ── members data ────────────────────────────────────────── */
+  const { data: membersRes } = useRoleMembers(selected?.id);
+  const memberRows = useMemo(() => {
+    const records = membersRes?.records ?? [];
+    // Enrich with user info
+    return records.map((m) => {
+      const user = allUsers.find((u) => u.id === m.user_id);
+      return {
+        ...m,
+        user_name: user?.user_name ?? '',
+        email: user?.email ?? '',
+        full_name: user?.full_name ?? '',
+      };
+    });
+  }, [membersRes, allUsers]);
+
+  const [memberSelection, setMemberSelection] = useState([]);
+
+  /* ── policies data ───────────────────────────────────────── */
+  const { data: policiesRes } = usePolicies(selected?.id);
+  const currentPolicies = useMemo(() => policiesRes?.records ?? [], [policiesRes?.records]);
+
+  const { data: catalogRes } = usePolicyCatalog();
+  const catalogRows = catalogRes?.rows ?? [];
+  const catalogTree = useMemo(() => buildCatalogTree(catalogRows), [catalogRows]);
+
+  // Policy editor state: map of "module::router::action" → level
+  const [policyEdits, setPolicyEdits] = useState({});
+  const [policiesDirty, setPoliciesDirty] = useState(false);
+
+  // Reset policy edits when selected role changes
+  useEffect(() => {
+    if (!selected?.id) {
+      setPolicyEdits({});
+      setPoliciesDirty(false);
+      return;
+    }
+    const map = {};
+    for (const p of currentPolicies) {
+      map[policyKey(p.module, p.router, p.action)] = p.level;
+    }
+    setPolicyEdits(map);
+    setPoliciesDirty(false);
+  }, [selected?.id, currentPolicies]);
+
+  // Reset member selection when role changes
+  useEffect(() => {
+    setMemberSelection([]);
+  }, [selected?.id]);
+
+  /* ── dialog state ────────────────────────────────────────── */
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const [restoreOpen, setRestoreOpen] = useState(false);
+  const [addMemberOpen, setAddMemberOpen] = useState(false);
+
+  /* ── form state ──────────────────────────────────────────── */
+  const [roleForm, setRoleForm] = useState(BLANK_ROLE);
+  const [addMemberUser, setAddMemberUser] = useState(null);
+
+  /* ── snackbar ────────────────────────────────────────────── */
+  const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
+  const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
+  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
+
+  /* ── field change helpers ────────────────────────────────── */
+  const onField = (f) => (e) => setRoleForm((p) => ({ ...p, [f]: e.target.value }));
+
+  /* ── open edit ───────────────────────────────────────────── */
+  const openEdit = useCallback(() => {
+    if (!selected) return;
+    setRoleForm({
+      code: selected.code ?? '',
+      name: selected.name ?? '',
+      description: selected.description ?? '',
+      scope: selected.scope ?? 'all_projects',
+    });
+    setEditOpen(true);
+  }, [selected]);
+
+  /* ── CRUD handlers ───────────────────────────────────────── */
+  const handleCreate = async () => {
+    try {
+      await createMut.mutateAsync(roleForm);
+      toast('Role created');
+      setCreateOpen(false);
+      setRoleForm(BLANK_ROLE);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  const handleUpdate = async () => {
+    try {
+      await updateMut.mutateAsync({ filter: { id: selected.id }, changes: roleForm });
+      toast('Role updated');
+      setEditOpen(false);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  const handleArchive = async () => {
+    try {
+      for (const row of selectedRows.filter((r) => !r.deactivated_at)) {
+        await archiveMut.mutateAsync({ id: row.id });
+      }
+      toast(selectedRows.length === 1 ? 'Role archived' : `${selectedRows.length} roles archived`);
+      setArchiveOpen(false);
+      setSelectionModel([]);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  const handleRestore = async () => {
+    try {
+      for (const row of selectedRows.filter((r) => !!r.deactivated_at)) {
+        await restoreMut.mutateAsync({ id: row.id });
+      }
+      toast(selectedRows.length === 1 ? 'Role restored' : `${selectedRows.length} roles restored`);
+      setRestoreOpen(false);
+      setSelectionModel([]);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  /* ── member handlers ─────────────────────────────────────── */
+  const handleAddMember = async () => {
+    if (!addMemberUser || !selected?.id) return;
+    try {
+      const currentUserIds = memberRows.map((m) => m.user_id);
+      await syncMembersMut.mutateAsync({
+        role_id: selected.id,
+        user_ids: [...currentUserIds, addMemberUser.id],
+      });
+      toast('Member added');
+      setAddMemberOpen(false);
+      setAddMemberUser(null);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  const handleRemoveMembers = async () => {
+    if (!selected?.id || !memberSelection.length) return;
+    try {
+      for (const memberId of memberSelection) {
+        const member = memberRows.find((m) => m.id === memberId);
+        if (member) {
+          await removeMemberMut.mutateAsync({ role_id: selected.id, user_id: member.user_id });
+        }
+      }
+      toast(memberSelection.length === 1 ? 'Member removed' : `${memberSelection.length} members removed`);
+      setMemberSelection([]);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  // Users not already in the role (for the add member autocomplete)
+  const availableUsers = useMemo(() => {
+    const memberUserIds = new Set(memberRows.map((m) => m.user_id));
+    return allUsers.filter((u) => !memberUserIds.has(u.id) && !u.deactivated_at);
+  }, [allUsers, memberRows]);
+
+  /* ── policy handlers ─────────────────────────────────────── */
+  const handlePolicyChange = (key, level) => {
+    setPolicyEdits((prev) => {
+      const next = { ...prev };
+      if (level === '') {
+        delete next[key];
+      } else {
+        next[key] = level;
+      }
+      return next;
+    });
+    setPoliciesDirty(true);
+  };
+
+  const handleSavePolicies = async () => {
+    if (!selected?.id) return;
+    try {
+      const policies = Object.entries(policyEdits).map(([key, level]) => {
+        const [module, router, action] = key.split('::');
+        return {
+          module,
+          router: router || null,
+          action: action || null,
+          level,
+        };
+      });
+      await syncPoliciesMut.mutateAsync({ role_id: selected.id, policies });
+      toast('Policies saved');
+      setPoliciesDirty(false);
+    } catch (err) {
+      toast(errMsg(err), 'error');
+    }
+  };
+
+  /* ── toolbar registration ────────────────────────────────── */
+  const canArchive = hasSelection && allActive && !selectedRows.some((r) => r.is_system);
+  const canEdit = isSingle && !selected?.is_immutable;
+
+  const toolbar = useMemo(
+    () => ({
+      tabs: [
+        { value: 'active', label: 'Active', selected: viewFilter === 'active', onClick: () => { setViewFilter('active'); setSelectionModel([]); } },
+        { value: 'all', label: 'All', selected: viewFilter === 'all', onClick: () => { setViewFilter('all'); setSelectionModel([]); } },
+        { value: 'archived', label: 'Archived', selected: viewFilter === 'archived', onClick: () => { setViewFilter('archived'); setSelectionModel([]); } },
+      ],
+      filters: [],
+      primaryActions: [
+        {
+          label: 'Create Role',
+          variant: 'contained',
+          color: 'primary',
+          onClick: () => { setRoleForm(BLANK_ROLE); setCreateOpen(true); },
+        },
+        { label: 'Edit Role', variant: 'outlined', disabled: !canEdit, onClick: openEdit },
+        {
+          label: selectedRows.length > 1 ? `Archive (${selectedRows.length})` : 'Archive',
+          variant: 'outlined',
+          color: 'error',
+          disabled: !canArchive,
+          onClick: () => setArchiveOpen(true),
+        },
+        {
+          label: selectedRows.length > 1 ? `Restore (${selectedRows.length})` : 'Restore',
+          variant: 'outlined',
+          color: 'success',
+          disabled: !hasSelection || !allArchived,
+          onClick: () => setRestoreOpen(true),
+        },
+      ],
+    }),
+    [canEdit, canArchive, hasSelection, allArchived, selectedRows.length, viewFilter, openEdit],
+  );
+  useModuleToolbarRegistration(toolbar);
+
+  /* ── render ──────────────────────────────────────────────── */
+  return (
+    <Box sx={{ ...pageContainerSx, flexDirection: 'row', gap: 2 }}>
+      {/* ── Left: Roles grid ──────────────────────────────────── */}
+      <Box sx={{ flex: isSingle ? '0 0 420px' : 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+        <DataGrid
+          rows={roles}
+          columns={rolesColumns}
+          getRowId={(r) => r.id}
+          loading={rolesLoading}
+          checkboxSelection
+          rowSelectionModel={selectionModel}
+          onRowSelectionModelChange={setSelectionModel}
+          pageSizeOptions={[25, 50, 100]}
+          initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
+          getRowClassName={(params) => (params.row.deactivated_at ? 'row-archived' : '')}
+        />
+      </Box>
+
+      {/* ── Right: Detail panel ───────────────────────────────── */}
+      {isSingle && (
+        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            {selected.name}
+            {selected.is_system && <Chip label="System" size="small" color="info" sx={{ ml: 1 }} />}
+            {selected.is_immutable && <Chip label="Immutable" size="small" color="warning" sx={{ ml: 1 }} />}
+          </Typography>
+          {selected.description && (
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {selected.description}
+            </Typography>
+          )}
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            Scope: <StatusBadge status={selected.scope} />
+          </Typography>
+
+          <Tabs value={detailTab} onChange={(_, v) => setDetailTab(v)} sx={{ mb: 1 }}>
+            <Tab label="Members" />
+            <Tab label="Policies" />
+          </Tabs>
+
+          {/* ── Members Tab ─────────────────────────────────────── */}
+          {detailTab === 0 && (
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={() => { setAddMemberUser(null); setAddMemberOpen(true); }}
+                >
+                  Add Member
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="error"
+                  disabled={!memberSelection.length}
+                  onClick={handleRemoveMembers}
+                >
+                  {memberSelection.length > 1 ? `Remove (${memberSelection.length})` : 'Remove'}
+                </Button>
+              </Box>
+              <DataGrid
+                rows={memberRows}
+                columns={membersColumns}
+                getRowId={(r) => r.id}
+                checkboxSelection
+                rowSelectionModel={memberSelection}
+                onRowSelectionModelChange={setMemberSelection}
+                pageSizeOptions={[10, 25]}
+                initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                autoHeight
+              />
+            </Box>
+          )}
+
+          {/* ── Policies Tab ────────────────────────────────────── */}
+          {detailTab === 1 && (
+            <Box sx={{ flex: 1, overflow: 'auto' }}>
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+                <Button
+                  size="small"
+                  variant="contained"
+                  disabled={!policiesDirty || syncPoliciesMut.isPending}
+                  onClick={handleSavePolicies}
+                >
+                  {syncPoliciesMut.isPending ? 'Saving...' : 'Save Policies'}
+                </Button>
+              </Box>
+
+              {[...catalogTree.entries()].map(([moduleName, mod]) => (
+                <Box key={moduleName} sx={{ mb: 2 }}>
+                  {/* Module-level row */}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5, py: 0.5, bgcolor: 'action.hover', px: 1, borderRadius: 1 }}>
+                    <Typography variant="subtitle2" sx={{ flex: 1 }}>
+                      {mod.label}
+                    </Typography>
+                    <TextField
+                      select
+                      size="small"
+                      value={policyEdits[policyKey(moduleName, null, null)] ?? ''}
+                      onChange={(e) => handlePolicyChange(policyKey(moduleName, null, null), e.target.value)}
+                      sx={{ width: 100 }}
+                    >
+                      {LEVEL_OPTS.map((o) => <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>)}
+                    </TextField>
+                  </Box>
+
+                  {/* Router-level rows */}
+                  {[...mod.routers.entries()].map(([routerName, rtr]) => (
+                    <Box key={routerName} sx={{ ml: 2 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.25, py: 0.25, px: 1 }}>
+                        <Typography variant="body2" sx={{ flex: 1 }}>
+                          {rtr.label}
+                        </Typography>
+                        <TextField
+                          select
+                          size="small"
+                          value={policyEdits[policyKey(moduleName, routerName, null)] ?? ''}
+                          onChange={(e) => handlePolicyChange(policyKey(moduleName, routerName, null), e.target.value)}
+                          sx={{ width: 100 }}
+                        >
+                          {LEVEL_OPTS.map((o) => <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>)}
+                        </TextField>
+                      </Box>
+
+                      {/* Action-level rows */}
+                      {rtr.actions.map((act) => (
+                        <Box key={act.action} sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: 2, mb: 0.25, py: 0.25, px: 1 }}>
+                          <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+                            {act.label}
+                          </Typography>
+                          <TextField
+                            select
+                            size="small"
+                            value={policyEdits[policyKey(moduleName, routerName, act.action)] ?? ''}
+                            onChange={(e) => handlePolicyChange(policyKey(moduleName, routerName, act.action), e.target.value)}
+                            sx={{ width: 100 }}
+                          >
+                            {LEVEL_OPTS.map((o) => <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>)}
+                          </TextField>
+                        </Box>
+                      ))}
+                    </Box>
+                  ))}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {/* ── Create Role Dialog ──────────────────────────────── */}
+      <FormDialog
+        open={createOpen}
+        title="Create Role"
+        maxWidth="sm"
+        submitLabel="Create"
+        loading={createMut.isPending}
+        onSubmit={handleCreate}
+        onCancel={() => setCreateOpen(false)}
+      >
+        <Box sx={formGridSx}>
+          <TextField label="Code" required value={roleForm.code} onChange={onField('code')} inputProps={{ maxLength: 64 }} />
+          <TextField label="Name" required value={roleForm.name} onChange={onField('name')} inputProps={{ maxLength: 128 }} />
+          <TextField label="Scope" select value={roleForm.scope} onChange={onField('scope')}>
+            {SCOPE_OPTS.map((o) => <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>)}
+          </TextField>
+          <TextField
+            label="Description"
+            multiline
+            minRows={2}
+            value={roleForm.description}
+            onChange={onField('description')}
+            sx={{ gridColumn: '1 / -1' }}
+          />
+        </Box>
+      </FormDialog>
+
+      {/* ── Edit Role Dialog ───────────────────────────────── */}
+      <FormDialog
+        open={editOpen}
+        title="Edit Role"
+        maxWidth="sm"
+        submitLabel="Save Changes"
+        loading={updateMut.isPending}
+        onSubmit={handleUpdate}
+        onCancel={() => setEditOpen(false)}
+      >
+        <Box sx={formGridSx}>
+          <TextField label="Code" required value={roleForm.code} onChange={onField('code')} inputProps={{ maxLength: 64 }} />
+          <TextField label="Name" required value={roleForm.name} onChange={onField('name')} inputProps={{ maxLength: 128 }} />
+          <TextField label="Scope" select value={roleForm.scope} onChange={onField('scope')}>
+            {SCOPE_OPTS.map((o) => <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>)}
+          </TextField>
+          <TextField
+            label="Description"
+            multiline
+            minRows={2}
+            value={roleForm.description}
+            onChange={onField('description')}
+            sx={{ gridColumn: '1 / -1' }}
+          />
+        </Box>
+      </FormDialog>
+
+      {/* ── Add Member Dialog ──────────────────────────────── */}
+      <FormDialog
+        open={addMemberOpen}
+        title="Add Member"
+        maxWidth="sm"
+        submitLabel="Add"
+        loading={syncMembersMut.isPending}
+        submitDisabled={!addMemberUser}
+        onSubmit={handleAddMember}
+        onCancel={() => setAddMemberOpen(false)}
+      >
+        <Autocomplete
+          options={availableUsers}
+          getOptionLabel={(u) => `${u.user_name} (${u.email})`}
+          value={addMemberUser}
+          onChange={(_, val) => setAddMemberUser(val)}
+          renderInput={(params) => <TextField {...params} label="Select User" />}
+        />
+      </FormDialog>
+
+      {/* ── Archive Confirmation ─────────────────────────────── */}
+      <ConfirmDialog
+        open={archiveOpen}
+        title="Archive Role"
+        message={
+          hasSelection
+            ? selectedRows.length === 1
+              ? `Are you sure you want to archive the "${selectedRows[0].name}" role?`
+              : `Are you sure you want to archive ${selectedRows.length} roles?`
+            : ''
+        }
+        confirmLabel="Archive"
+        confirmColor="error"
+        loading={archiveMut.isPending}
+        onConfirm={handleArchive}
+        onCancel={() => setArchiveOpen(false)}
+      />
+
+      {/* ── Restore Confirmation ─────────────────────────────── */}
+      <ConfirmDialog
+        open={restoreOpen}
+        title="Restore Role"
+        message={
+          hasSelection
+            ? selectedRows.length === 1
+              ? `Restore the "${selectedRows[0].name}" role?`
+              : `Restore ${selectedRows.length} roles?`
+            : ''
+        }
+        confirmLabel="Restore"
+        confirmColor="success"
+        loading={restoreMut.isPending}
+        onConfirm={handleRestore}
+        onCancel={() => setRestoreOpen(false)}
+      />
+
+      {/* ── Snackbar ────────────────────────────────────────── */}
+      <Snackbar
+        open={snack.open}
+        autoHideDuration={4000}
+        onClose={() => setSnack((s) => ({ ...s, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={snack.sev}
+          variant="filled"
+          onClose={() => setSnack((s) => ({ ...s, open: false }))}
+        >
+          {snack.msg}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
@@ -42,6 +42,7 @@ import {
   useArchiveUser,
   useRestoreUser,
 } from '../../hooks/useUsers.js';
+import { useRoles } from '../../hooks/useRbac.js';
 import {
   pageContainerSx,
   formGridSx,
@@ -76,6 +77,7 @@ const BLANK_REGISTER = {
   password: '',
   role: 'member',
   tenant_role: '',
+  role_id: '',
   tax_id: '',
   notes: '',
 };
@@ -159,6 +161,9 @@ export default function ManageUsersPage() {
   /* ── queries ─────────────────────────────────────────────── */
   const { data: usersRes, isLoading } = useUsers();
   const allRows = usersRes?.rows ?? [];
+
+  const { data: rolesRes } = useRoles({ limit: 200 });
+  const availableRoles = useMemo(() => (rolesRes?.rows ?? []).filter((r) => !r.deactivated_at), [rolesRes]);
 
   /* ── view filter ─────────────────────────────────────────── */
   const [viewFilter, setViewFilter] = useState('active');
@@ -312,6 +317,7 @@ export default function ManageUsersPage() {
         ...regForm,
         tenant_code: regForm.tenant_code.toUpperCase(),
         tenant_role: regForm.tenant_role || null,
+        role_id: regForm.role_id || undefined,
         phones: regPhones.filter((p) => p.phone_number),
         addresses: regAddresses.filter((a) => a.address_line_1),
       };
@@ -462,6 +468,10 @@ export default function ManageUsersPage() {
           </TextField>
           <TextField label="Tenant Role" select value={regForm.tenant_role} onChange={onRegField('tenant_role')}>
             {TENANT_ROLE_OPTS.map((o) => <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>)}
+          </TextField>
+          <TextField label="RBAC Role" select value={regForm.role_id} onChange={onRegField('role_id')} helperText="Assign tenant RBAC role on creation">
+            <MenuItem value="">None</MenuItem>
+            {availableRoles.map((r) => <MenuItem key={r.id} value={r.id}>{r.name}</MenuItem>)}
           </TextField>
           <TextField label="Tax ID" value={regForm.tax_id} onChange={onRegField('tax_id')} />
           <TextField label="Notes" multiline minRows={2} value={regForm.notes} onChange={onRegField('notes')} sx={formFullSpanSx} />

--- a/apps/nap-client/src/services/client.js
+++ b/apps/nap-client/src/services/client.js
@@ -12,6 +12,15 @@
 const BASE = '/api';
 
 let refreshPromise = null;
+let _assumedTenantCode = null;
+
+export function setAssumedTenant(code) {
+  _assumedTenantCode = code ? code.toLowerCase() : null;
+}
+
+export function getAssumedTenant() {
+  return _assumedTenantCode;
+}
 
 function doFetch(method, url, headers, body, opts) {
   return fetch(url, {
@@ -26,6 +35,10 @@ function doFetch(method, url, headers, body, opts) {
 async function request(method, path, body, opts = {}) {
   const url = `${BASE}${path}`;
   const headers = { ...(opts.headers || {}) };
+
+  if (_assumedTenantCode) {
+    headers['x-tenant-code'] = _assumedTenantCode;
+  }
 
   if (body && !(body instanceof FormData)) {
     headers['Content-Type'] = 'application/json';

--- a/apps/nap-client/src/services/employeeApi.js
+++ b/apps/nap-client/src/services/employeeApi.js
@@ -1,0 +1,44 @@
+/**
+ * @file Employee API methods — CRUD for tenant-scope employees
+ * @module nap-client/services/employeeApi
+ *
+ * All update/archive/restore endpoints read identifiers from query params.
+ * Base path: /core/v1/employees
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { client } from './client.js';
+
+const BASE = '/core/v1/employees';
+
+/** Build a query-string suffix from a params object. */
+const qs = (params) => {
+  const s = new URLSearchParams(params).toString();
+  return s ? `?${s}` : '';
+};
+
+export const employeeApi = {
+  /** GET / — cursor-based pagination. */
+  list: (params = {}) => client.get(`${BASE}${qs(params)}`),
+
+  /** GET /:id — single employee by UUID. */
+  getById: (id) => client.get(`${BASE}/${id}`),
+
+  /** POST / — create a new employee. */
+  create: (body) => client.post(BASE, body),
+
+  /** PUT /update?{filter} — filter in query string, changes in body. */
+  update: (filterParams, changes) =>
+    client.put(`${BASE}/update${qs(filterParams)}`, changes),
+
+  /** DELETE /archive?{filter} — soft-delete employee. */
+  archive: (filterParams) =>
+    client.del(`${BASE}/archive${qs(filterParams)}`, {}),
+
+  /** PATCH /restore?{filter} — reactivate employee. */
+  restore: (filterParams) =>
+    client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
+};
+
+export default employeeApi;

--- a/apps/nap-client/src/services/rbacApi.js
+++ b/apps/nap-client/src/services/rbacApi.js
@@ -1,0 +1,85 @@
+/**
+ * @file RBAC API methods — CRUD for roles, role members, policies, and policy catalog
+ * @module nap-client/services/rbacApi
+ *
+ * All update/archive/restore endpoints read identifiers from query params.
+ * Base paths: /core/v1/roles, /core/v1/role-members, /core/v1/policies, /core/v1/policy-catalog
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { client } from './client.js';
+
+/** Build a query-string suffix from a params object. */
+const qs = (params) => {
+  const s = new URLSearchParams(params).toString();
+  return s ? `?${s}` : '';
+};
+
+// ── Roles ───────────────────────────────────────────────────────────────────
+
+const ROLES_BASE = '/core/v1/roles';
+
+export const rolesApi = {
+  /** GET / — cursor-based pagination. */
+  list: (params = {}) => client.get(`${ROLES_BASE}${qs(params)}`),
+
+  /** GET /:id — single role by UUID. */
+  getById: (id) => client.get(`${ROLES_BASE}/${id}`),
+
+  /** POST / — create a new role. */
+  create: (body) => client.post(ROLES_BASE, body),
+
+  /** PUT /update?{filter} — update role fields. */
+  update: (filterParams, changes) =>
+    client.put(`${ROLES_BASE}/update${qs(filterParams)}`, changes),
+
+  /** DELETE /archive?{filter} — soft-delete role. */
+  archive: (filterParams) =>
+    client.del(`${ROLES_BASE}/archive${qs(filterParams)}`, {}),
+
+  /** PATCH /restore?{filter} — reactivate role. */
+  restore: (filterParams) =>
+    client.patch(`${ROLES_BASE}/restore${qs(filterParams)}`, {}),
+};
+
+// ── Role Members ────────────────────────────────────────────────────────────
+
+const MEMBERS_BASE = '/core/v1/role-members';
+
+export const roleMembersApi = {
+  /** GET /where?role_id=... — list members for a specific role. */
+  list: (params = {}) => client.get(`${MEMBERS_BASE}/where${qs(params)}`),
+
+  /** POST / — add a single member to a role. */
+  create: (body) => client.post(MEMBERS_BASE, body),
+
+  /** PUT /sync — replace all members for a role. Accepts { role_id, user_ids }. */
+  sync: (body) => client.put(`${MEMBERS_BASE}/sync`, body),
+
+  /** DELETE /remove?role_id=...&user_id=... — hard-delete a single membership. */
+  remove: (params) => client.del(`${MEMBERS_BASE}/remove${qs(params)}`, {}),
+};
+
+// ── Policies ────────────────────────────────────────────────────────────────
+
+const POLICIES_BASE = '/core/v1/policies';
+
+export const policiesApi = {
+  /** GET /where?role_id=... — list policies for a specific role. */
+  list: (params = {}) => client.get(`${POLICIES_BASE}/where${qs(params)}`),
+
+  /** PUT /sync-for-role — replace all policies for a role. Accepts { role_id, policies }. */
+  syncForRole: (body) => client.put(`${POLICIES_BASE}/sync-for-role`, body),
+};
+
+// ── Policy Catalog ──────────────────────────────────────────────────────────
+
+const CATALOG_BASE = '/core/v1/policy-catalog';
+
+export const policyCatalogApi = {
+  /** GET / — fetch full catalog of valid module/router/action combinations. */
+  list: (params = {}) => client.get(`${CATALOG_BASE}${qs(params)}`),
+};
+
+export default { rolesApi, roleMembersApi, policiesApi, policyCatalogApi };

--- a/apps/nap-serv/Modules/ar/apiRoutes/v1/arInvoicesRouter.js
+++ b/apps/nap-serv/Modules/ar/apiRoutes/v1/arInvoicesRouter.js
@@ -4,7 +4,7 @@
  *
  * Includes RBAC enforcement for the approve action per PRD §3.1.2.
  * The withMeta middleware annotates req.resource so that the
- * ar::invoices::approve policy can restrict approval rights.
+ * ar::ar-invoices::approve policy can restrict approval rights.
  *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
@@ -19,11 +19,11 @@ import arInvoicesController from '../../controllers/arInvoicesController.js';
 const router = Router();
 
 // RBAC-gated approval endpoint: PUT /approve
-// Requires ar::invoices::approve at 'full' level
+// Requires ar::ar-invoices::approve at 'full' level
 router.put(
   '/approve',
   addAuditFields,
-  withMeta({ module: 'ar', router: 'invoices', action: 'approve' }),
+  withMeta({ module: 'ar', router: 'ar-invoices', action: 'approve' }),
   rbac('full'),
   (req, res) => {
     // Set status to 'sent' (approval = sending the invoice to the client)

--- a/apps/nap-serv/Modules/projects/schemas/tasksMasterSchema.js
+++ b/apps/nap-serv/Modules/projects/schemas/tasksMasterSchema.js
@@ -26,8 +26,8 @@ const tasksMasterSchema = {
     foreignKeys: [
       {
         type: 'ForeignKey',
-        columns: ['task_group_code'],
-        references: { table: 'task_groups', columns: ['code'] },
+        columns: ['tenant_id', 'task_group_code'],
+        references: { table: 'task_groups', columns: ['tenant_id', 'code'] },
         onDelete: 'RESTRICT',
       },
     ],

--- a/apps/nap-serv/src/lib/ViewController.js
+++ b/apps/nap-serv/src/lib/ViewController.js
@@ -4,18 +4,25 @@
  *
  * Provides: get (cursor-based), getById, getWhere, exportXls, handleError, model(), getSchema()
  *
+ * Subclasses may set `this.rbacConfig` to opt into Layer 2-4 enforcement:
+ *   { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' }
+ *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
 
 import fs from 'fs';
 import db from '../db/db.js';
 import logger from '../utils/logger.js';
+import { buildQueryContext } from '../utils/RbacQueryContext.js';
 
 const PG_ERROR_STATUS = {
   23505: 409, // unique_violation
   23503: 400, // foreign_key_violation
   22001: 400, // string_data_right_truncation
 };
+
+/** System roles that bypass all Layer 2-4 filtering. */
+const BYPASS_ROLES = new Set(['super_user', 'admin']);
 
 class ViewController {
   constructor(modelName, errorLabel = null) {
@@ -24,6 +31,8 @@ class ViewController {
     }
     this.modelName = modelName;
     this.errorLabel = errorLabel ?? modelName;
+    /** @type {{ module: string, router: string, scopeColumn: string } | null} */
+    this.rbacConfig = null;
   }
 
   /**
@@ -46,6 +55,84 @@ class ViewController {
     const m = db(this.modelName, schemaName);
     if (!m) throw new Error(`Model '${this.modelName}' not found for schema '${schemaName}'`);
     return m;
+  }
+
+  /**
+   * Apply RBAC Layer 2-4 filters to query conditions and options.
+   * No-op when rbacConfig is null or user has a system bypass role.
+   *
+   * @param {object} req Express request (for perms + user role)
+   * @param {Array} conditions Mutable conditions array — scope/state filters are pushed in
+   * @param {object} options Mutable options object — columnWhitelist may be narrowed
+   */
+  _applyRbacFilters(req, conditions, options) {
+    if (!this.rbacConfig) return;
+    if (BYPASS_ROLES.has(req?.user?.role)) return;
+
+    const qctx = buildQueryContext(
+      req?.ctx?.perms,
+      this.rbacConfig.module,
+      this.rbacConfig.router,
+    );
+
+    // Layer 2: Data scope — restrict to assigned companies or projects
+    if (qctx.scope === 'assigned_companies') {
+      const col = this.rbacConfig.scopeColumn || 'project_id';
+      if (col === 'company_id' && qctx.companyIds) {
+        conditions.push({ [col]: { $in: qctx.companyIds } });
+      } else if (qctx.projectIds) {
+        conditions.push({ [col]: { $in: qctx.projectIds } });
+      }
+    } else if (qctx.scope === 'assigned_projects' && qctx.projectIds) {
+      const col = this.rbacConfig.scopeColumn || 'project_id';
+      conditions.push({ [col]: { $in: qctx.projectIds } });
+    }
+
+    // Layer 3: State filter — restrict to visible statuses
+    if (qctx.visibleStatuses) {
+      conditions.push({ status: { $in: qctx.visibleStatuses } });
+    }
+
+    // Layer 4: Field groups — restrict visible columns
+    if (qctx.allowedColumns) {
+      // Always include 'id' so records remain addressable
+      const allowed = new Set(qctx.allowedColumns);
+      allowed.add('id');
+
+      if (options.columnWhitelist) {
+        // Intersect with any caller-requested whitelist
+        options.columnWhitelist = options.columnWhitelist.filter((c) => allowed.has(c));
+        if (!options.columnWhitelist.length) options.columnWhitelist = ['id'];
+      } else {
+        options.columnWhitelist = [...allowed];
+      }
+    }
+  }
+
+  /**
+   * Strip disallowed fields from a single record (for getById).
+   * Returns the record unchanged when no field-group restriction applies.
+   */
+  _filterRecordFields(req, record) {
+    if (!this.rbacConfig || !record) return record;
+    if (BYPASS_ROLES.has(req?.user?.role)) return record;
+
+    const qctx = buildQueryContext(
+      req?.ctx?.perms,
+      this.rbacConfig.module,
+      this.rbacConfig.router,
+    );
+
+    if (!qctx.allowedColumns) return record;
+
+    const allowed = new Set(qctx.allowedColumns);
+    allowed.add('id');
+
+    const filtered = {};
+    for (const key of Object.keys(record)) {
+      if (allowed.has(key)) filtered[key] = record[key];
+    }
+    return filtered;
   }
 
   /**
@@ -87,7 +174,14 @@ class ViewController {
         options.includeDeactivated = true;
       }
 
-      const records = await this.model(this.getSchema(req)).findAfterCursor(cursor, limit, orderBy, options);
+      // Apply RBAC Layers 2-4 (scope, state, field groups)
+      const rbacConditions = [];
+      this._applyRbacFilters(req, rbacConditions, options);
+
+      const records = await this.model(this.getSchema(req)).findAfterCursor(cursor, limit, orderBy, {
+        ...options,
+        filters: { ...options.filters, ...Object.assign({}, ...rbacConditions) },
+      });
       res.json(records);
     } catch (err) {
       res.status(500).json({ error: err.message });
@@ -101,7 +195,7 @@ class ViewController {
     try {
       const record = await this.model(this.getSchema(req)).findById(req.params.id);
       if (!record) return res.status(404).json({ error: `${this.errorLabel} not found` });
-      res.json(record);
+      res.json(this._filterRecordFields(req, record));
     } catch (err) {
       this.handleError(err, res, 'fetching', this.errorLabel);
     }
@@ -156,6 +250,9 @@ class ViewController {
       if (req.query.includeDeactivated === 'true') {
         options.includeDeactivated = true;
       }
+
+      // Apply RBAC Layers 2-4 (scope, state, field groups)
+      this._applyRbacFilters(req, conditions, options);
 
       const schema = this.getSchema(req);
       const [records, totalCount] = await Promise.all([

--- a/apps/nap-serv/src/middleware/authRedis.js
+++ b/apps/nap-serv/src/middleware/authRedis.js
@@ -6,6 +6,9 @@
  * loads permissions from Redis (or builds fresh from DB), and populates req.user/req.ctx.
  * Sets X-Token-Stale: 1 header if the JWT's ph claim diverges from cached hash.
  *
+ * Supports cross-tenant access (NapSoft users only) via x-tenant-code header,
+ * and user impersonation via Redis imp:{userId} keys.
+ *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
 
@@ -15,14 +18,16 @@ import { getRedis } from '../utils/redis.js';
 import { calcPermHash } from '../utils/permHash.js';
 
 const AUTH_BYPASS_SEGMENTS = ['/auth/login', '/auth/refresh', '/auth/logout'];
+const NAPSOFT_TENANT = (process.env.NAPSOFT_TENANT || 'NAP').toLowerCase();
 
 /**
  * Build permission canon from database for a user in a tenant schema.
  */
 async function buildCanon({ schemaName, userId }) {
   const { loadPoliciesForUserTenant } = await import('../utils/RbacPolicies.js');
-  const caps = await loadPoliciesForUserTenant({ schemaName, userId });
-  return { caps };
+  const canon = await loadPoliciesForUserTenant({ schemaName, userId });
+  // canon = { caps, scope, projectIds, stateFilters, fieldGroups }
+  return canon;
 }
 
 /**
@@ -40,13 +45,47 @@ function shouldBypassAuth(path, fullPath) {
 
 /**
  * Resolve tenant context from headers and JWT claims.
+ *
+ * Cross-tenant access: when the x-tenant-code header differs from the JWT's
+ * tenant_code, only NapSoft users are allowed to switch. Non-NapSoft users
+ * silently fall back to their home tenant.
  */
 function resolveTenantContext({ headers, claims, fullPath }) {
   const lowerFullPath = (fullPath || '').toLowerCase();
-  const headerTenant = headers['x-tenant-code'] || headers['x-tenant'];
   const claimTenant = claims?.tenant_code || claims?.tenantId;
-  const tenantCode = (headerTenant || claimTenant || '').toLowerCase();
+  const homeTenant = (claimTenant || '').toLowerCase();
+  const headerTenant = headers['x-tenant-code'] || headers['x-tenant'];
+
+  // Determine effective tenant code with cross-tenant validation
+  let tenantCode;
+  let isCrossTenant = false;
+
+  if (headerTenant) {
+    const requestedTenant = headerTenant.toLowerCase();
+    if (!homeTenant) {
+      // Minimal JWT (no tenant_code claim) — trust the header as the user's own tenant
+      tenantCode = requestedTenant;
+    } else if (requestedTenant !== homeTenant) {
+      // Cross-tenant: only NapSoft users may switch
+      if (homeTenant === NAPSOFT_TENANT) {
+        tenantCode = requestedTenant;
+        isCrossTenant = true;
+      } else {
+        tenantCode = homeTenant; // silently ignore header
+      }
+    } else {
+      tenantCode = requestedTenant;
+    }
+  } else {
+    tenantCode = homeTenant;
+  }
+
   let schemaName = claims?.schema_name?.toLowerCase?.() || tenantCode || null;
+
+  // For cross-tenant, override schema to the assumed tenant's schema
+  if (isCrossTenant) {
+    schemaName = tenantCode;
+  }
 
   const isAdminArea =
     lowerFullPath.includes('/api/tenants/v1/') ||
@@ -61,14 +100,22 @@ function resolveTenantContext({ headers, claims, fullPath }) {
     schemaName = 'admin';
   }
 
-  return { tenantCode, schemaName, isAdminArea, isCoreAuthSelf };
+  // User's home tenant schema for RBAC policy resolution
+  const homeTenantSchema = homeTenant || null;
+
+  return { tenantCode, schemaName, isAdminArea, isCoreAuthSelf, homeTenantSchema, isCrossTenant };
 }
 
 /**
  * Load permissions from Redis cache or build fresh from DB.
  */
 async function loadPermissions({ userId, schemaName, tenantCode, bypassRbac }) {
-  const empty = { hash: null, version: 1, updatedAt: Date.now(), perms: { caps: {} } };
+  const empty = {
+    hash: null,
+    version: 1,
+    updatedAt: Date.now(),
+    perms: { caps: {}, scope: 'all_projects', projectIds: null, companyIds: null, stateFilters: {}, fieldGroups: {} },
+  };
 
   const redis = await getRedis();
   const key = `perm:${userId}:${tenantCode || schemaName}`;
@@ -90,6 +137,15 @@ async function loadPermissions({ userId, schemaName, tenantCode, bypassRbac }) {
   } catch {
     return empty;
   }
+}
+
+/**
+ * Check if this path is exempt from impersonation override.
+ * Exit-impersonation and status endpoints must run as the REAL user.
+ */
+function isImpersonationExempt(fullPath) {
+  const lower = (fullPath || '').toLowerCase();
+  return lower.includes('/exit-impersonation') || lower.includes('/impersonation-status');
 }
 
 /**
@@ -118,21 +174,82 @@ export function authRedis() {
         return res.status(401).json({ error: 'Unauthorized' });
       }
 
-      const { tenantCode, schemaName, isAdminArea, isCoreAuthSelf } = resolveTenantContext({
-        headers: req.headers,
-        claims,
-        fullPath,
-      });
+      const { tenantCode, schemaName, isAdminArea, isCoreAuthSelf, homeTenantSchema, isCrossTenant } =
+        resolveTenantContext({
+          headers: req.headers,
+          claims,
+          fullPath,
+        });
 
       if (!schemaName && !isCoreAuthSelf) {
         return res.status(401).json({ error: 'Unauthorized' });
       }
 
+      // ── Impersonation detection ───────────────────────────────────
+      // Check Redis for an active impersonation session. If found (and the
+      // path isn't an exit/status endpoint), swap to the target user's identity.
+      let impersonating = null;
+      if (!isImpersonationExempt(fullPath)) {
+        try {
+          const redis = await getRedis();
+          const impData = await redis.get(`imp:${uid}`);
+          if (impData) impersonating = JSON.parse(impData);
+        } catch {
+          // Redis unavailable — proceed without impersonation
+        }
+      }
+
+      if (impersonating) {
+        // Load target user's permissions from their tenant schema
+        const targetPermsRecord = await loadPermissions({
+          userId: impersonating.targetUserId,
+          schemaName: impersonating.targetSchemaName,
+          tenantCode: impersonating.targetTenantCode,
+          bypassRbac: false,
+        });
+
+        req.user = {
+          id: impersonating.targetUserId,
+          email: impersonating.targetUser.email,
+          user_name: impersonating.targetUser.user_name,
+          role: impersonating.targetUser.role,
+          status: impersonating.targetUser.status,
+          tenant_code: impersonating.targetTenantCode,
+          schema_name: impersonating.targetSchemaName,
+          perms: targetPermsRecord.perms,
+          impersonated_by: uid,
+          impersonation_log_id: impersonating.logId,
+          is_impersonating: true,
+        };
+
+        req.ctx = {
+          ...(req.ctx || {}),
+          user_id: impersonating.targetUserId,
+          tenant_code: impersonating.targetTenantCode,
+          schema: impersonating.targetSchemaName,
+          perms: targetPermsRecord.perms,
+          impersonated_by: uid,
+          is_impersonating: true,
+        };
+
+        return next();
+      }
+
+      // ── Normal (non-impersonating) flow ───────────────────────────
+      // For RBAC policy loading, use the user's home tenant schema (e.g. 'nap')
+      // even when the route is in admin-area or the user is cross-tenant.
+      const rbacSchema =
+        isAdminArea && homeTenantSchema && homeTenantSchema !== 'admin'
+          ? homeTenantSchema
+          : isCrossTenant && homeTenantSchema
+            ? homeTenantSchema
+            : schemaName;
+
       const permsRecord = await loadPermissions({
         userId: uid,
-        schemaName,
-        tenantCode,
-        bypassRbac: isAdminArea || isCoreAuthSelf,
+        schemaName: rbacSchema,
+        tenantCode: homeTenantSchema || tenantCode,
+        bypassRbac: isCoreAuthSelf,
       });
 
       // Hydrate user profile from Redis cache or DB (JWT is minimal: sub + ph only)
@@ -149,6 +266,7 @@ export function authRedis() {
               user_name: full.user_name,
               role: full.role,
               status: full.status,
+              tenant_id: full.tenant_id,
               tenant_code: full.tenant_code,
             };
           }
@@ -163,9 +281,13 @@ export function authRedis() {
         user_name: userProfile?.user_name || claims?.user_name,
         role: userProfile?.role || claims?.role,
         status: userProfile?.status || null,
+        tenant_id: userProfile?.tenant_id || null,
         tenant_code: tenantCode || userProfile?.tenant_code || null,
         schema_name: schemaName,
         perms: permsRecord.perms,
+        home_tenant: homeTenantSchema,
+        rbac_schema: rbacSchema,
+        is_cross_tenant: isCrossTenant,
       };
 
       req.ctx = {
@@ -174,6 +296,8 @@ export function authRedis() {
         tenant_code: tenantCode || null,
         schema: schemaName || null,
         perms: permsRecord.perms,
+        home_tenant: homeTenantSchema,
+        is_cross_tenant: isCrossTenant,
       };
 
       // Detect stale token permissions

--- a/apps/nap-serv/src/modules/core/apiRoutes/v1/adminRouter.js
+++ b/apps/nap-serv/src/modules/core/apiRoutes/v1/adminRouter.js
@@ -1,5 +1,5 @@
 /**
- * @file Core admin router — tenant assumption per PRD §3.2.3
+ * @file Core admin router — placeholder for future admin endpoints
  * @module core/apiRoutes/v1/adminRouter
  *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
@@ -8,30 +8,5 @@
 import { Router } from 'express';
 
 const router = Router();
-
-/**
- * POST /assume-tenant — assume another tenant's context (super_user only)
- */
-router.post('/assume-tenant', (req, res) => {
-  const { tenant_code, reason } = req.body || {};
-  if (!req.user) return res.status(401).json({ error: 'Unauthorized' });
-  if (req.user.role !== 'super_user') return res.status(403).json({ error: 'Forbidden: super_user only' });
-  if (!tenant_code) return res.status(400).json({ error: 'tenant_code required' });
-
-  req.ctx = { ...(req.ctx || {}), assumed_tenant: tenant_code, assumption_reason: reason || null };
-  return res.json({ message: 'Assumed tenant', tenant_code });
-});
-
-/**
- * POST /exit-assumption — exit tenant assumption
- */
-router.post('/exit-assumption', (req, res) => {
-  if (!req.user) return res.status(401).json({ error: 'Unauthorized' });
-  if (req.ctx) {
-    delete req.ctx.assumed_tenant;
-    delete req.ctx.assumption_reason;
-  }
-  return res.json({ message: 'Exited assumption' });
-});
 
 export default router;

--- a/apps/nap-serv/src/modules/core/apiRoutes/v1/coreApiRoutes.js
+++ b/apps/nap-serv/src/modules/core/apiRoutes/v1/coreApiRoutes.js
@@ -13,15 +13,25 @@ import employeesRouter from './employeesRouter.js';
 import contactsRouter from './contactsRouter.js';
 import addressesRouter from './addressesRouter.js';
 import interCompaniesRouter from './interCompaniesRouter.js';
+import sourcesRouter from './sourcesRouter.js';
+import rolesRouter from './rolesRouter.js';
+import roleMembersRouter from './roleMembersRouter.js';
+import policiesRouter from './policiesRouter.js';
+import policyCatalogRouter from './policyCatalogRouter.js';
 
 const router = Router();
 
 router.use('/v1/admin', adminRouter);
+router.use('/v1/sources', sourcesRouter);
 router.use('/v1/vendors', vendorsRouter);
 router.use('/v1/clients', clientsRouter);
 router.use('/v1/employees', employeesRouter);
 router.use('/v1/contacts', contactsRouter);
 router.use('/v1/addresses', addressesRouter);
 router.use('/v1/inter-companies', interCompaniesRouter);
+router.use('/v1/roles', rolesRouter);
+router.use('/v1/role-members', roleMembersRouter);
+router.use('/v1/policies', policiesRouter);
+router.use('/v1/policy-catalog', policyCatalogRouter);
 
 export default router;

--- a/apps/nap-serv/src/modules/core/apiRoutes/v1/employeesRouter.js
+++ b/apps/nap-serv/src/modules/core/apiRoutes/v1/employeesRouter.js
@@ -2,10 +2,21 @@
  * @file Employees router — /api/core/v1/employees
  * @module core/apiRoutes/v1/employeesRouter
  *
+ * RBAC-gated: core::employees at 'view' for reads, 'full' for mutations.
+ *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
 
 import createRouter from '../../../../lib/createRouter.js';
+import { withMeta, rbac } from '../../../../middleware/rbac.js';
 import employeesController from '../../controllers/employeesController.js';
 
-export default createRouter(employeesController);
+const meta = withMeta({ module: 'core', router: 'employees' });
+
+export default createRouter(employeesController, null, {
+  getMiddlewares: [meta, rbac('view')],
+  postMiddlewares: [meta, rbac('full')],
+  putMiddlewares: [meta, rbac('full')],
+  deleteMiddlewares: [meta, rbac('full')],
+  patchMiddlewares: [meta, rbac('full')],
+});

--- a/apps/nap-serv/src/modules/core/apiRoutes/v1/policiesRouter.js
+++ b/apps/nap-serv/src/modules/core/apiRoutes/v1/policiesRouter.js
@@ -1,0 +1,32 @@
+/**
+ * @file Policies router — /api/core/v1/policies
+ * @module core/apiRoutes/v1/policiesRouter
+ *
+ * RBAC-gated: core::policies at 'full' for all operations.
+ * Custom endpoint: PUT /sync-for-role.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import createRouter from '../../../../lib/createRouter.js';
+import { addAuditFields } from '../../../../middleware/addAuditFields.js';
+import { withMeta, rbac } from '../../../../middleware/rbac.js';
+import policiesController from '../../controllers/policiesController.js';
+
+const meta = withMeta({ module: 'core', router: 'policies' });
+
+export default createRouter(
+  policiesController,
+  (router) => {
+    router.put('/sync-for-role', addAuditFields, meta, rbac('full'), (req, res) =>
+      policiesController.syncForRole(req, res),
+    );
+  },
+  {
+    getMiddlewares: [meta, rbac('view')],
+    postMiddlewares: [meta, rbac('full')],
+    putMiddlewares: [meta, rbac('full')],
+    deleteMiddlewares: [meta, rbac('full')],
+    patchMiddlewares: [meta, rbac('full')],
+  },
+);

--- a/apps/nap-serv/src/modules/core/apiRoutes/v1/policyCatalogRouter.js
+++ b/apps/nap-serv/src/modules/core/apiRoutes/v1/policyCatalogRouter.js
@@ -1,0 +1,27 @@
+/**
+ * @file Policy Catalog router — /api/core/v1/policy-catalog
+ * @module core/apiRoutes/v1/policyCatalogRouter
+ *
+ * Read-only: exposes the seed-only policy_catalog table for client discovery.
+ * RBAC-gated: core::policy-catalog at 'view' for reads.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import createRouter from '../../../../lib/createRouter.js';
+import { withMeta, rbac } from '../../../../middleware/rbac.js';
+import policyCatalogController from '../../controllers/policyCatalogController.js';
+
+const meta = withMeta({ module: 'core', router: 'policy-catalog' });
+
+export default createRouter(policyCatalogController, null, {
+  getMiddlewares: [meta, rbac('view')],
+  // Disable all mutation routes — catalog is seed-only
+  disablePost: true,
+  disablePut: true,
+  disableDelete: true,
+  disablePatch: true,
+  disableBulkInsert: true,
+  disableBulkUpdate: true,
+  disableImportXls: true,
+});

--- a/apps/nap-serv/src/modules/core/apiRoutes/v1/roleMembersRouter.js
+++ b/apps/nap-serv/src/modules/core/apiRoutes/v1/roleMembersRouter.js
@@ -1,0 +1,35 @@
+/**
+ * @file Role Members router — /api/core/v1/role-members
+ * @module core/apiRoutes/v1/roleMembersRouter
+ *
+ * RBAC-gated: core::role-members at 'full' for all operations.
+ * Custom endpoints: PUT /sync, DELETE /remove.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import createRouter from '../../../../lib/createRouter.js';
+import { addAuditFields } from '../../../../middleware/addAuditFields.js';
+import { withMeta, rbac } from '../../../../middleware/rbac.js';
+import roleMembersController from '../../controllers/roleMembersController.js';
+
+const meta = withMeta({ module: 'core', router: 'role-members' });
+
+export default createRouter(
+  roleMembersController,
+  (router) => {
+    router.put('/sync', addAuditFields, meta, rbac('full'), (req, res) =>
+      roleMembersController.sync(req, res),
+    );
+    router.delete('/remove', meta, rbac('full'), (req, res) =>
+      roleMembersController.remove(req, res),
+    );
+  },
+  {
+    getMiddlewares: [meta, rbac('view')],
+    postMiddlewares: [meta, rbac('full')],
+    putMiddlewares: [meta, rbac('full')],
+    deleteMiddlewares: [meta, rbac('full')],
+    patchMiddlewares: [meta, rbac('full')],
+  },
+);

--- a/apps/nap-serv/src/modules/core/apiRoutes/v1/rolesRouter.js
+++ b/apps/nap-serv/src/modules/core/apiRoutes/v1/rolesRouter.js
@@ -1,0 +1,22 @@
+/**
+ * @file Roles router — /api/core/v1/roles
+ * @module core/apiRoutes/v1/rolesRouter
+ *
+ * RBAC-gated: core::roles at 'view' for reads, 'full' for mutations.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import createRouter from '../../../../lib/createRouter.js';
+import { withMeta, rbac } from '../../../../middleware/rbac.js';
+import rolesController from '../../controllers/rolesController.js';
+
+const meta = withMeta({ module: 'core', router: 'roles' });
+
+export default createRouter(rolesController, null, {
+  getMiddlewares: [meta, rbac('view')],
+  postMiddlewares: [meta, rbac('full')],
+  putMiddlewares: [meta, rbac('full')],
+  deleteMiddlewares: [meta, rbac('full')],
+  patchMiddlewares: [meta, rbac('full')],
+});

--- a/apps/nap-serv/src/modules/core/apiRoutes/v1/sourcesRouter.js
+++ b/apps/nap-serv/src/modules/core/apiRoutes/v1/sourcesRouter.js
@@ -1,0 +1,22 @@
+/**
+ * @file Sources router — read-only /api/core/v1/sources
+ * @module core/apiRoutes/v1/sourcesRouter
+ *
+ * Sources are auto-created by vendor/client/employee controllers.
+ * This router exposes read-only access (GET endpoints only).
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import createRouter from '../../../../lib/createRouter.js';
+import sourcesController from '../../controllers/sourcesController.js';
+
+export default createRouter(sourcesController, null, {
+  disablePost: true,
+  disablePut: true,
+  disableDelete: true,
+  disablePatch: true,
+  disableBulkInsert: true,
+  disableBulkUpdate: true,
+  disableImportXls: true,
+});

--- a/apps/nap-serv/src/modules/core/controllers/clientsController.js
+++ b/apps/nap-serv/src/modules/core/controllers/clientsController.js
@@ -21,6 +21,11 @@ class ClientsController extends BaseController {
     try {
       const schema = this.getSchema(req);
 
+      // Inject tenant_id from authenticated session
+      if (!req.body.tenant_id && req.user?.tenant_id) {
+        req.body.tenant_id = req.user.tenant_id;
+      }
+
       const record = await db.tx(async (t) => {
         const clientsModel = this.model(schema);
         clientsModel.tx = t;

--- a/apps/nap-serv/src/modules/core/controllers/employeesController.js
+++ b/apps/nap-serv/src/modules/core/controllers/employeesController.js
@@ -1,12 +1,17 @@
 /**
- * @file Employees controller — auto-creates a sources record on employee creation
+ * @file Employees controller — auto-creates a sources record on employee creation,
+ *       manages is_app_user lifecycle (provision/archive/restore nap_users records)
  * @module core/controllers/employeesController
  *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
 
+import bcrypt from 'bcrypt';
+import crypto from 'node:crypto';
 import BaseController from '../../../lib/BaseController.js';
 import db from '../../../db/db.js';
+import { invalidateUserPermissions } from '../../../utils/rbacCacheInvalidation.js';
+import logger from '../../../utils/logger.js';
 
 class EmployeesController extends BaseController {
   constructor() {
@@ -15,11 +20,16 @@ class EmployeesController extends BaseController {
 
   /**
    * POST / — insert an employee and auto-create a linked sources record.
-   * Runs inside a transaction so both inserts succeed or both roll back.
+   * If is_app_user is true, also provisions a nap_users login account.
    */
   async create(req, res) {
     try {
       const schema = this.getSchema(req);
+
+      // Inject tenant_id from authenticated session
+      if (!req.body.tenant_id && req.user?.tenant_id) {
+        req.body.tenant_id = req.user.tenant_id;
+      }
 
       const record = await db.tx(async (t) => {
         const employeesModel = this.model(schema);
@@ -48,10 +58,213 @@ class EmployeesController extends BaseController {
         return { ...employee, source_id: source.id };
       });
 
+      // 4. If is_app_user, create the nap_users login record
+      if (record.is_app_user && record.email) {
+        await this.#provisionAppUser(record, schema, req);
+      }
+
       res.status(201).json(record);
     } catch (err) {
       if (err.name === 'SchemaDefinitionError') err.message = 'Invalid input data';
       this.handleError(err, res, 'creating', this.errorLabel);
+    }
+  }
+
+  /**
+   * PUT /update — update employee and manage is_app_user toggle.
+   */
+  async update(req, res) {
+    const schema = this.getSchema(req);
+    const employeeId = req.query.id;
+
+    if (!employeeId) {
+      return res.status(400).json({ error: 'id query parameter is required' });
+    }
+
+    try {
+      // Fetch employee BEFORE update to detect is_app_user toggle
+      const before = await this.model(schema).findById(employeeId);
+      if (!before) return res.status(404).json({ error: `${this.errorLabel} not found` });
+
+      // Apply the standard update
+      const count = await this.model(schema).updateWhere([{ id: employeeId }], req.body);
+      if (!count) return res.status(404).json({ error: `${this.errorLabel} not found` });
+
+      // Detect is_app_user toggle
+      const wasAppUser = !!before.is_app_user;
+      const isNowAppUser = req.body.is_app_user !== undefined ? !!req.body.is_app_user : wasAppUser;
+      const email = req.body.email || before.email;
+
+      if (!wasAppUser && isNowAppUser) {
+        // Toggled ON: provision or restore nap_user
+        if (!email) {
+          return res.status(400).json({ error: 'Email is required to enable app user access' });
+        }
+        const updatedEmployee = { ...before, ...req.body, id: before.id, email };
+        await this.#provisionAppUser(updatedEmployee, schema, req);
+      } else if (wasAppUser && !isNowAppUser) {
+        // Toggled OFF: archive the linked nap_user
+        await this.#archiveAppUser(before.id, req);
+      }
+
+      res.json({ updatedRecords: count });
+    } catch (err) {
+      if (err.name === 'SchemaDefinitionError') err.message = 'Invalid input data';
+      this.handleError(err, res, 'updating', this.errorLabel);
+    }
+  }
+
+  /**
+   * DELETE /archive — soft-delete employee, cascade to nap_users if is_app_user.
+   */
+  async archive(req, res) {
+    const schema = this.getSchema(req);
+    const employeeId = req.query.id;
+
+    req.body.deactivated_at = new Date();
+    try {
+      // Cascade to nap_user before archiving employee
+      if (employeeId) {
+        const employee = await this.model(schema).findById(employeeId);
+        if (employee?.is_app_user) {
+          await this.#archiveAppUser(employee.id, req);
+        }
+      }
+
+      const filters = Array.isArray(req.query) ? req.query : [{ ...req.query }];
+      const count = await this.model(schema).updateWhere(filters, req.body);
+      if (!count) return res.status(404).json({ error: `${this.errorLabel} not found or already inactive` });
+      res.status(200).json({ message: `${this.errorLabel} marked as inactive` });
+    } catch (err) {
+      this.handleError(err, res, 'archiving', this.errorLabel);
+    }
+  }
+
+  /**
+   * PATCH /restore — reactivate employee, cascade to nap_users if is_app_user.
+   */
+  async restore(req, res) {
+    const schema = this.getSchema(req);
+    const employeeId = req.query.id;
+
+    req.body.deactivated_at = null;
+    const filters = [{ deactivated_at: { $not: null } }, { ...req.query }];
+
+    try {
+      const count = await this.model(schema).updateWhere(filters, req.body, { includeDeactivated: true });
+      if (!count) return res.status(404).json({ error: `${this.errorLabel} not found or already active` });
+
+      // Cascade restore to nap_user if employee is an app user
+      if (employeeId) {
+        const employee = await this.model(schema).findById(employeeId);
+        if (employee?.is_app_user) {
+          await this.#restoreAppUser(employee.id, req);
+        }
+      }
+
+      res.status(200).json({ message: `${this.errorLabel} marked as active` });
+    } catch (err) {
+      this.handleError(err, res, 'restoring', this.errorLabel);
+    }
+  }
+
+  /**
+   * Create or restore a nap_users record for an employee gaining app access.
+   */
+  async #provisionAppUser(employee, schemaName, req) {
+    const tenantCode = req.user?.tenant_code;
+    if (!tenantCode) throw new Error('Tenant context required to provision app user');
+
+    const tenant = await db.oneOrNone(
+      `SELECT id, tenant_code FROM admin.tenants
+       WHERE UPPER(tenant_code) = $1 AND deactivated_at IS NULL`,
+      [tenantCode.toUpperCase()],
+    );
+    if (!tenant) throw new Error('Tenant not found or inactive');
+
+    // Check if an archived nap_user already exists for this employee
+    const existing = await db.oneOrNone(
+      `SELECT id, deactivated_at FROM admin.nap_users WHERE employee_id = $1`,
+      [employee.id],
+    );
+
+    const tempPassword = crypto.randomBytes(12).toString('base64url');
+    const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
+    const passwordHash = await bcrypt.hash(tempPassword, rounds);
+
+    if (existing) {
+      // Restore the archived record
+      await db.none(
+        `UPDATE admin.nap_users
+         SET deactivated_at = NULL, status = 'invited',
+             password_hash = $1, email = $2, full_name = $3,
+             updated_by = $4
+         WHERE id = $5`,
+        [
+          passwordHash,
+          employee.email,
+          `${employee.first_name} ${employee.last_name}`,
+          req.user?.id || null,
+          existing.id,
+        ],
+      );
+      logger.info(`Restored nap_user ${existing.id} for employee ${employee.id}`);
+      return existing.id;
+    }
+
+    // Create a new nap_users record
+    const user = await db('napUsers', 'admin').insert({
+      tenant_id: tenant.id,
+      tenant_code: tenant.tenant_code,
+      email: employee.email,
+      user_name: employee.email,
+      full_name: `${employee.first_name} ${employee.last_name}`,
+      password_hash: passwordHash,
+      role: 'member',
+      status: 'invited',
+      employee_id: employee.id,
+      created_by: req.user?.id || null,
+    });
+
+    logger.info(`Provisioned nap_user ${user.id} for employee ${employee.id}`);
+    return user.id;
+  }
+
+  /**
+   * Archive (soft-delete) the nap_users record linked to an employee.
+   */
+  async #archiveAppUser(employeeId, req) {
+    const napUser = await db.oneOrNone(
+      `SELECT id FROM admin.nap_users WHERE employee_id = $1 AND deactivated_at IS NULL`,
+      [employeeId],
+    );
+    if (napUser) {
+      await db.none(
+        `UPDATE admin.nap_users SET deactivated_at = NOW(), updated_by = $1 WHERE id = $2`,
+        [req.user?.id || null, napUser.id],
+      );
+      const tenantCode = req.user?.tenant_code;
+      if (tenantCode) {
+        await invalidateUserPermissions(napUser.id, tenantCode.toLowerCase());
+      }
+      logger.info(`Archived nap_user ${napUser.id} for employee ${employeeId}`);
+    }
+  }
+
+  /**
+   * Restore the nap_users record linked to an employee.
+   */
+  async #restoreAppUser(employeeId, req) {
+    const napUser = await db.oneOrNone(
+      `SELECT id FROM admin.nap_users WHERE employee_id = $1 AND deactivated_at IS NOT NULL`,
+      [employeeId],
+    );
+    if (napUser) {
+      await db.none(
+        `UPDATE admin.nap_users SET deactivated_at = NULL, updated_by = $1 WHERE id = $2`,
+        [req.user?.id || null, napUser.id],
+      );
+      logger.info(`Restored nap_user ${napUser.id} for employee ${employeeId}`);
     }
   }
 }

--- a/apps/nap-serv/src/modules/core/controllers/policiesController.js
+++ b/apps/nap-serv/src/modules/core/controllers/policiesController.js
@@ -1,0 +1,73 @@
+/**
+ * @file Policies controller — CRUD + sync for tenant-scope RBAC policies
+ * @module core/controllers/policiesController
+ *
+ * Custom endpoints:
+ * - PUT /sync-for-role — replace all policies for a role in one operation
+ *
+ * All mutations invalidate affected users' cached permission canons.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import BaseController from '../../../lib/BaseController.js';
+import db from '../../../db/db.js';
+import { invalidateRolePermissions } from '../../../utils/rbacCacheInvalidation.js';
+
+class PoliciesController extends BaseController {
+  constructor() {
+    super('policies');
+  }
+
+  /**
+   * PUT /sync-for-role — replace all policies for a given role.
+   * Accepts { role_id, policies: [{ module, router, action, level }] }.
+   * Deletes existing policies and inserts new ones in a transaction.
+   * Invalidates cache for all users holding the role.
+   */
+  async syncForRole(req, res) {
+    const { role_id, policies } = req.body;
+
+    if (!role_id || !Array.isArray(policies)) {
+      return res.status(400).json({ error: 'role_id and policies[] are required' });
+    }
+
+    try {
+      const schema = this.getSchema(req);
+
+      await db.tx(async (t) => {
+        // Delete all existing policies for this role
+        await t.none(`DELETE FROM ${schema}.policies WHERE role_id = $1`, [role_id]);
+
+        // Insert new policies
+        if (policies.length > 0) {
+          const model = this.model(schema);
+          model.tx = t;
+          for (const policy of policies) {
+            await model.insert({
+              role_id,
+              module: policy.module,
+              router: policy.router || null,
+              action: policy.action || null,
+              level: policy.level,
+              tenant_code: req.user?.tenant_code || null,
+              created_by: req.user?.id || null,
+              updated_by: req.user?.id || null,
+            });
+          }
+        }
+      });
+
+      // Invalidate cache for all users holding this role
+      await invalidateRolePermissions(role_id, schema);
+
+      res.json({ message: 'Policies synced for role', count: policies.length });
+    } catch (err) {
+      this.handleError(err, res, 'syncing policies for', this.errorLabel);
+    }
+  }
+}
+
+const instance = new PoliciesController();
+export default instance;
+export { PoliciesController };

--- a/apps/nap-serv/src/modules/core/controllers/policyCatalogController.js
+++ b/apps/nap-serv/src/modules/core/controllers/policyCatalogController.js
@@ -1,0 +1,22 @@
+/**
+ * @file Policy Catalog controller — read-only access to the policy catalog
+ * @module core/controllers/policyCatalogController
+ *
+ * The policy_catalog table is seed-only reference data. This controller
+ * exposes read endpoints (GET /, GET /where, GET /:id) so the client
+ * can discover valid module/router/action combinations for role configuration.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import ViewController from '../../../lib/ViewController.js';
+
+class PolicyCatalogController extends ViewController {
+  constructor() {
+    super('policyCatalog');
+  }
+}
+
+const instance = new PolicyCatalogController();
+export default instance;
+export { PolicyCatalogController };

--- a/apps/nap-serv/src/modules/core/controllers/roleMembersController.js
+++ b/apps/nap-serv/src/modules/core/controllers/roleMembersController.js
@@ -1,0 +1,129 @@
+/**
+ * @file Role Members controller — CRUD + sync for tenant-scope role membership
+ * @module core/controllers/roleMembersController
+ *
+ * Custom endpoints:
+ * - PUT /sync — replace all members for a role in one operation
+ * - DELETE /remove — hard-delete a single membership row
+ *
+ * All mutations invalidate affected users' cached permission canons.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import BaseController from '../../../lib/BaseController.js';
+import db from '../../../db/db.js';
+import { invalidateUserPermissions } from '../../../utils/rbacCacheInvalidation.js';
+
+class RoleMembersController extends BaseController {
+  constructor() {
+    super('roleMembers');
+  }
+
+  /**
+   * POST / — add a user to a role.
+   * After insert, invalidates the user's cached permissions.
+   */
+  async create(req, res) {
+    try {
+      const schema = this.getSchema(req);
+      const record = await this.model(schema).insert(req.body);
+      await invalidateUserPermissions(record.user_id, schema);
+      res.status(201).json(record);
+    } catch (err) {
+      if (err.name === 'SchemaDefinitionError') err.message = 'Invalid input data';
+      this.handleError(err, res, 'creating', this.errorLabel);
+    }
+  }
+
+  /**
+   * PUT /sync — replace all members for a role.
+   * Accepts { role_id, user_ids: string[] }.
+   * Deletes existing members and inserts new ones in a transaction.
+   * Invalidates cache for all affected users (old + new).
+   */
+  async sync(req, res) {
+    const { role_id, user_ids } = req.body;
+
+    if (!role_id || !Array.isArray(user_ids)) {
+      return res.status(400).json({ error: 'role_id and user_ids[] are required' });
+    }
+
+    try {
+      const schema = this.getSchema(req);
+
+      // Collect existing members for cache invalidation
+      const existing = await this.model(schema).findWhere(
+        [{ role_id }],
+        'AND',
+        { columnWhitelist: ['user_id'] },
+      );
+      const oldUserIds = existing.map((m) => m.user_id);
+
+      await db.tx(async (t) => {
+        // Delete all existing members for this role
+        await t.none(`DELETE FROM ${schema}.role_members WHERE role_id = $1`, [role_id]);
+
+        // Insert new members
+        if (user_ids.length > 0) {
+          const model = this.model(schema);
+          model.tx = t;
+          for (const user_id of user_ids) {
+            await model.insert({
+              role_id,
+              user_id,
+              is_primary: false,
+              tenant_code: req.user?.tenant_code || null,
+              created_by: req.user?.id || null,
+              updated_by: req.user?.id || null,
+            });
+          }
+        }
+      });
+
+      // Invalidate cache for all affected users (union of old + new)
+      const allUserIds = [...new Set([...oldUserIds, ...user_ids])];
+      for (const uid of allUserIds) {
+        await invalidateUserPermissions(uid, schema);
+      }
+
+      res.json({ message: 'Role members synced', count: user_ids.length });
+    } catch (err) {
+      this.handleError(err, res, 'syncing members for', this.errorLabel);
+    }
+  }
+
+  /**
+   * DELETE /remove — hard-delete a single role_member row.
+   * Accepts query params: role_id, user_id.
+   * Invalidates the removed user's cached permissions.
+   */
+  async remove(req, res) {
+    const { role_id, user_id } = req.query;
+
+    if (!role_id || !user_id) {
+      return res.status(400).json({ error: 'role_id and user_id query params are required' });
+    }
+
+    try {
+      const schema = this.getSchema(req);
+      const result = await db.result(
+        `DELETE FROM ${schema}.role_members WHERE role_id = $1 AND user_id = $2`,
+        [role_id, user_id],
+      );
+
+      if (result.rowCount === 0) {
+        return res.status(404).json({ error: 'Role member not found' });
+      }
+
+      await invalidateUserPermissions(user_id, schema);
+      res.json({ message: 'Role member removed' });
+    } catch (err) {
+      this.handleError(err, res, 'removing member from', this.errorLabel);
+    }
+  }
+}
+
+const instance = new RoleMembersController();
+export default instance;
+export { RoleMembersController };

--- a/apps/nap-serv/src/modules/core/controllers/rolesController.js
+++ b/apps/nap-serv/src/modules/core/controllers/rolesController.js
@@ -1,0 +1,98 @@
+/**
+ * @file Roles controller — CRUD for tenant-scope RBAC roles
+ * @module core/controllers/rolesController
+ *
+ * Guards:
+ * - Cannot create system or immutable roles via API (seed-only)
+ * - Cannot update immutable roles
+ * - Cannot archive system roles
+ * - Invalidates cached permissions when scope changes
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import BaseController from '../../../lib/BaseController.js';
+import { invalidateRolePermissions } from '../../../utils/rbacCacheInvalidation.js';
+
+class RolesController extends BaseController {
+  constructor() {
+    super('roles');
+  }
+
+  /**
+   * POST / — create a new tenant role.
+   * Rejects if is_system or is_immutable is true (only seeds may create those).
+   */
+  async create(req, res) {
+    if (req.body.is_system || req.body.is_immutable) {
+      return res.status(400).json({ error: 'Cannot create system or immutable roles via API' });
+    }
+    return super.create(req, res);
+  }
+
+  /**
+   * PUT /update — update a role.
+   * Rejects if the target role is immutable. Invalidates cached permissions
+   * for all members of the role after update (scope changes affect canons).
+   */
+  async update(req, res) {
+    try {
+      const schema = this.getSchema(req);
+      const id = req.query.id;
+
+      if (id) {
+        const existing = await this.model(schema).findById(id);
+        if (existing?.is_immutable) {
+          return res.status(400).json({ error: 'Cannot modify an immutable role' });
+        }
+      }
+
+      // Delegate to BaseController.update
+      const result = await super.update(req, res);
+
+      // Invalidate cache for all users holding this role
+      if (id) {
+        await invalidateRolePermissions(id, schema);
+      }
+
+      return result;
+    } catch (err) {
+      this.handleError(err, res, 'updating', this.errorLabel);
+    }
+  }
+
+  /**
+   * DELETE /archive — soft-delete a role.
+   * Rejects if the target role is a system role.
+   * Invalidates cached permissions for all members after archival.
+   */
+  async archive(req, res) {
+    try {
+      const schema = this.getSchema(req);
+      const id = req.query.id;
+
+      if (id) {
+        const existing = await this.model(schema).findById(id);
+        if (existing?.is_system) {
+          return res.status(400).json({ error: 'Cannot archive a system role' });
+        }
+      }
+
+      // Delegate to BaseController.archive
+      const result = await super.archive(req, res);
+
+      // Invalidate cache for all users holding this role
+      if (id) {
+        await invalidateRolePermissions(id, schema);
+      }
+
+      return result;
+    } catch (err) {
+      this.handleError(err, res, 'archiving', this.errorLabel);
+    }
+  }
+}
+
+const instance = new RolesController();
+export default instance;
+export { RolesController };

--- a/apps/nap-serv/src/modules/core/controllers/vendorsController.js
+++ b/apps/nap-serv/src/modules/core/controllers/vendorsController.js
@@ -21,6 +21,11 @@ class VendorsController extends BaseController {
     try {
       const schema = this.getSchema(req);
 
+      // Inject tenant_id from authenticated session
+      if (!req.body.tenant_id && req.user?.tenant_id) {
+        req.body.tenant_id = req.user.tenant_id;
+      }
+
       const record = await db.tx(async (t) => {
         const vendorsModel = this.model(schema);
         vendorsModel.tx = t;

--- a/apps/nap-serv/src/modules/core/coreRepositories.js
+++ b/apps/nap-serv/src/modules/core/coreRepositories.js
@@ -10,6 +10,12 @@
 import Roles from './models/Roles.js';
 import RoleMembers from './models/RoleMembers.js';
 import Policies from './models/Policies.js';
+import PolicyCatalog from './models/PolicyCatalog.js';
+import ProjectMembers from './models/ProjectMembers.js';
+import CompanyMembers from './models/CompanyMembers.js';
+import StateFilters from './models/StateFilters.js';
+import FieldGroupDefinitions from './models/FieldGroupDefinitions.js';
+import FieldGroupGrants from './models/FieldGroupGrants.js';
 import Sources from './models/Sources.js';
 import Vendors from './models/Vendors.js';
 import Clients from './models/Clients.js';
@@ -19,10 +25,16 @@ import Addresses from './models/Addresses.js';
 import InterCompanies from './models/InterCompanies.js';
 
 const repositories = {
-  // RBAC (Phase 2)
+  // RBAC (Phase 2 + Layers 2-4)
   roles: Roles,
   roleMembers: RoleMembers,
   policies: Policies,
+  policyCatalog: PolicyCatalog,
+  projectMembers: ProjectMembers,
+  companyMembers: CompanyMembers,
+  stateFilters: StateFilters,
+  fieldGroupDefinitions: FieldGroupDefinitions,
+  fieldGroupGrants: FieldGroupGrants,
   // Core entities (Phase 7)
   sources: Sources,
   vendors: Vendors,

--- a/apps/nap-serv/src/modules/core/models/CompanyMembers.js
+++ b/apps/nap-serv/src/modules/core/models/CompanyMembers.js
@@ -1,0 +1,15 @@
+/**
+ * @file CompanyMembers model — extends TableModel for RBAC Layer 2 company scoping
+ * @module core/models/CompanyMembers
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { TableModel } from 'pg-schemata';
+import companyMembersSchema from '../schemas/companyMembersSchema.js';
+
+export default class CompanyMembers extends TableModel {
+  constructor(db, pgp, logger = null) {
+    super(db, pgp, companyMembersSchema, logger);
+  }
+}

--- a/apps/nap-serv/src/modules/core/models/FieldGroupDefinitions.js
+++ b/apps/nap-serv/src/modules/core/models/FieldGroupDefinitions.js
@@ -1,0 +1,15 @@
+/**
+ * @file FieldGroupDefinitions model — extends TableModel for RBAC Layer 4 column-group definitions
+ * @module core/models/FieldGroupDefinitions
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { TableModel } from 'pg-schemata';
+import fieldGroupDefinitionsSchema from '../schemas/fieldGroupDefinitionsSchema.js';
+
+export default class FieldGroupDefinitions extends TableModel {
+  constructor(db, pgp, logger = null) {
+    super(db, pgp, fieldGroupDefinitionsSchema, logger);
+  }
+}

--- a/apps/nap-serv/src/modules/core/models/FieldGroupGrants.js
+++ b/apps/nap-serv/src/modules/core/models/FieldGroupGrants.js
@@ -1,0 +1,15 @@
+/**
+ * @file FieldGroupGrants model — extends TableModel for RBAC Layer 4 role-to-field-group assignments
+ * @module core/models/FieldGroupGrants
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { TableModel } from 'pg-schemata';
+import fieldGroupGrantsSchema from '../schemas/fieldGroupGrantsSchema.js';
+
+export default class FieldGroupGrants extends TableModel {
+  constructor(db, pgp, logger = null) {
+    super(db, pgp, fieldGroupGrantsSchema, logger);
+  }
+}

--- a/apps/nap-serv/src/modules/core/models/PolicyCatalog.js
+++ b/apps/nap-serv/src/modules/core/models/PolicyCatalog.js
@@ -1,0 +1,15 @@
+/**
+ * @file PolicyCatalog model — extends TableModel for RBAC policy catalog
+ * @module core/models/PolicyCatalog
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { TableModel } from 'pg-schemata';
+import policyCatalogSchema from '../schemas/policyCatalogSchema.js';
+
+export default class PolicyCatalog extends TableModel {
+  constructor(db, pgp, logger = null) {
+    super(db, pgp, policyCatalogSchema, logger);
+  }
+}

--- a/apps/nap-serv/src/modules/core/models/ProjectMembers.js
+++ b/apps/nap-serv/src/modules/core/models/ProjectMembers.js
@@ -1,0 +1,15 @@
+/**
+ * @file ProjectMembers model — extends TableModel for RBAC Layer 2 project assignments
+ * @module core/models/ProjectMembers
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { TableModel } from 'pg-schemata';
+import projectMembersSchema from '../schemas/projectMembersSchema.js';
+
+export default class ProjectMembers extends TableModel {
+  constructor(db, pgp, logger = null) {
+    super(db, pgp, projectMembersSchema, logger);
+  }
+}

--- a/apps/nap-serv/src/modules/core/models/StateFilters.js
+++ b/apps/nap-serv/src/modules/core/models/StateFilters.js
@@ -1,0 +1,15 @@
+/**
+ * @file StateFilters model — extends TableModel for RBAC Layer 3 record-state visibility
+ * @module core/models/StateFilters
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { TableModel } from 'pg-schemata';
+import stateFiltersSchema from '../schemas/stateFiltersSchema.js';
+
+export default class StateFilters extends TableModel {
+  constructor(db, pgp, logger = null) {
+    super(db, pgp, stateFiltersSchema, logger);
+  }
+}

--- a/apps/nap-serv/src/modules/core/schema/migrations/202502180012_rbacScopeTables.js
+++ b/apps/nap-serv/src/modules/core/schema/migrations/202502180012_rbacScopeTables.js
@@ -1,0 +1,114 @@
+/**
+ * @file Migration: add RBAC Layers 2-4 tables and scope column
+ * @module core/schema/migrations/202502180012_rbacScopeTables
+ *
+ * Adds:
+ *   - `scope` column to existing `roles` table (Layer 2)
+ *   - `project_members` table (Layer 2 — user-to-project assignment)
+ *   - `company_members` table (Layer 2 — user-to-company assignment)
+ *   - `state_filters` table (Layer 3 — record-status visibility)
+ *   - `field_group_definitions` table (Layer 4 — named column groups)
+ *   - `field_group_grants` table (Layer 4 — role-to-group assignment)
+ *   - `policy_catalog` table (RBAC registry of valid module/router/action combinations)
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { defineMigration } from '../../../../db/migrations/defineMigration.js';
+
+export default defineMigration({
+  id: '202502180012-rbac-scope-tables',
+  description:
+    'Add scope to roles; create project_members, state_filters, field_group_definitions, field_group_grants',
+
+  async up({ schema, db, pgp, models }) {
+    if (schema === 'admin') return;
+
+    const s = pgp.as.name(schema);
+
+    // ── Layer 2: Add scope column to roles ──────────────────────────────
+    await db.none(
+      `ALTER TABLE ${s}.roles ADD COLUMN IF NOT EXISTS scope varchar(32) NOT NULL DEFAULT 'all_projects'`,
+    );
+    // Guard against duplicate constraint (idempotent)
+    await db.none(`
+      DO $$ BEGIN
+        ALTER TABLE ${s}.roles
+          ADD CONSTRAINT roles_scope_check CHECK (scope IN ('all_projects','assigned_companies','assigned_projects'));
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+
+    // ── Create new tables in dependency order ───────────────────────────
+    // state_filters depends on roles (FK)
+    if (models.stateFilters) await models.stateFilters.createTable();
+
+    // field_group_definitions has no FK deps
+    if (models.fieldGroupDefinitions) await models.fieldGroupDefinitions.createTable();
+
+    // field_group_grants depends on roles + field_group_definitions
+    if (models.fieldGroupGrants) await models.fieldGroupGrants.createTable();
+
+    // project_members — table created without FK (cross-module dep on projects)
+    if (models.projectMembers) await models.projectMembers.createTable();
+
+    // company_members — table created without FK (cross-module dep on inter_companies)
+    if (models.companyMembers) await models.companyMembers.createTable();
+
+    // policy_catalog — no FK deps
+    if (models.policyCatalog) await models.policyCatalog.createTable();
+
+    // Add FK from project_members → projects after table exists
+    // Uses the circular-FK pattern: ALTER TABLE after creation
+    const projectsExists = await db.oneOrNone(
+      'SELECT to_regclass($1) AS exists',
+      [`${schema}.projects`],
+    );
+    if (projectsExists?.exists) {
+      await db.none(`
+        DO $$ BEGIN
+          ALTER TABLE ${s}.project_members
+            ADD CONSTRAINT fk_project_members_project_id
+            FOREIGN KEY (project_id) REFERENCES ${s}.projects(id) ON DELETE CASCADE;
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+    }
+
+    // Add FK from company_members → inter_companies after table exists
+    const interCompaniesExists = await db.oneOrNone(
+      'SELECT to_regclass($1) AS exists',
+      [`${schema}.inter_companies`],
+    );
+    if (interCompaniesExists?.exists) {
+      await db.none(`
+        DO $$ BEGIN
+          ALTER TABLE ${s}.company_members
+            ADD CONSTRAINT fk_company_members_company_id
+            FOREIGN KEY (company_id) REFERENCES ${s}.inter_companies(id) ON DELETE CASCADE;
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+    }
+  },
+
+  async down({ schema, db, pgp }) {
+    if (schema === 'admin') return;
+
+    const s = pgp.as.name(schema);
+
+    await db.none(`DROP TABLE IF EXISTS ${s}.policy_catalog CASCADE`);
+    await db.none(`DROP TABLE IF EXISTS ${s}.company_members CASCADE`);
+    await db.none(`DROP TABLE IF EXISTS ${s}.field_group_grants CASCADE`);
+    await db.none(`DROP TABLE IF EXISTS ${s}.field_group_definitions CASCADE`);
+    await db.none(`DROP TABLE IF EXISTS ${s}.state_filters CASCADE`);
+    await db.none(`DROP TABLE IF EXISTS ${s}.project_members CASCADE`);
+    await db.none(`ALTER TABLE ${s}.roles DROP COLUMN IF EXISTS scope`);
+    await db.none(`
+      DO $$ BEGIN
+        ALTER TABLE ${s}.roles DROP CONSTRAINT IF EXISTS roles_scope_check;
+      EXCEPTION WHEN undefined_object THEN NULL;
+      END $$
+    `);
+  },
+});

--- a/apps/nap-serv/src/modules/core/schema/migrations/index.js
+++ b/apps/nap-serv/src/modules/core/schema/migrations/index.js
@@ -7,5 +7,6 @@
 
 import coreTables from './202502110010_coreTables.js';
 import coreEntityTables from './202502110011_coreEntityTables.js';
+import rbacScopeTables from './202502180012_rbacScopeTables.js';
 
-export default [coreTables, coreEntityTables];
+export default [coreTables, coreEntityTables, rbacScopeTables];

--- a/apps/nap-serv/src/modules/core/schemas/companyMembersSchema.js
+++ b/apps/nap-serv/src/modules/core/schemas/companyMembersSchema.js
@@ -1,0 +1,39 @@
+/**
+ * @file Schema definition for tenant-scope company_members table (RBAC Layer 2)
+ * @module core/schemas/companyMembersSchema
+ *
+ * Maps users to inter-companies for data-scope enforcement.
+ * When a role has scope = 'assigned_companies', the user only sees data
+ * from projects belonging to their assigned inter-companies.
+ *
+ * FK to inter_companies is added via ALTER TABLE in migration (cross-module dependency).
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+/** @type {import('pg-schemata').TableSchema} */
+const companyMembersSchema = {
+  dbSchema: 'public',
+  table: 'company_members',
+  version: '1.0.0',
+  hasAuditFields: { enabled: true, userFields: { type: 'uuid', nullable: true, default: null } },
+  softDelete: false,
+  columns: [
+    { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
+    { name: 'tenant_code', type: 'varchar(6)', default: null },
+    { name: 'company_id', type: 'uuid', notNull: true },
+    { name: 'user_id', type: 'uuid', notNull: true },
+  ],
+  constraints: {
+    primaryKey: ['id'],
+    unique: [['company_id', 'user_id']],
+    foreignKeys: [],
+    indexes: [
+      { type: 'Index', columns: ['company_id'] },
+      { type: 'Index', columns: ['user_id'] },
+      { type: 'Index', columns: ['user_id', 'company_id'] },
+    ],
+  },
+};
+
+export default companyMembersSchema;

--- a/apps/nap-serv/src/modules/core/schemas/employeesSchema.js
+++ b/apps/nap-serv/src/modules/core/schemas/employeesSchema.js
@@ -21,6 +21,8 @@ const employeesSchema = {
     { name: 'code', type: 'varchar(16)' },
     { name: 'position', type: 'varchar(64)' },
     { name: 'department', type: 'varchar(64)' },
+    { name: 'email', type: 'varchar(128)', default: null },
+    { name: 'is_app_user', type: 'boolean', notNull: true, default: false },
     { name: 'is_active', type: 'boolean', notNull: true, default: true },
   ],
   constraints: {
@@ -37,6 +39,7 @@ const employeesSchema = {
     indexes: [
       { type: 'Index', columns: ['tenant_id'] },
       { type: 'Index', columns: ['tenant_id', 'code'], unique: true, where: 'deactivated_at IS NULL' },
+      { type: 'Index', columns: ['tenant_id', 'email'], unique: true, where: 'email IS NOT NULL AND deactivated_at IS NULL' },
     ],
   },
 };

--- a/apps/nap-serv/src/modules/core/schemas/fieldGroupDefinitionsSchema.js
+++ b/apps/nap-serv/src/modules/core/schemas/fieldGroupDefinitionsSchema.js
@@ -1,0 +1,37 @@
+/**
+ * @file Schema definition for tenant-scope field_group_definitions table (RBAC Layer 4)
+ * @module core/schemas/fieldGroupDefinitionsSchema
+ *
+ * Defines named column groups per resource. Each group maps a group_name to an
+ * array of column names. Groups marked is_default are granted to all roles.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+/** @type {import('pg-schemata').TableSchema} */
+const fieldGroupDefinitionsSchema = {
+  dbSchema: 'public',
+  table: 'field_group_definitions',
+  version: '1.0.0',
+  hasAuditFields: { enabled: true, userFields: { type: 'uuid', nullable: true, default: null } },
+  softDelete: false,
+  columns: [
+    { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
+    { name: 'tenant_code', type: 'varchar(6)', default: null },
+    { name: 'module', type: 'varchar(32)', notNull: true },
+    { name: 'router', type: 'varchar(64)', default: null },
+    { name: 'group_name', type: 'varchar(64)', notNull: true },
+    { name: 'columns', type: 'text[]', notNull: true },
+    { name: 'is_default', type: 'boolean', notNull: true, default: false },
+  ],
+  constraints: {
+    primaryKey: ['id'],
+    unique: [['module', 'router', 'group_name']],
+    foreignKeys: [],
+    indexes: [
+      { type: 'Index', columns: ['module', 'router'] },
+    ],
+  },
+};
+
+export default fieldGroupDefinitionsSchema;

--- a/apps/nap-serv/src/modules/core/schemas/fieldGroupGrantsSchema.js
+++ b/apps/nap-serv/src/modules/core/schemas/fieldGroupGrantsSchema.js
@@ -1,0 +1,48 @@
+/**
+ * @file Schema definition for tenant-scope field_group_grants table (RBAC Layer 4)
+ * @module core/schemas/fieldGroupGrantsSchema
+ *
+ * Assigns field groups to roles. A role can see the union of columns across
+ * all granted groups plus any is_default groups.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+/** @type {import('pg-schemata').TableSchema} */
+const fieldGroupGrantsSchema = {
+  dbSchema: 'public',
+  table: 'field_group_grants',
+  version: '1.0.0',
+  hasAuditFields: { enabled: true, userFields: { type: 'uuid', nullable: true, default: null } },
+  softDelete: false,
+  columns: [
+    { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
+    { name: 'tenant_code', type: 'varchar(6)', default: null },
+    { name: 'role_id', type: 'uuid', notNull: true },
+    { name: 'field_group_id', type: 'uuid', notNull: true },
+  ],
+  constraints: {
+    primaryKey: ['id'],
+    unique: [['role_id', 'field_group_id']],
+    foreignKeys: [
+      {
+        type: 'ForeignKey',
+        columns: ['role_id'],
+        references: { table: 'roles', columns: ['id'] },
+        onDelete: 'CASCADE',
+      },
+      {
+        type: 'ForeignKey',
+        columns: ['field_group_id'],
+        references: { table: 'field_group_definitions', columns: ['id'] },
+        onDelete: 'CASCADE',
+      },
+    ],
+    indexes: [
+      { type: 'Index', columns: ['role_id'] },
+      { type: 'Index', columns: ['field_group_id'] },
+    ],
+  },
+};
+
+export default fieldGroupGrantsSchema;

--- a/apps/nap-serv/src/modules/core/schemas/policyCatalogSchema.js
+++ b/apps/nap-serv/src/modules/core/schemas/policyCatalogSchema.js
@@ -1,0 +1,41 @@
+/**
+ * @file Schema definition for tenant-scope policy_catalog table (RBAC)
+ * @module core/schemas/policyCatalogSchema
+ *
+ * Read-only registry of all valid module/router/action combinations.
+ * Seeded at bootstrap — administrators query this to discover available
+ * permissions when configuring roles.
+ *
+ * No audit fields or tenant_code — this is static application-level
+ * reference data, identical across all tenants.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+/** @type {import('pg-schemata').TableSchema} */
+const policyCatalogSchema = {
+  dbSchema: 'public',
+  table: 'policy_catalog',
+  version: '1.0.0',
+  hasAuditFields: { enabled: false },
+  softDelete: false,
+  columns: [
+    { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
+    { name: 'module', type: 'varchar(32)', notNull: true },
+    { name: 'router', type: 'varchar(64)', default: null },
+    { name: 'action', type: 'varchar(64)', default: null },
+    { name: 'label', type: 'varchar(128)', notNull: true },
+    { name: 'description', type: 'varchar(512)', default: null },
+    { name: 'sort_order', type: 'integer', notNull: true, default: 0 },
+  ],
+  constraints: {
+    primaryKey: ['id'],
+    unique: [['module', 'router', 'action']],
+    indexes: [
+      { type: 'Index', columns: ['module'] },
+      { type: 'Index', columns: ['module', 'sort_order'] },
+    ],
+  },
+};
+
+export default policyCatalogSchema;

--- a/apps/nap-serv/src/modules/core/schemas/projectMembersSchema.js
+++ b/apps/nap-serv/src/modules/core/schemas/projectMembersSchema.js
@@ -1,0 +1,37 @@
+/**
+ * @file Schema definition for tenant-scope project_members table (RBAC Layer 2)
+ * @module core/schemas/projectMembersSchema
+ *
+ * Maps users to projects for data-scope enforcement.
+ * FK to projects is added via ALTER TABLE in migration (cross-module dependency).
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+/** @type {import('pg-schemata').TableSchema} */
+const projectMembersSchema = {
+  dbSchema: 'public',
+  table: 'project_members',
+  version: '1.0.0',
+  hasAuditFields: { enabled: true, userFields: { type: 'uuid', nullable: true, default: null } },
+  softDelete: false,
+  columns: [
+    { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
+    { name: 'tenant_code', type: 'varchar(6)', default: null },
+    { name: 'project_id', type: 'uuid', notNull: true },
+    { name: 'user_id', type: 'uuid', notNull: true },
+    { name: 'role', type: 'varchar(32)', notNull: true, default: 'member' },
+  ],
+  constraints: {
+    primaryKey: ['id'],
+    unique: [['project_id', 'user_id']],
+    foreignKeys: [],
+    indexes: [
+      { type: 'Index', columns: ['project_id'] },
+      { type: 'Index', columns: ['user_id'] },
+      { type: 'Index', columns: ['user_id', 'project_id'] },
+    ],
+  },
+};
+
+export default projectMembersSchema;

--- a/apps/nap-serv/src/modules/core/schemas/rolesSchema.js
+++ b/apps/nap-serv/src/modules/core/schemas/rolesSchema.js
@@ -20,10 +20,12 @@ const rolesSchema = {
     { name: 'description', type: 'varchar(255)', default: null },
     { name: 'is_system', type: 'boolean', notNull: true, default: false },
     { name: 'is_immutable', type: 'boolean', notNull: true, default: false },
+    { name: 'scope', type: 'varchar(32)', notNull: true, default: 'all_projects' },
   ],
   constraints: {
     primaryKey: ['id'],
     unique: [['code']],
+    checks: [{ type: 'Check', expression: "scope IN ('all_projects','assigned_companies','assigned_projects')" }],
     indexes: [{ type: 'Index', columns: ['code'] }],
   },
 };

--- a/apps/nap-serv/src/modules/core/schemas/stateFiltersSchema.js
+++ b/apps/nap-serv/src/modules/core/schemas/stateFiltersSchema.js
@@ -1,0 +1,44 @@
+/**
+ * @file Schema definition for tenant-scope state_filters table (RBAC Layer 3)
+ * @module core/schemas/stateFiltersSchema
+ *
+ * Controls which record statuses are visible per role per resource.
+ * Empty table (no row for a role+resource) = all statuses visible.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+/** @type {import('pg-schemata').TableSchema} */
+const stateFiltersSchema = {
+  dbSchema: 'public',
+  table: 'state_filters',
+  version: '1.0.0',
+  hasAuditFields: { enabled: true, userFields: { type: 'uuid', nullable: true, default: null } },
+  softDelete: false,
+  columns: [
+    { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
+    { name: 'tenant_code', type: 'varchar(6)', default: null },
+    { name: 'role_id', type: 'uuid', notNull: true },
+    { name: 'module', type: 'varchar(32)', notNull: true },
+    { name: 'router', type: 'varchar(64)', default: null },
+    { name: 'visible_statuses', type: 'text[]', notNull: true },
+  ],
+  constraints: {
+    primaryKey: ['id'],
+    unique: [['role_id', 'module', 'router']],
+    foreignKeys: [
+      {
+        type: 'ForeignKey',
+        columns: ['role_id'],
+        references: { table: 'roles', columns: ['id'] },
+        onDelete: 'CASCADE',
+      },
+    ],
+    indexes: [
+      { type: 'Index', columns: ['role_id'] },
+      { type: 'Index', columns: ['module', 'router'] },
+    ],
+  },
+};
+
+export default stateFiltersSchema;

--- a/apps/nap-serv/src/modules/core/seeds/seed_policy_catalog.js
+++ b/apps/nap-serv/src/modules/core/seeds/seed_policy_catalog.js
@@ -1,0 +1,158 @@
+/**
+ * @file Seeds the policy_catalog table with all valid module/router/action combinations
+ * @module core/seeds/seed_policy_catalog
+ *
+ * The policy_catalog is a read-only registry that administrators query to discover
+ * available permissions when configuring roles. Router names use URL path segments
+ * as the canonical convention.
+ *
+ * sort_order uses 100-level gaps for modules, 10-level gaps for routers,
+ * and 1-level gaps for actions.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import db from '../../../db/db.js';
+
+/**
+ * Safely insert a record, silently skipping unique constraint violations.
+ */
+async function safeInsert(schema, data) {
+  try {
+    return await db('policyCatalog', schema).insert(data);
+  } catch (e) {
+    if (e?.code === '23505') return null; // unique violation — already seeded
+    throw e;
+  }
+}
+
+/** @type {Array<{module: string, router: string|null, action: string|null, label: string, description: string|null, sort_order: number}>} */
+const CATALOG = [
+  // ── tenants ─────────────────────────────────────────────────────────
+  { module: 'tenants', router: null, action: null, label: 'Tenants (all)', description: 'Full tenant management module access', sort_order: 100 },
+  { module: 'tenants', router: 'tenants', action: null, label: 'Tenants', description: 'Create, view, and manage tenant organizations', sort_order: 110 },
+  { module: 'tenants', router: 'nap-users', action: null, label: 'NAP Users', description: 'Create, view, and manage platform users', sort_order: 120 },
+
+  // ── core ────────────────────────────────────────────────────────────
+  { module: 'core', router: null, action: null, label: 'Core (all)', description: 'Full core entities module access', sort_order: 200 },
+  { module: 'core', router: 'sources', action: null, label: 'Sources', description: 'View source records (read-only)', sort_order: 210 },
+  { module: 'core', router: 'vendors', action: null, label: 'Vendors', description: 'Manage vendor records', sort_order: 220 },
+  { module: 'core', router: 'clients', action: null, label: 'Clients', description: 'Manage client records', sort_order: 230 },
+  { module: 'core', router: 'employees', action: null, label: 'Employees', description: 'Manage employee records', sort_order: 240 },
+  { module: 'core', router: 'contacts', action: null, label: 'Contacts', description: 'Manage contact records', sort_order: 250 },
+  { module: 'core', router: 'addresses', action: null, label: 'Addresses', description: 'Manage address records', sort_order: 260 },
+  { module: 'core', router: 'inter-companies', action: null, label: 'Inter-Companies', description: 'Manage inter-company entities', sort_order: 270 },
+  { module: 'core', router: 'roles', action: null, label: 'Roles', description: 'Manage tenant RBAC roles', sort_order: 280 },
+  { module: 'core', router: 'role-members', action: null, label: 'Role Members', description: 'Manage role membership assignments', sort_order: 281 },
+  { module: 'core', router: 'policies', action: null, label: 'Policies', description: 'Manage role permission policies', sort_order: 282 },
+  { module: 'core', router: 'policy-catalog', action: null, label: 'Policy Catalog', description: 'View available permission combinations (read-only)', sort_order: 283 },
+
+  // ── projects ────────────────────────────────────────────────────────
+  { module: 'projects', router: null, action: null, label: 'Projects (all)', description: 'Full projects module access', sort_order: 300 },
+  { module: 'projects', router: 'projects', action: null, label: 'Projects', description: 'Manage project records', sort_order: 310 },
+  { module: 'projects', router: 'projects', action: 'release', label: 'Release Project', description: 'Transition project from budgeting to released', sort_order: 311 },
+  { module: 'projects', router: 'units', action: null, label: 'Units', description: 'Manage project units', sort_order: 320 },
+  { module: 'projects', router: 'tasks', action: null, label: 'Tasks', description: 'Manage project tasks', sort_order: 330 },
+  { module: 'projects', router: 'task-groups', action: null, label: 'Task Groups', description: 'Manage task groups', sort_order: 340 },
+  { module: 'projects', router: 'tasks-master', action: null, label: 'Tasks Master', description: 'Manage master task list', sort_order: 350 },
+  { module: 'projects', router: 'cost-items', action: null, label: 'Cost Items', description: 'Manage project cost items', sort_order: 360 },
+  { module: 'projects', router: 'change-orders', action: null, label: 'Change Orders', description: 'Manage project change orders', sort_order: 370 },
+  { module: 'projects', router: 'change-orders', action: 'approve', label: 'Approve Change Order', description: 'Approve a submitted change order', sort_order: 371 },
+  { module: 'projects', router: 'change-orders', action: 'reject', label: 'Reject Change Order', description: 'Reject a submitted change order', sort_order: 372 },
+  { module: 'projects', router: 'template-units', action: null, label: 'Template Units', description: 'Manage project template units', sort_order: 380 },
+  { module: 'projects', router: 'template-tasks', action: null, label: 'Template Tasks', description: 'Manage project template tasks', sort_order: 390 },
+  { module: 'projects', router: 'template-cost-items', action: null, label: 'Template Cost Items', description: 'Manage project template cost items', sort_order: 395 },
+  { module: 'projects', router: 'template-change-orders', action: null, label: 'Template Change Orders', description: 'Manage project template change orders', sort_order: 396 },
+
+  // ── activities ──────────────────────────────────────────────────────
+  { module: 'activities', router: null, action: null, label: 'Activities (all)', description: 'Full activities module access', sort_order: 400 },
+  { module: 'activities', router: 'activities', action: null, label: 'Activities', description: 'Manage activity records', sort_order: 410 },
+  { module: 'activities', router: 'budgets', action: null, label: 'Budgets', description: 'Manage activity budgets', sort_order: 420 },
+  { module: 'activities', router: 'budgets', action: 'approve', label: 'Approve Budget', description: 'Approve a submitted budget', sort_order: 421 },
+  { module: 'activities', router: 'budgets', action: 'reject', label: 'Reject Budget', description: 'Reject a submitted budget', sort_order: 422 },
+  { module: 'activities', router: 'categories', action: null, label: 'Categories', description: 'Manage activity categories', sort_order: 430 },
+  { module: 'activities', router: 'actual-costs', action: null, label: 'Actual Costs', description: 'Manage actual cost records', sort_order: 440 },
+  { module: 'activities', router: 'actual-costs', action: 'approve', label: 'Approve Actual Cost', description: 'Approve an actual cost for GL posting', sort_order: 441 },
+  { module: 'activities', router: 'actual-costs', action: 'reject', label: 'Reject Actual Cost', description: 'Reject an actual cost', sort_order: 442 },
+  { module: 'activities', router: 'cost-lines', action: null, label: 'Cost Lines', description: 'Manage cost line items', sort_order: 450 },
+  { module: 'activities', router: 'deliverables', action: null, label: 'Deliverables', description: 'Manage deliverable records', sort_order: 460 },
+  { module: 'activities', router: 'deliverable-assignments', action: null, label: 'Deliverable Assignments', description: 'Manage deliverable-to-vendor assignments', sort_order: 470 },
+  { module: 'activities', router: 'vendor-parts', action: null, label: 'Vendor Parts', description: 'Manage vendor part records', sort_order: 480 },
+
+  // ── bom ─────────────────────────────────────────────────────────────
+  { module: 'bom', router: null, action: null, label: 'BOM (all)', description: 'Full bill of materials module access', sort_order: 500 },
+  { module: 'bom', router: 'catalog-skus', action: null, label: 'Catalog SKUs', description: 'Manage catalog SKU records', sort_order: 510 },
+  { module: 'bom', router: 'vendor-skus', action: null, label: 'Vendor SKUs', description: 'Manage vendor SKU mappings', sort_order: 520 },
+  { module: 'bom', router: 'vendor-pricing', action: null, label: 'Vendor Pricing', description: 'Manage vendor pricing records', sort_order: 530 },
+
+  // ── ap ──────────────────────────────────────────────────────────────
+  { module: 'ap', router: null, action: null, label: 'AP (all)', description: 'Full accounts payable module access', sort_order: 600 },
+  { module: 'ap', router: 'ap-invoices', action: null, label: 'AP Invoices', description: 'Manage AP invoice records', sort_order: 610 },
+  { module: 'ap', router: 'ap-invoices', action: 'approve', label: 'AP Invoice Approval', description: 'Approve vendor invoices for payment', sort_order: 611 },
+  { module: 'ap', router: 'ap-invoices', action: 'void', label: 'Void AP Invoice', description: 'Void an AP invoice', sort_order: 612 },
+  { module: 'ap', router: 'ap-invoice-lines', action: null, label: 'AP Invoice Lines', description: 'Manage AP invoice line items', sort_order: 620 },
+  { module: 'ap', router: 'ap-credit-memos', action: null, label: 'AP Credit Memos', description: 'Manage AP credit memo records', sort_order: 630 },
+  { module: 'ap', router: 'ap-credit-memos', action: 'void', label: 'Void AP Credit Memo', description: 'Void an AP credit memo', sort_order: 631 },
+  { module: 'ap', router: 'payments', action: null, label: 'Payments', description: 'Manage payment records', sort_order: 640 },
+
+  // ── ar ──────────────────────────────────────────────────────────────
+  { module: 'ar', router: null, action: null, label: 'AR (all)', description: 'Full accounts receivable module access', sort_order: 700 },
+  { module: 'ar', router: 'ar-invoices', action: null, label: 'AR Invoices', description: 'Manage AR invoice records', sort_order: 710 },
+  { module: 'ar', router: 'ar-invoices', action: 'approve', label: 'AR Invoice Approval', description: 'Approve AR invoices for sending to clients', sort_order: 711 },
+  { module: 'ar', router: 'ar-invoices', action: 'void', label: 'Void AR Invoice', description: 'Void an AR invoice', sort_order: 712 },
+  { module: 'ar', router: 'ar-invoice-lines', action: null, label: 'AR Invoice Lines', description: 'Manage AR invoice line items', sort_order: 720 },
+  { module: 'ar', router: 'clients', action: null, label: 'AR Clients', description: 'Manage AR client records', sort_order: 730 },
+  { module: 'ar', router: 'receipts', action: null, label: 'Receipts', description: 'Manage receipt records', sort_order: 740 },
+
+  // ── accounting ──────────────────────────────────────────────────────
+  { module: 'accounting', router: null, action: null, label: 'Accounting (all)', description: 'Full general ledger module access', sort_order: 800 },
+  { module: 'accounting', router: 'chart-of-accounts', action: null, label: 'Chart of Accounts', description: 'Manage chart of accounts', sort_order: 810 },
+  { module: 'accounting', router: 'journal-entries', action: null, label: 'Journal Entries', description: 'Manage journal entries', sort_order: 820 },
+  { module: 'accounting', router: 'journal-entries', action: 'post', label: 'Post Journal Entry', description: 'Post a journal entry to the general ledger', sort_order: 821 },
+  { module: 'accounting', router: 'journal-entries', action: 'reverse', label: 'Reverse Journal Entry', description: 'Reverse a posted journal entry', sort_order: 822 },
+  { module: 'accounting', router: 'journal-entry-lines', action: null, label: 'Journal Entry Lines', description: 'Manage journal entry line items', sort_order: 830 },
+  { module: 'accounting', router: 'ledger-balances', action: null, label: 'Ledger Balances', description: 'View ledger balance summaries', sort_order: 840 },
+  { module: 'accounting', router: 'posting-queues', action: null, label: 'Posting Queues', description: 'Manage posting queue records', sort_order: 850 },
+  { module: 'accounting', router: 'categories-account-map', action: null, label: 'Categories Account Map', description: 'Manage category-to-account mappings', sort_order: 860 },
+  { module: 'accounting', router: 'inter-company-accounts', action: null, label: 'Inter-Company Accounts', description: 'Manage inter-company GL accounts', sort_order: 870 },
+  { module: 'accounting', router: 'inter-company-transactions', action: null, label: 'Inter-Company Transactions', description: 'Manage inter-company transactions', sort_order: 880 },
+  { module: 'accounting', router: 'internal-transfers', action: null, label: 'Internal Transfers', description: 'Manage internal fund transfers', sort_order: 890 },
+
+  // ── reports ─────────────────────────────────────────────────────────
+  { module: 'reports', router: null, action: null, label: 'Reports (all)', description: 'Full reports module access', sort_order: 900 },
+  { module: 'reports', router: 'reports', action: null, label: 'Reports', description: 'View and generate reports', sort_order: 910 },
+
+  // ── views ───────────────────────────────────────────────────────────
+  { module: 'views', router: null, action: null, label: 'Views (all)', description: 'Full views module access', sort_order: 1000 },
+  { module: 'views', router: 'views', action: null, label: 'Views', description: 'Manage saved views', sort_order: 1010 },
+];
+
+/**
+ * Seed the policy_catalog table with all valid module/router/action combinations.
+ * Idempotent — skips entries that already exist via unique constraint on (module, router, action).
+ *
+ * @param {object} options
+ * @param {string} options.schemaName Tenant schema name
+ */
+export async function seedPolicyCatalog({ schemaName }) {
+  const schema = schemaName ? schemaName.toLowerCase() : 'public';
+  if (schema === 'admin') return;
+
+  // Check that policy_catalog table exists
+  const tableExists = await db.oneOrNone(
+    'SELECT to_regclass($1) AS exists',
+    [`${schema}.policy_catalog`],
+  );
+  if (!tableExists?.exists) {
+    console.warn(`Skipping policy_catalog seeding for schema "${schema}" — table missing.`);
+    return;
+  }
+
+  console.log(`Seeding policy_catalog for schema: ${schema}`);
+  for (const entry of CATALOG) {
+    await safeInsert(schema, entry);
+  }
+}
+
+export { CATALOG };
+export default seedPolicyCatalog;

--- a/apps/nap-serv/src/modules/core/seeds/seed_rbac.js
+++ b/apps/nap-serv/src/modules/core/seeds/seed_rbac.js
@@ -1,11 +1,24 @@
 /**
- * @file Seeds RBAC system roles and policies per module
+ * @file Seeds RBAC system roles, policies, and Layer 2-3 defaults per module
  * @module core/seeds/seed_rbac
  *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
 
 import db from '../../../db/db.js';
+import { seedPolicyCatalog } from './seed_policy_catalog.js';
+
+/**
+ * Safely insert a record, silently skipping unique constraint violations.
+ */
+async function safeInsert(modelName, schema, data) {
+  try {
+    return await db(modelName, schema).insert(data);
+  } catch (e) {
+    if (e?.code === '23505') return null; // unique violation — already seeded
+    throw e;
+  }
+}
 
 export async function seedRbac({ schemaName, createdBy = null }) {
   console.log('Seeding RBAC for schema:', schemaName);
@@ -20,17 +33,20 @@ export async function seedRbac({ schemaName, createdBy = null }) {
     return;
   }
 
-  const roleCodesToCheck = isAdminSchema ? ['super_user', 'admin'] : ['admin', 'project_manager'];
+  const roleCodesToCheck = isAdminSchema
+    ? ['super_user', 'admin']
+    : ['admin', 'project_manager', 'controller'];
   const existing = await db('roles', schema).findWhere([{ code: { $in: roleCodesToCheck } }], 'AND');
   const haveCodes = new Set(existing.map((r) => r.code));
 
-  // System roles
+  // ── System roles ──────────────────────────────────────────────────────
   if (isAdminSchema && !haveCodes.has('super_user')) {
     await db('roles', schema).insert({
       code: 'super_user',
       name: 'Super User',
       is_system: true,
       is_immutable: true,
+      scope: 'all_projects',
       created_by: createdBy,
     });
   }
@@ -38,46 +54,103 @@ export async function seedRbac({ schemaName, createdBy = null }) {
   if (!haveCodes.has('admin')) {
     await db('roles', schema).insert({
       code: 'admin',
-      name: 'Tenant Admin',
+      name: 'Administrator',
       is_system: true,
       is_immutable: true,
+      scope: 'all_projects',
       created_by: createdBy,
     });
   }
 
-  // Tenant-specific roles and policies
+  // ── Tenant-specific roles, policies, and state filters ────────────────
   if (!isAdminSchema) {
+    // ── Project Manager ───────────────────────────────────────────────
     let pm;
     if (!haveCodes.has('project_manager')) {
       pm = await db('roles', schema).insert({
         code: 'project_manager',
         name: 'Project Manager',
+        scope: 'assigned_projects',
         created_by: createdBy,
       });
     } else {
       pm = await db('roles', schema).findOneBy([{ code: 'project_manager' }]);
     }
 
-    // Seed policies per PRD §3.7 RBAC hierarchy
-    const policies = [
+    // Layer 1: Policies per PRD §3.7 RBAC hierarchy
+    const pmPolicies = [
       { role_id: pm.id, module: 'projects', router: null, action: null, level: 'full' },
       { role_id: pm.id, module: 'accounting', router: null, action: null, level: 'view' },
       { role_id: pm.id, module: 'ar', router: null, action: null, level: 'view' },
-      { role_id: pm.id, module: 'ar', router: 'invoices', action: 'approve', level: 'none' },
+      { role_id: pm.id, module: 'ar', router: 'ar-invoices', action: 'approve', level: 'none' },
     ];
 
-    for (const p of policies) {
-      const data = { ...p, created_by: createdBy };
-      try {
-        await db('policies', schema).insert(data);
-      } catch (e) {
-        if (e?.code === '23505') {
-          // unique violation — already seeded, skip
-          continue;
-        }
-        throw e;
+    for (const p of pmPolicies) {
+      await safeInsert('policies', schema, { ...p, created_by: createdBy });
+    }
+
+    // Layer 3: State filters — PM can only see approved/sent invoices
+    await safeInsert('stateFilters', schema, {
+      role_id: pm.id,
+      module: 'ar',
+      router: 'ar-invoices',
+      visible_statuses: ['approved', 'sent'],
+      created_by: createdBy,
+    });
+
+    // ── Controller ────────────────────────────────────────────────────
+    let ctrl;
+    if (!haveCodes.has('controller')) {
+      ctrl = await db('roles', schema).insert({
+        code: 'controller',
+        name: 'Controller',
+        description: 'Financial controller with full accounting access, scoped to assigned companies',
+        scope: 'assigned_companies',
+        created_by: createdBy,
+      });
+    } else {
+      ctrl = await db('roles', schema).findOneBy([{ code: 'controller' }]);
+    }
+
+    const ctrlPolicies = [
+      { role_id: ctrl.id, module: 'accounting', router: null, action: null, level: 'full' },
+      { role_id: ctrl.id, module: 'ar', router: null, action: null, level: 'full' },
+      { role_id: ctrl.id, module: 'ap', router: null, action: null, level: 'full' },
+      { role_id: ctrl.id, module: 'projects', router: null, action: null, level: 'view' },
+      { role_id: ctrl.id, module: 'reports', router: null, action: null, level: 'view' },
+    ];
+
+    for (const p of ctrlPolicies) {
+      await safeInsert('policies', schema, { ...p, created_by: createdBy });
+    }
+
+    // ── Admin role policies for tenants module ────────────────────────
+    // Only effective for NapSoft users (requireNapsoftTenant gates the router).
+    const adminRole = await db('roles', schema).findOneBy([{ code: 'admin' }]);
+    if (adminRole) {
+      const adminPolicies = [
+        { role_id: adminRole.id, module: 'tenants', router: 'tenants', action: null, level: 'full' },
+        { role_id: adminRole.id, module: 'tenants', router: 'nap-users', action: null, level: 'full' },
+      ];
+      for (const p of adminPolicies) {
+        await safeInsert('policies', schema, { ...p, created_by: createdBy });
       }
     }
+
+    // ── Auto-assign admin role to the creating user ──────────────────
+    if (createdBy && typeof createdBy === 'string' && /^[0-9a-f-]{36}$/i.test(createdBy)) {
+      if (adminRole) {
+        await safeInsert('roleMembers', schema, {
+          role_id: adminRole.id,
+          user_id: createdBy,
+          is_primary: true,
+          created_by: createdBy,
+        });
+      }
+    }
+
+    // ── Policy catalog ────────────────────────────────────────────────
+    await seedPolicyCatalog({ schemaName });
   }
 }
 

--- a/apps/nap-serv/src/modules/tenants/apiRoutes/v1/adminRouter.js
+++ b/apps/nap-serv/src/modules/tenants/apiRoutes/v1/adminRouter.js
@@ -1,16 +1,24 @@
 /**
- * @file Tenants admin router — schema management per PRD §3.2.3
+ * @file Tenants admin router — schema listing, impersonation per PRD §3.2.3
  * @module tenants/apiRoutes/v1/adminRouter
  *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
 
 import { Router } from 'express';
-import { getAllSchemas, switchSchema } from '../../controllers/adminController.js';
+import { requireNapsoftTenant } from '../../../../middleware/requireNapsoftTenant.js';
+import {
+  getAllSchemas,
+  startImpersonation,
+  endImpersonation,
+  getImpersonationStatus,
+} from '../../controllers/adminController.js';
 
 const router = Router();
 
-router.get('/schemas', getAllSchemas);
-router.post('/switch-schema/:schema', switchSchema);
+router.get('/schemas', requireNapsoftTenant, getAllSchemas);
+router.post('/impersonate', requireNapsoftTenant, startImpersonation);
+router.post('/exit-impersonation', endImpersonation);
+router.get('/impersonation-status', getImpersonationStatus);
 
 export default router;

--- a/apps/nap-serv/src/modules/tenants/apiRoutes/v1/napUsersRouter.js
+++ b/apps/nap-serv/src/modules/tenants/apiRoutes/v1/napUsersRouter.js
@@ -3,6 +3,7 @@
  * @module tenants/apiRoutes/v1/napUsersRouter
  *
  * Standard POST is disabled; users must be created via /register.
+ * All routes gated by requireNapsoftTenant + RBAC (tenants::nap-users).
  *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
@@ -10,13 +11,21 @@
 import napUsersController from '../../controllers/napUsersController.js';
 import createRouter from '../../../../lib/createRouter.js';
 import { addAuditFields } from '../../../../middleware/addAuditFields.js';
+import { requireNapsoftTenant } from '../../../../middleware/requireNapsoftTenant.js';
+import { withMeta, rbac } from '../../../../middleware/rbac.js';
+
+const meta = withMeta({ module: 'tenants', router: 'nap-users' });
 
 export default createRouter(
   napUsersController,
   (router) => {
-    router.post('/register', addAuditFields, (req, res) => napUsersController.register(req, res));
+    router.post('/register', requireNapsoftTenant, meta, rbac('full'), addAuditFields, (req, res) => napUsersController.register(req, res));
   },
   {
     disablePost: true,
+    getMiddlewares: [requireNapsoftTenant, meta, rbac('view')],
+    putMiddlewares: [requireNapsoftTenant, meta, rbac('full')],
+    deleteMiddlewares: [requireNapsoftTenant, meta, rbac('full')],
+    patchMiddlewares: [requireNapsoftTenant, meta, rbac('full')],
   },
 );

--- a/apps/nap-serv/src/modules/tenants/apiRoutes/v1/tenantsRouter.js
+++ b/apps/nap-serv/src/modules/tenants/apiRoutes/v1/tenantsRouter.js
@@ -8,17 +8,20 @@
 import tenantsController from '../../controllers/tenantsController.js';
 import createRouter from '../../../../lib/createRouter.js';
 import { requireNapsoftTenant } from '../../../../middleware/requireNapsoftTenant.js';
+import { withMeta, rbac } from '../../../../middleware/rbac.js';
+
+const meta = withMeta({ module: 'tenants', router: 'tenants' });
 
 export default createRouter(
   tenantsController,
   (router) => {
-    router.get('/:id/modules', requireNapsoftTenant, (req, res) => tenantsController.getAllowedModules(req, res));
+    router.get('/:id/modules', requireNapsoftTenant, meta, rbac('view'), (req, res) => tenantsController.getAllowedModules(req, res));
   },
   {
-    postMiddlewares: [requireNapsoftTenant],
-    getMiddlewares: [requireNapsoftTenant],
-    putMiddlewares: [requireNapsoftTenant],
-    deleteMiddlewares: [requireNapsoftTenant],
-    patchMiddlewares: [requireNapsoftTenant],
+    postMiddlewares: [requireNapsoftTenant, meta, rbac('full')],
+    getMiddlewares: [requireNapsoftTenant, meta, rbac('view')],
+    putMiddlewares: [requireNapsoftTenant, meta, rbac('full')],
+    deleteMiddlewares: [requireNapsoftTenant, meta, rbac('full')],
+    patchMiddlewares: [requireNapsoftTenant, meta, rbac('full')],
   },
 );

--- a/apps/nap-serv/src/modules/tenants/controllers/adminController.js
+++ b/apps/nap-serv/src/modules/tenants/controllers/adminController.js
@@ -1,43 +1,145 @@
 /**
- * @file Admin controller — schema listing and context switching per PRD §3.2.3
+ * @file Admin controller — schema listing and impersonation per PRD §3.2.3
  * @module tenants/controllers/adminController
  *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
 
 import db from '../../../db/db.js';
+import { getRedis } from '../../../utils/redis.js';
 
 /**
- * GET /schemas — list all tenant schemas (super_user only)
+ * GET /schemas — list all tenant schemas (NapSoft users)
+ * Returns full tenant objects for the UI tenant picker.
  */
 export async function getAllSchemas(req, res) {
-  const isSuperUser = req.user?.role === 'super_user';
-  if (!isSuperUser) return res.status(403).json({ error: 'Forbidden: super_user only' });
-
   try {
-    const tenants = await db('tenants', 'admin').findWhere([], 'AND', {
-      columnWhitelist: ['tenant_code', 'schema_name'],
-      includeDeactivated: true,
-    });
-    const list = tenants.map((t) => (t.schema_name || t.tenant_code || '').toLowerCase());
-    if (!list.includes('admin')) list.unshift('admin');
-    return res.json(list);
+    const tenants = await db('tenants', 'admin').findWhere(
+      [{ status: 'active' }],
+      'AND',
+      { columnWhitelist: ['id', 'tenant_code', 'schema_name', 'company', 'status'] },
+    );
+    return res.json(tenants);
   } catch {
     return res.status(500).json({ error: 'Database error' });
   }
 }
 
 /**
- * POST /switch-schema/:schema — switch tenant context
+ * POST /impersonate — start impersonating a target user
+ * Body: { target_user_id, reason? }
  */
-export function switchSchema(req, res) {
-  const isSuperUser = req.user?.role === 'super_user';
-  if (!isSuperUser) return res.status(403).json({ error: 'Forbidden: super_user only' });
+export async function startImpersonation(req, res) {
+  const impersonatorId = req.user?.id;
+  if (!impersonatorId) return res.status(401).json({ error: 'Unauthorized' });
 
-  const { schema } = req.params;
-  if (!schema) return res.status(400).json({ error: 'schema parameter required' });
+  const { target_user_id, reason } = req.body || {};
+  if (!target_user_id) return res.status(400).json({ error: 'target_user_id required' });
 
-  return res.json({ message: `Schema switched to ${schema}`, schema });
+  try {
+    // Look up target user
+    const targetUser = await db('napUsers', 'admin').findOneBy([{ id: target_user_id }]);
+    if (!targetUser) return res.status(404).json({ error: 'Target user not found' });
+
+    // Check no active session exists for this impersonator
+    const redis = await getRedis();
+    const existing = await redis.get(`imp:${impersonatorId}`);
+    if (existing) {
+      return res.status(409).json({ error: 'Active impersonation session already exists. Exit first.' });
+    }
+
+    // Insert audit log
+    const log = await db('impersonationLogs', 'admin').insert({
+      impersonator_id: impersonatorId,
+      target_user_id,
+      target_tenant_code: targetUser.tenant_code,
+      reason: reason || null,
+      created_by: impersonatorId,
+    });
+
+    // Store in Redis for authRedis middleware to detect
+    const impData = {
+      logId: log.id,
+      targetUserId: targetUser.id,
+      targetTenantCode: targetUser.tenant_code?.toLowerCase(),
+      targetSchemaName: targetUser.tenant_code?.toLowerCase(),
+      targetUser: {
+        id: targetUser.id,
+        email: targetUser.email,
+        user_name: targetUser.user_name,
+        role: targetUser.role,
+        status: targetUser.status,
+        tenant_code: targetUser.tenant_code,
+      },
+    };
+    await redis.set(`imp:${impersonatorId}`, JSON.stringify(impData));
+
+    return res.json({
+      message: 'Impersonation started',
+      target_user: impData.targetUser,
+      log_id: log.id,
+    });
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to start impersonation' });
+  }
 }
 
-export default { getAllSchemas, switchSchema };
+/**
+ * POST /exit-impersonation — end the current impersonation session
+ */
+export async function endImpersonation(req, res) {
+  const impersonatorId = req.user?.id;
+  if (!impersonatorId) return res.status(401).json({ error: 'Unauthorized' });
+
+  try {
+    const redis = await getRedis();
+    const impData = await redis.get(`imp:${impersonatorId}`);
+    if (!impData) {
+      return res.json({ message: 'No active impersonation session' });
+    }
+
+    const { logId } = JSON.parse(impData);
+
+    // Update audit log with ended_at
+    if (logId) {
+      await db.none(
+        'UPDATE admin.impersonation_logs SET ended_at = NOW() WHERE id = $/id/ AND ended_at IS NULL',
+        { id: logId },
+      );
+    }
+
+    // Remove Redis key
+    await redis.del(`imp:${impersonatorId}`);
+
+    return res.json({ message: 'Impersonation ended' });
+  } catch {
+    return res.status(500).json({ error: 'Failed to end impersonation' });
+  }
+}
+
+/**
+ * GET /impersonation-status — check if user has an active impersonation session
+ */
+export async function getImpersonationStatus(req, res) {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+  try {
+    const redis = await getRedis();
+    const impData = await redis.get(`imp:${userId}`);
+    if (!impData) {
+      return res.json({ active: false });
+    }
+
+    const parsed = JSON.parse(impData);
+    return res.json({
+      active: true,
+      target_user: parsed.targetUser,
+      log_id: parsed.logId,
+    });
+  } catch {
+    return res.json({ active: false });
+  }
+}
+
+export default { getAllSchemas, startImpersonation, endImpersonation, getImpersonationStatus };

--- a/apps/nap-serv/src/modules/tenants/models/ImpersonationLogs.js
+++ b/apps/nap-serv/src/modules/tenants/models/ImpersonationLogs.js
@@ -1,0 +1,15 @@
+/**
+ * @file ImpersonationLogs model — extends TableModel for admin.impersonation_logs
+ * @module tenants/models/ImpersonationLogs
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { TableModel } from 'pg-schemata';
+import impersonationLogsSchema from '../schemas/impersonationLogsSchema.js';
+
+export default class ImpersonationLogs extends TableModel {
+  constructor(db, pgp, logger = null) {
+    super(db, pgp, impersonationLogsSchema, logger);
+  }
+}

--- a/apps/nap-serv/src/modules/tenants/schema/migrations/202502110001_bootstrapAdmin.js
+++ b/apps/nap-serv/src/modules/tenants/schema/migrations/202502110001_bootstrapAdmin.js
@@ -14,7 +14,7 @@ export default defineMigration({
   async up({ schema, models, ensureExtensions }) {
     if (schema !== 'admin') return;
 
-    await ensureExtensions(['pgcrypto', 'uuid-ossp']);
+    await ensureExtensions(['pgcrypto', 'uuid-ossp', 'vector']);
 
     const adminModels = Object.values(models)
       .filter(isTableModel)

--- a/apps/nap-serv/src/modules/tenants/schemas/impersonationLogsSchema.js
+++ b/apps/nap-serv/src/modules/tenants/schemas/impersonationLogsSchema.js
@@ -1,0 +1,40 @@
+/**
+ * @file Schema definition for admin.impersonation_logs table
+ * @module tenants/schemas/impersonationLogsSchema
+ *
+ * Audit trail for NapSoft user impersonation sessions.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+/** @type {import('pg-schemata').TableSchema} */
+const impersonationLogsSchema = {
+  dbSchema: 'admin',
+  table: 'impersonation_logs',
+  version: '1.0.0',
+  hasAuditFields: { enabled: true, userFields: { type: 'uuid', nullable: true, default: null } },
+  softDelete: false,
+  columns: [
+    { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
+    { name: 'impersonator_id', type: 'uuid', notNull: true },
+    { name: 'target_user_id', type: 'uuid', notNull: true },
+    { name: 'target_tenant_code', type: 'varchar(6)', notNull: true },
+    { name: 'reason', type: 'text', default: null },
+    { name: 'started_at', type: 'timestamptz', notNull: true, default: 'now()' },
+    { name: 'ended_at', type: 'timestamptz', default: null },
+  ],
+  constraints: {
+    primaryKey: ['id'],
+    foreignKeys: [
+      { columns: ['impersonator_id'], references: { table: 'nap_users', columns: ['id'], schema: 'admin' } },
+      { columns: ['target_user_id'], references: { table: 'nap_users', columns: ['id'], schema: 'admin' } },
+    ],
+    indexes: [
+      { type: 'Index', columns: ['impersonator_id'] },
+      { type: 'Index', columns: ['target_user_id'] },
+      { type: 'Index', columns: ['impersonator_id'], where: 'ended_at IS NULL' },
+    ],
+  },
+};
+
+export default impersonationLogsSchema;

--- a/apps/nap-serv/src/modules/tenants/schemas/napUsersSchema.js
+++ b/apps/nap-serv/src/modules/tenants/schemas/napUsersSchema.js
@@ -25,6 +25,7 @@ const napUsersSchema = {
     { name: 'role', type: 'varchar(32)', notNull: true, default: 'member' },
     { name: 'status', type: 'varchar(20)', notNull: true, default: 'active' },
     { name: 'tenant_role', type: 'varchar(16)', default: null },
+    { name: 'employee_id', type: 'uuid', default: null },
   ],
   constraints: {
     primaryKey: ['id'],
@@ -39,6 +40,7 @@ const napUsersSchema = {
       { type: 'Index', columns: ['email'], unique: true, where: 'deactivated_at IS NULL' },
       { type: 'Index', columns: ['tenant_id'] },
       { type: 'Index', columns: ['tenant_code'] },
+      { type: 'Index', columns: ['employee_id'], where: 'employee_id IS NOT NULL' },
     ],
   },
 };

--- a/apps/nap-serv/src/modules/tenants/tenantsRepositories.js
+++ b/apps/nap-serv/src/modules/tenants/tenantsRepositories.js
@@ -10,6 +10,7 @@ import NapUsers from './models/NapUsers.js';
 import NapUserAddresses from './models/NapUserAddresses.js';
 import NapUserPhones from './models/NapUserPhones.js';
 import MatchReviewLogs from './models/MatchReviewLogs.js';
+import ImpersonationLogs from './models/ImpersonationLogs.js';
 
 const repositories = {
   tenants: Tenants,
@@ -17,6 +18,7 @@ const repositories = {
   napUserAddresses: NapUserAddresses,
   napUserPhones: NapUserPhones,
   matchReviewLogs: MatchReviewLogs,
+  impersonationLogs: ImpersonationLogs,
 };
 
 export default repositories;

--- a/apps/nap-serv/src/utils/RbacPolicies.js
+++ b/apps/nap-serv/src/utils/RbacPolicies.js
@@ -2,6 +2,12 @@
  * @file RBAC policy loader — resolves effective permissions for a user in a tenant schema
  * @module nap-serv/utils/RbacPolicies
  *
+ * Loads the full 4-layer permission canon:
+ *   Layer 1 — caps (module::router::action → level)
+ *   Layer 2 — scope (all_projects | assigned_companies | assigned_projects) + projectIds + companyIds
+ *   Layer 3 — stateFilters (module::router → visible status values)
+ *   Layer 4 — fieldGroups (module::router → allowed column names)
+ *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
 
@@ -10,49 +16,177 @@ import db from '../db/db.js';
 const LEVEL_ORDER = { none: 0, view: 1, full: 2 };
 const LEVEL_NAMES = ['none', 'view', 'full'];
 
+/** Scope hierarchy: higher value = broader access. Most permissive wins on merge. */
+const SCOPE_ORDER = { assigned_projects: 0, assigned_companies: 1, all_projects: 2 };
+
 /**
- * Load flattened policies for a user in a tenant.
- * Queries role_members and policies tables in the tenant schema.
- * Returns a map of "module::router::action" => level (highest wins across roles).
+ * Load the full RBAC canon for a user in a tenant.
  *
  * @param {object} options
  * @param {string} options.schemaName Tenant schema name
  * @param {string} options.userId User UUID
- * @returns {Promise<object>} Capabilities map
+ * @returns {Promise<object>} Permission canon: { caps, scope, projectIds, companyIds, stateFilters, fieldGroups }
  */
 export async function loadPoliciesForUserTenant({ schemaName, userId }) {
-  if (!schemaName || !userId) return {};
+  const empty = { caps: {}, scope: 'all_projects', projectIds: null, companyIds: null, stateFilters: {}, fieldGroups: {} };
+  if (!schemaName || !userId) return empty;
 
+  // ── Role membership ───────────────────────────────────────────────────
   const tenantRoles = await db('roleMembers', schemaName).findWhere(
     [{ user_id: userId }],
     'AND',
     { columnWhitelist: ['role_id'] },
   );
 
-  if (!tenantRoles?.length) return {};
+  if (!tenantRoles?.length) return empty;
 
   const roleIds = tenantRoles.map((r) => r.role_id);
 
+  // ── Layer 1: Policies (capabilities map) ──────────────────────────────
   const policies = await db('policies', schemaName).findWhere(
     [{ role_id: { $in: roleIds } }],
     'AND',
     { columnWhitelist: ['module', 'router', 'action', 'level'] },
   );
 
-  // Combine by taking the maximum level across roles
-  const map = {};
+  const caps = {};
   for (const p of policies) {
     const key = `${p.module ?? ''}::${p.router ?? ''}::${p.action ?? ''}`;
-    const current = map[key];
+    const current = caps[key];
     if (!current) {
-      map[key] = p.level;
+      caps[key] = p.level;
       continue;
     }
     const have = LEVEL_ORDER[current] ?? 0;
     const next = LEVEL_ORDER[p.level] ?? 0;
-    map[key] = LEVEL_NAMES[Math.max(have, next)];
+    caps[key] = LEVEL_NAMES[Math.max(have, next)];
   }
-  return map;
+
+  // ── Layer 2: Data scope ───────────────────────────────────────────────
+  // Three-tier hierarchy: all_projects > assigned_companies > assigned_projects
+  // Most permissive scope wins when user has multiple roles
+  const roles = await db('roles', schemaName).findWhere(
+    [{ id: { $in: roleIds } }],
+    'AND',
+    { columnWhitelist: ['id', 'scope'] },
+  );
+
+  let winningScope = 'assigned_projects';
+  for (const r of roles) {
+    if ((SCOPE_ORDER[r.scope] ?? 0) > (SCOPE_ORDER[winningScope] ?? 0)) {
+      winningScope = r.scope;
+    }
+  }
+
+  let projectIds = null;
+  let companyIds = null;
+
+  if (winningScope === 'assigned_companies') {
+    // Load user's company memberships
+    const companyMemberships = await db('companyMembers', schemaName).findWhere(
+      [{ user_id: userId }],
+      'AND',
+      { columnWhitelist: ['company_id'] },
+    );
+    companyIds = companyMemberships.map((m) => m.company_id);
+
+    // Resolve project IDs belonging to those companies so downstream
+    // resources with project_id (not company_id) can still be filtered
+    if (companyIds.length) {
+      const companyProjects = await db('projects', schemaName).findWhere(
+        [{ company_id: { $in: companyIds } }],
+        'AND',
+        { columnWhitelist: ['id'] },
+      );
+      projectIds = companyProjects.map((p) => p.id);
+    } else {
+      projectIds = [];
+    }
+  } else if (winningScope === 'assigned_projects') {
+    const memberships = await db('projectMembers', schemaName).findWhere(
+      [{ user_id: userId }],
+      'AND',
+      { columnWhitelist: ['project_id'] },
+    );
+    projectIds = memberships.map((m) => m.project_id);
+  }
+  // winningScope === 'all_projects' → both stay null
+
+  // ── Layer 3: State filters ────────────────────────────────────────────
+  // Union of visible_statuses across roles for each module::router
+  const stateRows = await db('stateFilters', schemaName).findWhere(
+    [{ role_id: { $in: roleIds } }],
+    'AND',
+    { columnWhitelist: ['module', 'router', 'visible_statuses'] },
+  );
+
+  const stateFilters = {};
+  for (const sf of stateRows) {
+    const key = `${sf.module ?? ''}::${sf.router ?? ''}`;
+    const existing = stateFilters[key];
+    if (!existing) {
+      stateFilters[key] = [...sf.visible_statuses];
+    } else {
+      // Union: add any statuses not already present
+      for (const status of sf.visible_statuses) {
+        if (!existing.includes(status)) existing.push(status);
+      }
+    }
+  }
+
+  // ── Layer 4: Field groups ─────────────────────────────────────────────
+  // Union of columns across all granted groups + default groups per resource
+  const grants = await db('fieldGroupGrants', schemaName).findWhere(
+    [{ role_id: { $in: roleIds } }],
+    'AND',
+    { columnWhitelist: ['field_group_id'] },
+  );
+
+  const fieldGroups = {};
+  const grantedIds = grants.map((g) => g.field_group_id);
+
+  if (grantedIds.length) {
+    // Fetch granted definitions
+    const grantedDefs = await db('fieldGroupDefinitions', schemaName).findWhere(
+      [{ id: { $in: grantedIds } }],
+      'AND',
+      { columnWhitelist: ['module', 'router', 'columns'] },
+    );
+    for (const def of grantedDefs) {
+      const key = `${def.module ?? ''}::${def.router ?? ''}`;
+      const existing = fieldGroups[key];
+      if (!existing) {
+        fieldGroups[key] = [...def.columns];
+      } else {
+        for (const col of def.columns) {
+          if (!existing.includes(col)) existing.push(col);
+        }
+      }
+    }
+  }
+
+  // Also include is_default groups for any resource that has explicit grants
+  // (so default columns are always visible when field groups are active)
+  if (Object.keys(fieldGroups).length) {
+    const defaultDefs = await db('fieldGroupDefinitions', schemaName).findWhere(
+      [{ is_default: true }],
+      'AND',
+      { columnWhitelist: ['module', 'router', 'columns'] },
+    );
+    for (const def of defaultDefs) {
+      const key = `${def.module ?? ''}::${def.router ?? ''}`;
+      const existing = fieldGroups[key];
+      if (!existing) {
+        // Only add defaults for resources that have explicit grants active
+        continue;
+      }
+      for (const col of def.columns) {
+        if (!existing.includes(col)) existing.push(col);
+      }
+    }
+  }
+
+  return { caps, scope: winningScope, projectIds, companyIds, stateFilters, fieldGroups };
 }
 
 export default { loadPoliciesForUserTenant };

--- a/apps/nap-serv/src/utils/RbacQueryContext.js
+++ b/apps/nap-serv/src/utils/RbacQueryContext.js
@@ -1,0 +1,35 @@
+/**
+ * @file RBAC query context builder — translates permission canon into query modifiers
+ * @module nap-serv/utils/RbacQueryContext
+ *
+ * Layers 2-4 narrow query results after Layer 1 grants access at the route level.
+ * Returns null values for any layer that should not apply (permissive default).
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+/**
+ * Build query modifiers from the RBAC permission canon for a specific resource.
+ *
+ * @param {object} perms Full permission canon from req.ctx.perms
+ * @param {string} module Module name (e.g., 'ar')
+ * @param {string} router Router name (e.g., 'ar-invoices')
+ * @returns {object} Query context: { scope, projectIds, companyIds, visibleStatuses, allowedColumns }
+ */
+export function buildQueryContext(perms, module, router) {
+  const key = `${module}::${router}`;
+  return {
+    // Layer 2: data scoping
+    scope: perms?.scope || 'all_projects',
+    projectIds: perms?.projectIds || null,
+    companyIds: perms?.companyIds || null,
+
+    // Layer 3: status filtering (null = all statuses visible)
+    visibleStatuses: perms?.stateFilters?.[key] || null,
+
+    // Layer 4: column restriction (null = all columns visible)
+    allowedColumns: perms?.fieldGroups?.[key] || null,
+  };
+}
+
+export default { buildQueryContext };

--- a/apps/nap-serv/src/utils/rbacCacheInvalidation.js
+++ b/apps/nap-serv/src/utils/rbacCacheInvalidation.js
@@ -1,0 +1,53 @@
+/**
+ * @file RBAC cache invalidation helpers
+ * @module nap-serv/utils/rbacCacheInvalidation
+ *
+ * Clears cached permission canons from Redis when RBAC data changes.
+ * Must be called when project_members, state_filters, field_group_grants,
+ * or role scope values are mutated.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { getRedis } from './redis.js';
+import db from '../db/db.js';
+import logger from './logger.js';
+
+/**
+ * Invalidate cached permissions for a single user in a tenant.
+ * @param {string} userId User UUID
+ * @param {string} tenantCode Tenant code or schema name
+ */
+export async function invalidateUserPermissions(userId, tenantCode) {
+  if (!userId || !tenantCode) return;
+  try {
+    const redis = await getRedis();
+    await redis.del(`perm:${userId}:${tenantCode}`);
+  } catch (err) {
+    logger.warn('Failed to invalidate user permissions cache', { userId, tenantCode, error: err?.message });
+  }
+}
+
+/**
+ * Invalidate cached permissions for all users holding a given role.
+ * Use when role-level RBAC data changes (state_filters, field_group_grants, scope).
+ * @param {string} roleId Role UUID
+ * @param {string} schemaName Tenant schema name
+ */
+export async function invalidateRolePermissions(roleId, schemaName) {
+  if (!roleId || !schemaName) return;
+  try {
+    const members = await db('roleMembers', schemaName).findWhere(
+      [{ role_id: roleId }],
+      'AND',
+      { columnWhitelist: ['user_id'] },
+    );
+    for (const m of members) {
+      await invalidateUserPermissions(m.user_id, schemaName);
+    }
+  } catch (err) {
+    logger.warn('Failed to invalidate role permissions cache', { roleId, schemaName, error: err?.message });
+  }
+}
+
+export default { invalidateUserPermissions, invalidateRolePermissions };

--- a/apps/nap-serv/tests/contract/accountingRoutes.test.js
+++ b/apps/nap-serv/tests/contract/accountingRoutes.test.js
@@ -85,7 +85,7 @@ vi.mock('../../src/db/db.js', () => {
 
   // Register all model names the proxy needs to resolve
   const modelNames = [
-    'tenants', 'napUsers', 'roleMembers', 'policies', 'napUserPhones', 'napUserAddresses',
+    'tenants', 'napUsers', 'roles', 'roleMembers', 'policies', 'policyCatalog', 'napUserPhones', 'napUserAddresses',
     // Projects module
     'projects', 'units', 'tasks', 'taskGroups', 'tasksMaster',
     'costItems', 'changeOrders',
@@ -108,6 +108,7 @@ vi.mock('../../src/db/db.js', () => {
     dbProxy[name] = model;
   }
   dbProxy.none = vi.fn();
+  dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
   dbProxy.tx = vi.fn(async (fn) => {
     const t = {
       one: vi.fn(async () => ({ id: 'tx-entry' })),

--- a/apps/nap-serv/tests/contract/activityRoutes.test.js
+++ b/apps/nap-serv/tests/contract/activityRoutes.test.js
@@ -85,7 +85,7 @@ vi.mock('../../src/db/db.js', () => {
 
   // Register all model names the proxy needs to resolve
   const modelNames = [
-    'tenants', 'napUsers', 'roleMembers', 'policies', 'napUserPhones', 'napUserAddresses',
+    'tenants', 'napUsers', 'roles', 'roleMembers', 'policies', 'policyCatalog', 'napUserPhones', 'napUserAddresses',
     // Projects module
     'projects', 'units', 'tasks', 'taskGroups', 'tasksMaster',
     'costItems', 'changeOrders',
@@ -98,6 +98,7 @@ vi.mock('../../src/db/db.js', () => {
     dbProxy[name] = model;
   }
   dbProxy.none = vi.fn();
+  dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
   return { default: dbProxy, db: dbProxy };
 });
 

--- a/apps/nap-serv/tests/contract/apRoutes.test.js
+++ b/apps/nap-serv/tests/contract/apRoutes.test.js
@@ -85,7 +85,7 @@ vi.mock('../../src/db/db.js', () => {
 
   // Register all model names the proxy needs to resolve
   const modelNames = [
-    'tenants', 'napUsers', 'roleMembers', 'policies', 'napUserPhones', 'napUserAddresses',
+    'tenants', 'napUsers', 'roles', 'roleMembers', 'policies', 'policyCatalog', 'napUserPhones', 'napUserAddresses',
     // Projects module
     'projects', 'units', 'tasks', 'taskGroups', 'tasksMaster',
     'costItems', 'changeOrders',
@@ -102,6 +102,7 @@ vi.mock('../../src/db/db.js', () => {
     dbProxy[name] = model;
   }
   dbProxy.none = vi.fn();
+  dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
   return { default: dbProxy, db: dbProxy };
 });
 

--- a/apps/nap-serv/tests/contract/arRoutes.test.js
+++ b/apps/nap-serv/tests/contract/arRoutes.test.js
@@ -85,7 +85,7 @@ vi.mock('../../src/db/db.js', () => {
 
   // Register all model names the proxy needs to resolve
   const modelNames = [
-    'tenants', 'napUsers', 'roleMembers', 'policies', 'napUserPhones', 'napUserAddresses',
+    'tenants', 'napUsers', 'roles', 'roleMembers', 'policies', 'policyCatalog', 'napUserPhones', 'napUserAddresses',
     // Projects module
     'projects', 'units', 'tasks', 'taskGroups', 'tasksMaster',
     'costItems', 'changeOrders',
@@ -104,6 +104,7 @@ vi.mock('../../src/db/db.js', () => {
     dbProxy[name] = model;
   }
   dbProxy.none = vi.fn();
+  dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
   return { default: dbProxy, db: dbProxy };
 });
 

--- a/apps/nap-serv/tests/contract/bomRoutes.test.js
+++ b/apps/nap-serv/tests/contract/bomRoutes.test.js
@@ -88,7 +88,7 @@ vi.mock('../../src/db/db.js', () => {
 
   // Register all model names the proxy needs to resolve
   const modelNames = [
-    'tenants', 'napUsers', 'roleMembers', 'policies', 'napUserPhones', 'napUserAddresses',
+    'tenants', 'napUsers', 'roles', 'roleMembers', 'policies', 'policyCatalog', 'napUserPhones', 'napUserAddresses',
     // Projects module
     'projects', 'units', 'tasks', 'taskGroups', 'tasksMaster',
     'costItems', 'changeOrders',
@@ -105,6 +105,7 @@ vi.mock('../../src/db/db.js', () => {
     dbProxy[name] = model;
   }
   dbProxy.none = vi.fn();
+  dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
   dbProxy.manyOrNone = vi.fn(async () => []);
   return { default: dbProxy, db: dbProxy };
 });

--- a/apps/nap-serv/tests/contract/coreRoutes.test.js
+++ b/apps/nap-serv/tests/contract/coreRoutes.test.js
@@ -1,0 +1,351 @@
+/**
+ * @file Contract tests — Core module API shape verification
+ * @module tests/contract/coreRoutes
+ *
+ * Verifies that expected routes exist and respond with correct status codes/shapes.
+ * Sources router is read-only; all other core entity routers support full CRUD.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import bcrypt from 'bcrypt';
+
+// Set env
+process.env.ACCESS_TOKEN_SECRET = 'test-access-secret-core';
+process.env.REFRESH_TOKEN_SECRET = 'test-refresh-secret-core';
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL_TEST = 'postgres://nap_admin:test@localhost:5432/nap_test';
+process.env.NAPSOFT_TENANT = 'NAP';
+process.env.COOKIE_SECURE = 'false';
+process.env.BCRYPT_ROUNDS = '4';
+
+const testPasswordHash = await bcrypt.hash('TestPassword123!', 4);
+const mockUser = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  email: 'admin@napsoft.com',
+  user_name: 'admin',
+  password_hash: testPasswordHash,
+  tenant_code: 'NAP',
+  tenant_id: '660e8400-e29b-41d4-a716-446655440001',
+  role: 'super_user',
+  status: 'active',
+  deactivated_at: null,
+};
+
+const mockTenant = {
+  id: '660e8400-e29b-41d4-a716-446655440001',
+  tenant_code: 'NAP',
+  company: 'NapSoft',
+  schema_name: 'nap',
+  status: 'active',
+  deactivated_at: null,
+  allowed_modules: [],
+};
+
+// Mock Redis
+vi.mock('../../src/utils/redis.js', () => ({
+  getRedis: vi.fn().mockResolvedValue({
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue('OK'),
+    del: vi.fn().mockResolvedValue(1),
+  }),
+  closeRedis: vi.fn(),
+}));
+
+// Mock provisioning
+vi.mock('../../src/services/tenantProvisioning.js', () => ({
+  provisionTenant: vi.fn().mockResolvedValue({ applied: [] }),
+}));
+
+// Mock DB
+vi.mock('../../src/db/db.js', () => {
+  const handler = {
+    findOneBy: vi.fn(async (conds) => {
+      const c = conds[0];
+      if (c.email === mockUser.email || c.id === mockUser.id) return mockUser;
+      if (c.tenant_code === 'NAP') return mockTenant;
+      return null;
+    }),
+    findById: vi.fn(async (id) => {
+      if (id === mockTenant.id) return mockTenant;
+      if (id === mockUser.id) return mockUser;
+      return null;
+    }),
+    findAfterCursor: vi.fn(async () => ({ data: [], hasMore: false })),
+    findWhere: vi.fn(async () => []),
+    countWhere: vi.fn(async () => 0),
+    insert: vi.fn(async (data) => ({ id: `new-${Date.now()}`, ...data })),
+    updateWhere: vi.fn(async () => 1),
+    bulkInsert: vi.fn(async (data) => data),
+  };
+
+  const model = { setSchemaName: vi.fn().mockReturnValue(handler) };
+
+  const dbProxy = (name, schema) => model.setSchemaName(schema);
+
+  // Register all model names the proxy needs to resolve
+  const modelNames = [
+    'tenants', 'napUsers', 'roles', 'roleMembers', 'policies', 'policyCatalog', 'napUserPhones', 'napUserAddresses',
+    // Core entities
+    'sources', 'vendors', 'clients', 'employees', 'contacts', 'addresses', 'interCompanies',
+    // Projects module
+    'projects', 'units', 'tasks', 'taskGroups', 'tasksMaster',
+    'costItems', 'changeOrders',
+    'templateUnits', 'templateTasks', 'templateCostItems', 'templateChangeOrders',
+    // Activities module
+    'categories', 'activities', 'deliverables', 'deliverableAssignments',
+    'budgets', 'costLines', 'actualCosts', 'vendorParts',
+    // BOM module
+    'catalogSkus', 'vendorSkus', 'vendorPricing',
+    // AP module
+    'apInvoices', 'apInvoiceLines', 'payments', 'apCreditMemos',
+    // AR module
+    'arInvoices', 'arInvoiceLines', 'receipts', 'arCreditMemos',
+    // Accounting module
+    'chartOfAccounts', 'fiscalPeriods', 'journalEntries', 'journalEntryLines',
+    'categoryAccountMap', 'interCompanyTransactions', 'costCenters',
+    'budgetEntries', 'recurringJournals',
+  ];
+  for (const name of modelNames) {
+    dbProxy[name] = model;
+  }
+  dbProxy.none = vi.fn();
+  dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
+  dbProxy.tx = vi.fn(async (cb) => {
+    const t = { none: vi.fn() };
+    return cb(t);
+  });
+  return { default: dbProxy, db: dbProxy };
+});
+
+vi.mock('../../src/utils/RbacPolicies.js', () => ({
+  loadPoliciesForUserTenant: vi.fn().mockResolvedValue({}),
+}));
+
+let request;
+
+beforeAll(async () => {
+  const supertest = await import('supertest');
+  const { default: app } = await import('../../src/app.js');
+  request = supertest.default(app);
+});
+
+async function getAuthCookies() {
+  const res = await request.post('/api/auth/login').send({ email: 'admin@napsoft.com', password: 'TestPassword123!' });
+  return res.headers['set-cookie'];
+}
+
+const CORE_ENDPOINTS = [
+  '/api/core/v1/sources',
+  '/api/core/v1/vendors',
+  '/api/core/v1/clients',
+  '/api/core/v1/employees',
+  '/api/core/v1/contacts',
+  '/api/core/v1/addresses',
+  '/api/core/v1/inter-companies',
+  '/api/core/v1/roles',
+  '/api/core/v1/role-members',
+  '/api/core/v1/policies',
+  '/api/core/v1/policy-catalog',
+];
+
+const CRUD_ENDPOINTS = CORE_ENDPOINTS.filter((e) => e !== '/api/core/v1/sources');
+
+describe('Core Routes Contract', () => {
+  describe('Ping routes', () => {
+    for (const endpoint of CORE_ENDPOINTS) {
+      it(`GET ${endpoint}/ping should return pong`, async () => {
+        const cookies = await getAuthCookies();
+        const res = await request.get(`${endpoint}/ping`).set('Cookie', cookies).set('x-tenant-code', 'NAP');
+        expect(res.status).toBe(200);
+        expect(res.body.message).toBe('pong');
+      });
+    }
+  });
+
+  describe('GET list routes', () => {
+    for (const endpoint of CORE_ENDPOINTS) {
+      it(`GET ${endpoint} returns list`, async () => {
+        const cookies = await getAuthCookies();
+        const res = await request.get(endpoint).set('Cookie', cookies).set('x-tenant-code', 'NAP');
+        expect(res.status).toBe(200);
+        expect(res.body).toBeDefined();
+      });
+    }
+  });
+
+  describe('Sources read-only enforcement', () => {
+    it('POST /api/core/v1/sources returns 404', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/sources')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ tenant_id: 'tid', table_id: 'v1', source_type: 'vendor' });
+      expect(res.status).toBe(404);
+    });
+
+    it('PUT /api/core/v1/sources/update returns 404', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .put('/api/core/v1/sources/update')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ label: 'updated' });
+      expect(res.status).toBe(404);
+    });
+
+    it('DELETE /api/core/v1/sources/archive returns 404', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .delete('/api/core/v1/sources/archive')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP');
+      expect(res.status).toBe(404);
+    });
+
+    it('PATCH /api/core/v1/sources/restore returns 404', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .patch('/api/core/v1/sources/restore')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST create routes (CRUD entities)', () => {
+    it('POST /api/core/v1/vendors creates a vendor', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/vendors')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ tenant_id: 'tid', name: 'Acme Lumber', code: 'ACM-001' });
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBeDefined();
+    });
+
+    it('POST /api/core/v1/clients creates a client', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/clients')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ tenant_id: 'tid', name: 'Big Builder Corp', code: 'BBC-001' });
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBeDefined();
+    });
+
+    it('POST /api/core/v1/employees creates an employee', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/employees')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ tenant_id: 'tid', first_name: 'John', last_name: 'Doe' });
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBeDefined();
+    });
+
+    it('POST /api/core/v1/contacts creates a contact', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/contacts')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ tenant_id: 'tid', source_id: 'src-1', first_name: 'Jane', last_name: 'Smith' });
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBeDefined();
+    });
+
+    it('POST /api/core/v1/addresses creates an address', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/addresses')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ tenant_id: 'tid', source_id: 'src-1', address_line1: '123 Main St', city: 'Springfield', state: 'IL', zip: '62701' });
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBeDefined();
+    });
+
+    it('POST /api/core/v1/inter-companies creates an inter-company', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/inter-companies')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ tenant_id: 'tid', name: 'NapSoft West', code: 'NSW-001' });
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBeDefined();
+    });
+  });
+
+  describe('RBAC management routes', () => {
+    it('POST /api/core/v1/roles creates a role', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/roles')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ code: 'pm', name: 'Project Manager', scope: 'assigned_projects' });
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBeDefined();
+    });
+
+    it('POST /api/core/v1/roles rejects system role creation', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/roles')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ code: 'sys', name: 'System', is_system: true });
+      expect(res.status).toBe(400);
+    });
+
+    it('Policy catalog is read-only — POST returns 404', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .post('/api/core/v1/policy-catalog')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ module: 'test', label: 'Test' });
+      expect(res.status).toBe(404);
+    });
+
+    it('PUT /api/core/v1/policies/sync-for-role syncs policies', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .put('/api/core/v1/policies/sync-for-role')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ role_id: 'r1', policies: [{ module: 'ar', router: null, action: null, level: 'view' }] });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Policies synced for role');
+    });
+
+    it('PUT /api/core/v1/role-members/sync syncs members', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .put('/api/core/v1/role-members/sync')
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP')
+        .send({ role_id: 'r1', user_ids: ['u1', 'u2'] });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Role members synced');
+    });
+
+    it('DELETE /api/core/v1/role-members/remove deletes a member', async () => {
+      const cookies = await getAuthCookies();
+      const res = await request
+        .delete('/api/core/v1/role-members/remove')
+        .query({ role_id: 'r1', user_id: 'u1' })
+        .set('Cookie', cookies)
+        .set('x-tenant-code', 'NAP');
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Role member removed');
+    });
+  });
+});

--- a/apps/nap-serv/tests/contract/projectRoutes.test.js
+++ b/apps/nap-serv/tests/contract/projectRoutes.test.js
@@ -85,7 +85,7 @@ vi.mock('../../src/db/db.js', () => {
 
   // Register all model names the proxy needs to resolve
   const modelNames = [
-    'tenants', 'napUsers', 'roleMembers', 'policies', 'napUserPhones', 'napUserAddresses',
+    'tenants', 'napUsers', 'roles', 'roleMembers', 'policies', 'policyCatalog', 'napUserPhones', 'napUserAddresses',
     'projects', 'units', 'tasks', 'taskGroups', 'tasksMaster',
     'costItems', 'changeOrders',
     'templateUnits', 'templateTasks', 'templateCostItems', 'templateChangeOrders',
@@ -94,6 +94,7 @@ vi.mock('../../src/db/db.js', () => {
     dbProxy[name] = model;
   }
   dbProxy.none = vi.fn();
+  dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
   return { default: dbProxy, db: dbProxy };
 });
 

--- a/apps/nap-serv/tests/contract/reportRoutes.test.js
+++ b/apps/nap-serv/tests/contract/reportRoutes.test.js
@@ -85,7 +85,7 @@ vi.mock('../../src/db/db.js', () => {
 
   // Register all model names the proxy needs to resolve
   const modelNames = [
-    'tenants', 'napUsers', 'roleMembers', 'policies', 'napUserPhones', 'napUserAddresses',
+    'tenants', 'napUsers', 'roles', 'roleMembers', 'policies', 'policyCatalog', 'napUserPhones', 'napUserAddresses',
     'projects', 'units', 'tasks', 'taskGroups', 'tasksMaster',
     'costItems', 'changeOrders',
     'templateUnits', 'templateTasks', 'templateCostItems', 'templateChangeOrders',
@@ -102,6 +102,7 @@ vi.mock('../../src/db/db.js', () => {
     dbProxy[name] = model;
   }
   dbProxy.none = vi.fn();
+  dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
   dbProxy.manyOrNone = vi.fn(async () => []);
   dbProxy.oneOrNone = vi.fn(async () => null);
   dbProxy.tx = vi.fn(async (fn) => {

--- a/apps/nap-serv/tests/contract/tenantRoutes.test.js
+++ b/apps/nap-serv/tests/contract/tenantRoutes.test.js
@@ -88,6 +88,9 @@ vi.mock('../../src/db/db.js', () => {
   dbProxy.policies = model;
   dbProxy.napUserPhones = model;
   dbProxy.napUserAddresses = model;
+  dbProxy.impersonationLogs = model;
+  dbProxy.none = vi.fn(async () => undefined);
+  dbProxy.oneOrNone = vi.fn(async () => null);
   return { default: dbProxy, db: dbProxy };
 });
 
@@ -154,28 +157,23 @@ describe('Tenant Routes Contract', () => {
       expect(Array.isArray(res.body)).toBe(true);
     });
 
-    it('POST /api/core/v1/admin/assume-tenant requires tenant_code', async () => {
+    it('POST /api/tenants/v1/admin/impersonate requires target_user_id', async () => {
       const cookies = await getAuthCookies();
-      const res = await request.post('/api/core/v1/admin/assume-tenant').set('Cookie', cookies).set('x-tenant-code', 'NAP').send({});
+      const res = await request.post('/api/tenants/v1/admin/impersonate').set('Cookie', cookies).set('x-tenant-code', 'NAP').send({});
       expect(res.status).toBe(400);
     });
 
-    it('POST /api/core/v1/admin/assume-tenant succeeds with tenant_code', async () => {
+    it('GET /api/tenants/v1/admin/impersonation-status returns status', async () => {
       const cookies = await getAuthCookies();
-      const res = await request
-        .post('/api/core/v1/admin/assume-tenant')
-        .set('Cookie', cookies)
-        .set('x-tenant-code', 'NAP')
-        .send({ tenant_code: 'ACME', reason: 'testing' });
+      const res = await request.get('/api/tenants/v1/admin/impersonation-status').set('Cookie', cookies).set('x-tenant-code', 'NAP');
       expect(res.status).toBe(200);
-      expect(res.body.message).toBe('Assumed tenant');
+      expect(res.body).toHaveProperty('active');
     });
 
-    it('POST /api/core/v1/admin/exit-assumption succeeds', async () => {
+    it('POST /api/tenants/v1/admin/exit-impersonation returns success', async () => {
       const cookies = await getAuthCookies();
-      const res = await request.post('/api/core/v1/admin/exit-assumption').set('Cookie', cookies).set('x-tenant-code', 'NAP');
+      const res = await request.post('/api/tenants/v1/admin/exit-impersonation').set('Cookie', cookies).set('x-tenant-code', 'NAP');
       expect(res.status).toBe(200);
-      expect(res.body.message).toBe('Exited assumption');
     });
   });
 });

--- a/apps/nap-serv/tests/contract/viewRoutes.test.js
+++ b/apps/nap-serv/tests/contract/viewRoutes.test.js
@@ -84,7 +84,7 @@ vi.mock('../../src/db/db.js', () => {
   const dbProxy = (name, schema) => model.setSchemaName(schema);
 
   const modelNames = [
-    'tenants', 'napUsers', 'roleMembers', 'policies', 'napUserPhones', 'napUserAddresses',
+    'tenants', 'napUsers', 'roles', 'roleMembers', 'policies', 'policyCatalog', 'napUserPhones', 'napUserAddresses',
     'projects', 'units', 'tasks', 'taskGroups', 'tasksMaster',
     'costItems', 'changeOrders',
     'templateUnits', 'templateTasks', 'templateCostItems', 'templateChangeOrders',
@@ -101,6 +101,7 @@ vi.mock('../../src/db/db.js', () => {
     dbProxy[name] = model;
   }
   dbProxy.none = vi.fn();
+  dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
   dbProxy.manyOrNone = vi.fn(async () => []);
   dbProxy.oneOrNone = vi.fn(async () => null);
   dbProxy.tx = vi.fn(async (fn) => {

--- a/apps/nap-serv/tests/integration/coreLifecycle.test.js
+++ b/apps/nap-serv/tests/integration/coreLifecycle.test.js
@@ -1,0 +1,209 @@
+/**
+ * @file Integration tests — Core entity lifecycle (source auto-creation)
+ * @module tests/integration/coreLifecycle
+ *
+ * Verifies that creating a vendor, client, or employee auto-creates a
+ * polymorphic sources record and links it back to the entity.
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Track inserts and updates across models
+let insertCallLog = [];
+let findByIdStore = {};
+
+const mockModel = {
+  findOneBy: vi.fn(async () => null),
+  findById: vi.fn(async (id) => findByIdStore[id] ?? null),
+  findAfterCursor: vi.fn(async () => ({ data: [], hasMore: false })),
+  findWhere: vi.fn(async () => []),
+  countWhere: vi.fn(async () => 0),
+  insert: vi.fn(async (data) => {
+    const record = { id: `id-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`, ...data };
+    insertCallLog.push(record);
+    findByIdStore[record.id] = record;
+    return record;
+  }),
+  updateWhere: vi.fn(async () => 1),
+  bulkInsert: vi.fn(async (data) => data),
+  setSchemaName: vi.fn(),
+};
+
+// Mock DB — tracks which model name is requested and provides tx support
+vi.mock('../../src/db/db.js', () => {
+  const dbProxy = (name, schema) => {
+    mockModel._lastModelName = name;
+    mockModel.setSchemaName(schema);
+    return mockModel;
+  };
+
+  const modelNames = [
+    'tenants', 'napUsers', 'roleMembers', 'policies',
+    'sources', 'vendors', 'clients', 'employees', 'contacts', 'addresses', 'interCompanies',
+  ];
+  for (const name of modelNames) {
+    dbProxy[name] = { setSchemaName: vi.fn().mockReturnValue(mockModel) };
+  }
+  dbProxy.none = vi.fn();
+  dbProxy.tx = vi.fn(async (cb) => {
+    const t = { none: vi.fn() };
+    const result = await cb(t);
+    // Capture the t.none calls for UPDATE assertions
+    dbProxy._lastTx = t;
+    return result;
+  });
+  return { default: dbProxy, db: dbProxy };
+});
+
+function mockReqRes({ body = {}, query = {}, params = {} } = {}) {
+  const req = {
+    user: { id: 'u1', tenant_code: 'TEST', schema_name: 'test' },
+    body,
+    query,
+    params,
+    ctx: { schema: 'test' },
+  };
+  const res = {
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(data) { this.body = data; return this; },
+  };
+  return { req, res };
+}
+
+describe('Core Entity Lifecycle', () => {
+  beforeEach(() => {
+    insertCallLog = [];
+    findByIdStore = {};
+    vi.clearAllMocks();
+  });
+
+  describe('Vendor → source auto-creation', () => {
+    it('creating a vendor auto-creates a source with source_type=vendor', async () => {
+      const { VendorsController } = await import('../../src/modules/core/controllers/vendorsController.js');
+      const ctrl = new VendorsController();
+
+      const { req, res } = mockReqRes({
+        body: { tenant_id: 'tid', name: 'Acme Lumber', code: 'ACM-001' },
+      });
+
+      await ctrl.create(req, res);
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.id).toBeDefined();
+      expect(res.body.source_id).toBeDefined();
+
+      // Two inserts: vendor + source
+      expect(insertCallLog).toHaveLength(2);
+
+      const vendorInsert = insertCallLog[0];
+      const sourceInsert = insertCallLog[1];
+
+      expect(vendorInsert.name).toBe('Acme Lumber');
+      expect(sourceInsert.source_type).toBe('vendor');
+      expect(sourceInsert.table_id).toBe(vendorInsert.id);
+      expect(sourceInsert.label).toBe('Acme Lumber');
+    });
+
+    it('links source back to vendor via UPDATE', async () => {
+      const db = (await import('../../src/db/db.js')).default;
+      const { VendorsController } = await import('../../src/modules/core/controllers/vendorsController.js');
+      const ctrl = new VendorsController();
+
+      const { req, res } = mockReqRes({
+        body: { tenant_id: 'tid', name: 'Acme Lumber', code: 'ACM-001', created_by: null },
+      });
+
+      await ctrl.create(req, res);
+
+      // db.tx was called and the transaction's none() was used for the UPDATE
+      expect(db.tx).toHaveBeenCalled();
+      expect(db._lastTx.none).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE'),
+        expect.arrayContaining([res.body.source_id]),
+      );
+    });
+  });
+
+  describe('Client → source auto-creation', () => {
+    it('creating a client auto-creates a source with source_type=client', async () => {
+      const { ClientsController } = await import('../../src/modules/core/controllers/clientsController.js');
+      const ctrl = new ClientsController();
+
+      const { req, res } = mockReqRes({
+        body: { tenant_id: 'tid', name: 'Big Builder Corp', code: 'BBC-001' },
+      });
+
+      await ctrl.create(req, res);
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.source_id).toBeDefined();
+
+      expect(insertCallLog).toHaveLength(2);
+
+      const clientInsert = insertCallLog[0];
+      const sourceInsert = insertCallLog[1];
+
+      expect(clientInsert.name).toBe('Big Builder Corp');
+      expect(sourceInsert.source_type).toBe('client');
+      expect(sourceInsert.table_id).toBe(clientInsert.id);
+      expect(sourceInsert.label).toBe('Big Builder Corp');
+    });
+  });
+
+  describe('Employee → source auto-creation', () => {
+    it('creating an employee auto-creates a source with source_type=employee', async () => {
+      const { EmployeesController } = await import('../../src/modules/core/controllers/employeesController.js');
+      const ctrl = new EmployeesController();
+
+      const { req, res } = mockReqRes({
+        body: { tenant_id: 'tid', first_name: 'John', last_name: 'Doe' },
+      });
+
+      await ctrl.create(req, res);
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.source_id).toBeDefined();
+
+      expect(insertCallLog).toHaveLength(2);
+
+      const employeeInsert = insertCallLog[0];
+      const sourceInsert = insertCallLog[1];
+
+      expect(employeeInsert.first_name).toBe('John');
+      expect(sourceInsert.source_type).toBe('employee');
+      expect(sourceInsert.table_id).toBe(employeeInsert.id);
+      expect(sourceInsert.label).toBe('John Doe');
+    });
+  });
+
+  describe('Source record type correctness', () => {
+    it('each entity type produces the correct source_type value', async () => {
+      const { VendorsController } = await import('../../src/modules/core/controllers/vendorsController.js');
+      const { ClientsController } = await import('../../src/modules/core/controllers/clientsController.js');
+      const { EmployeesController } = await import('../../src/modules/core/controllers/employeesController.js');
+
+      const cases = [
+        { Ctrl: VendorsController, body: { tenant_id: 'tid', name: 'V1', code: 'V1' }, expectedType: 'vendor' },
+        { Ctrl: ClientsController, body: { tenant_id: 'tid', name: 'C1', code: 'C1' }, expectedType: 'client' },
+        { Ctrl: EmployeesController, body: { tenant_id: 'tid', first_name: 'E', last_name: '1' }, expectedType: 'employee' },
+      ];
+
+      for (const { Ctrl, body, expectedType } of cases) {
+        insertCallLog = [];
+        vi.clearAllMocks();
+
+        const ctrl = new Ctrl();
+        const { req, res } = mockReqRes({ body });
+        await ctrl.create(req, res);
+
+        const sourceInsert = insertCallLog.find((r) => r.source_type);
+        expect(sourceInsert).toBeDefined();
+        expect(sourceInsert.source_type).toBe(expectedType);
+      }
+    });
+  });
+});

--- a/apps/nap-serv/tests/rbac/arInvoiceApproval.test.js
+++ b/apps/nap-serv/tests/rbac/arInvoiceApproval.test.js
@@ -1,9 +1,9 @@
 /**
- * @file RBAC tests — ar::invoices::approve permission enforcement
+ * @file RBAC tests — ar::ar-invoices::approve permission enforcement
  * @module tests/rbac/arInvoiceApproval
  *
  * Verifies that the PUT /approve endpoint on AR invoices enforces the
- * ar::invoices::approve policy at 'full' level.
+ * ar::ar-invoices::approve policy at 'full' level.
  *
  * Copyright (c) 2025 NapSoft LLC. All rights reserved.
  */
@@ -11,8 +11,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { rbac, withMeta } from '../../src/middleware/rbac.js';
 
+const { EMPTY_CANON } = vi.hoisted(() => ({
+  EMPTY_CANON: { caps: {}, scope: 'all_projects', projectIds: null, companyIds: null, stateFilters: {}, fieldGroups: {} },
+}));
+
 vi.mock('../../src/utils/RbacPolicies.js', () => ({
-  loadPoliciesForUserTenant: vi.fn().mockResolvedValue({}),
+  loadPoliciesForUserTenant: vi.fn().mockResolvedValue({ ...EMPTY_CANON }),
 }));
 
 function createMockReqRes({ user = {}, resource = {}, method = 'PUT', ctx = {} } = {}) {
@@ -41,81 +45,83 @@ describe('AR Invoice Approval RBAC', () => {
     const mod = await import('../../src/utils/RbacPolicies.js');
     loadPoliciesForUserTenant = mod.loadPoliciesForUserTenant;
     loadPoliciesForUserTenant.mockReset();
-    loadPoliciesForUserTenant.mockResolvedValue({});
+    loadPoliciesForUserTenant.mockResolvedValue({ ...EMPTY_CANON });
   });
 
-  it('withMeta sets ar::invoices::approve resource metadata', () => {
-    const middleware = withMeta({ module: 'ar', router: 'invoices', action: 'approve' });
+  it('withMeta sets ar::ar-invoices::approve resource metadata', () => {
+    const middleware = withMeta({ module: 'ar', router: 'ar-invoices', action: 'approve' });
     const { req, res, next } = createMockReqRes();
     middleware(req, res, next);
-    expect(req.resource).toEqual({ module: 'ar', router: 'invoices', action: 'approve' });
+    expect(req.resource).toEqual({ module: 'ar', router: 'ar-invoices', action: 'approve' });
     expect(next).toHaveBeenCalled();
   });
 
-  it('super_user bypasses ar::invoices::approve check', async () => {
+  it('super_user bypasses ar::ar-invoices::approve check', async () => {
     const middleware = rbac('full');
     const { req, res, next } = createMockReqRes({
       user: { id: 'u1', role: 'super_user', schema_name: 'nap' },
-      resource: { module: 'ar', router: 'invoices', action: 'approve' },
+      resource: { module: 'ar', router: 'ar-invoices', action: 'approve' },
     });
     await middleware(req, res, next);
     expect(next).toHaveBeenCalled();
     expect(res.statusCode).toBeNull();
   });
 
-  it('admin bypasses ar::invoices::approve check', async () => {
+  it('admin bypasses ar::ar-invoices::approve check', async () => {
     const middleware = rbac('full');
     const { req, res, next } = createMockReqRes({
       user: { id: 'u1', role: 'admin', schema_name: 'acme' },
-      resource: { module: 'ar', router: 'invoices', action: 'approve' },
+      resource: { module: 'ar', router: 'ar-invoices', action: 'approve' },
     });
     await middleware(req, res, next);
     expect(next).toHaveBeenCalled();
   });
 
-  it('denies member without ar::invoices::approve policy', async () => {
-    loadPoliciesForUserTenant.mockResolvedValue({});
+  it('denies member without ar::ar-invoices::approve policy', async () => {
+    loadPoliciesForUserTenant.mockResolvedValue({ ...EMPTY_CANON });
 
     const middleware = rbac('full');
     const { req, res, next } = createMockReqRes({
       user: { id: 'u1', role: 'member', schema_name: 'acme' },
-      resource: { module: 'ar', router: 'invoices', action: 'approve' },
+      resource: { module: 'ar', router: 'ar-invoices', action: 'approve' },
       ctx: { schema: 'acme' },
     });
     await middleware(req, res, next);
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(403);
     expect(res.body.module).toBe('ar');
-    expect(res.body.router).toBe('invoices');
+    expect(res.body.router).toBe('ar-invoices');
     expect(res.body.action).toBe('approve');
     expect(res.body.needed).toBe('full');
     expect(res.body.have).toBe('none');
   });
 
-  it('allows member with ar::invoices::approve = full', async () => {
+  it('allows member with ar::ar-invoices::approve = full', async () => {
     loadPoliciesForUserTenant.mockResolvedValue({
-      'ar::invoices::approve': 'full',
+      ...EMPTY_CANON,
+      caps: { 'ar::ar-invoices::approve': 'full' },
     });
 
     const middleware = rbac('full');
     const { req, res, next } = createMockReqRes({
       user: { id: 'u1', role: 'member', schema_name: 'acme' },
-      resource: { module: 'ar', router: 'invoices', action: 'approve' },
+      resource: { module: 'ar', router: 'ar-invoices', action: 'approve' },
       ctx: { schema: 'acme' },
     });
     await middleware(req, res, next);
     expect(next).toHaveBeenCalled();
   });
 
-  it('denies member with ar::invoices::approve = view (need full)', async () => {
+  it('denies member with ar::ar-invoices::approve = view (need full)', async () => {
     loadPoliciesForUserTenant.mockResolvedValue({
-      'ar::invoices::approve': 'view',
+      ...EMPTY_CANON,
+      caps: { 'ar::ar-invoices::approve': 'view' },
     });
 
     const middleware = rbac('full');
     const { req, res, next } = createMockReqRes({
       user: { id: 'u1', role: 'member', schema_name: 'acme' },
-      resource: { module: 'ar', router: 'invoices', action: 'approve' },
+      resource: { module: 'ar', router: 'ar-invoices', action: 'approve' },
       ctx: { schema: 'acme' },
     });
     await middleware(req, res, next);
@@ -125,14 +131,14 @@ describe('AR Invoice Approval RBAC', () => {
 
   it('denies when module-level is full but action-level overrides to none', async () => {
     loadPoliciesForUserTenant.mockResolvedValue({
-      'ar::::': 'full',
-      'ar::invoices::approve': 'none',
+      ...EMPTY_CANON,
+      caps: { 'ar::::': 'full', 'ar::ar-invoices::approve': 'none' },
     });
 
     const middleware = rbac('full');
     const { req, res, next } = createMockReqRes({
       user: { id: 'u1', role: 'member', schema_name: 'acme' },
-      resource: { module: 'ar', router: 'invoices', action: 'approve' },
+      resource: { module: 'ar', router: 'ar-invoices', action: 'approve' },
       ctx: { schema: 'acme' },
     });
     await middleware(req, res, next);
@@ -142,13 +148,14 @@ describe('AR Invoice Approval RBAC', () => {
 
   it('falls back to module-level policy when action not defined', async () => {
     loadPoliciesForUserTenant.mockResolvedValue({
-      'ar::::': 'full',
+      ...EMPTY_CANON,
+      caps: { 'ar::::': 'full' },
     });
 
     const middleware = rbac('full');
     const { req, res, next } = createMockReqRes({
       user: { id: 'u1', role: 'member', schema_name: 'acme' },
-      resource: { module: 'ar', router: 'invoices', action: 'approve' },
+      resource: { module: 'ar', router: 'ar-invoices', action: 'approve' },
       ctx: { schema: 'acme' },
     });
     await middleware(req, res, next);

--- a/apps/nap-serv/tests/rbac/rbacFieldGroups.test.js
+++ b/apps/nap-serv/tests/rbac/rbacFieldGroups.test.js
@@ -1,0 +1,158 @@
+/**
+ * @file RBAC Layer 4 tests — field group enforcement via ViewController._applyRbacFilters
+ * @module tests/rbac/rbacFieldGroups
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { describe, it, expect } from 'vitest';
+import ViewController from '../../src/lib/ViewController.js';
+
+function makeReq(perms, role = 'member') {
+  return {
+    user: { id: 'u1', role },
+    ctx: { perms, schema: 'acme' },
+  };
+}
+
+const basePerms = {
+  caps: {},
+  scope: 'all_projects',
+  projectIds: null,
+  companyIds: null,
+  stateFilters: {},
+  fieldGroups: {},
+};
+
+describe('ViewController._applyRbacFilters — Layer 4 (field groups)', () => {
+  it('should not restrict columns when no fieldGroups defined', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(basePerms), conditions, options);
+    expect(options.columnWhitelist).toBeUndefined();
+  });
+
+  it('should set columnWhitelist from fieldGroups', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['amount', 'status'] },
+    };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    // 'id' is always included
+    expect(options.columnWhitelist).toEqual(expect.arrayContaining(['id', 'amount', 'status']));
+    expect(options.columnWhitelist).toHaveLength(3);
+  });
+
+  it('should intersect with existing columnWhitelist', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['id', 'amount', 'status'] },
+    };
+    const conditions = [];
+    const options = { columnWhitelist: ['id', 'amount', 'client_name'] };
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    // Intersection: only 'id' and 'amount' survive
+    expect(options.columnWhitelist).toEqual(expect.arrayContaining(['id', 'amount']));
+    expect(options.columnWhitelist).not.toContain('client_name');
+    expect(options.columnWhitelist).not.toContain('status');
+  });
+
+  it('should always include id even if not in allowed columns', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['amount'] },
+    };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(options.columnWhitelist).toContain('id');
+  });
+
+  it('should fall back to [id] when intersection is empty', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['amount'] },
+    };
+    const conditions = [];
+    const options = { columnWhitelist: ['client_name'] };
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(options.columnWhitelist).toEqual(['id']);
+  });
+
+  it('should bypass field groups for admin', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['amount'] },
+    };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms, 'admin'), conditions, options);
+    expect(options.columnWhitelist).toBeUndefined();
+  });
+});
+
+describe('ViewController._filterRecordFields — Layer 4 (single record)', () => {
+  it('should return record unchanged when no fieldGroups', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const record = { id: '1', amount: 100, client_name: 'Acme' };
+    const result = ctrl._filterRecordFields(makeReq(basePerms), record);
+    expect(result).toEqual(record);
+  });
+
+  it('should strip disallowed fields from record', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['amount'] },
+    };
+    const record = { id: '1', amount: 100, client_name: 'Acme', margin: 0.15 };
+    const result = ctrl._filterRecordFields(makeReq(perms), record);
+    expect(result).toEqual({ id: '1', amount: 100 });
+  });
+
+  it('should always include id in filtered record', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['status'] },
+    };
+    const record = { id: '1', amount: 100, status: 'sent' };
+    const result = ctrl._filterRecordFields(makeReq(perms), record);
+    expect(result).toEqual({ id: '1', status: 'sent' });
+  });
+
+  it('should return null unchanged', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    expect(ctrl._filterRecordFields(makeReq(basePerms), null)).toBeNull();
+  });
+
+  it('should bypass for super_user', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['amount'] },
+    };
+    const record = { id: '1', amount: 100, client_name: 'Acme' };
+    const result = ctrl._filterRecordFields(makeReq(perms, 'super_user'), record);
+    expect(result).toEqual(record);
+  });
+});

--- a/apps/nap-serv/tests/rbac/rbacScope.test.js
+++ b/apps/nap-serv/tests/rbac/rbacScope.test.js
@@ -1,0 +1,148 @@
+/**
+ * @file RBAC Layer 2 tests — data scope enforcement via ViewController._applyRbacFilters
+ * @module tests/rbac/rbacScope
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { describe, it, expect } from 'vitest';
+import ViewController from '../../src/lib/ViewController.js';
+
+// Minimal mock for testing _applyRbacFilters directly
+function makeReq(perms, role = 'member') {
+  return {
+    user: { id: 'u1', role },
+    ctx: { perms, schema: 'acme' },
+  };
+}
+
+const basePerms = {
+  caps: {},
+  scope: 'all_projects',
+  projectIds: null,
+  companyIds: null,
+  stateFilters: {},
+  fieldGroups: {},
+};
+
+describe('ViewController._applyRbacFilters — Layer 2 (scope)', () => {
+  it('should be a no-op when rbacConfig is null', () => {
+    const ctrl = new ViewController('test');
+    // rbacConfig not set
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(basePerms), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+
+  it('should be a no-op for all_projects scope', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'projects', router: 'projects', scopeColumn: 'id' };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(basePerms), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+
+  it('should add project filter for assigned_projects scope', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'projects', router: 'projects', scopeColumn: 'id' };
+    const perms = { ...basePerms, scope: 'assigned_projects', projectIds: ['p1', 'p2'] };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([{ id: { $in: ['p1', 'p2'] } }]);
+  });
+
+  it('should use scopeColumn for non-project resources', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = { ...basePerms, scope: 'assigned_projects', projectIds: ['p1'] };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([{ project_id: { $in: ['p1'] } }]);
+  });
+
+  it('should bypass scope for super_user', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'projects', router: 'projects', scopeColumn: 'id' };
+    const perms = { ...basePerms, scope: 'assigned_projects', projectIds: ['p1'] };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms, 'super_user'), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+
+  it('should bypass scope for admin', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'projects', router: 'projects', scopeColumn: 'id' };
+    const perms = { ...basePerms, scope: 'assigned_projects', projectIds: ['p1'] };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms, 'admin'), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+
+  it('should not add filter when projectIds is null even with assigned_projects scope', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'projects', router: 'projects', scopeColumn: 'id' };
+    const perms = { ...basePerms, scope: 'assigned_projects', projectIds: null };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+
+  // ── assigned_companies scope ──────────────────────────────────────────
+
+  it('should filter by company_id when scope is assigned_companies and scopeColumn is company_id', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'projects', router: 'projects', scopeColumn: 'company_id' };
+    const perms = { ...basePerms, scope: 'assigned_companies', companyIds: ['c1', 'c2'], projectIds: ['p1', 'p2'] };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([{ company_id: { $in: ['c1', 'c2'] } }]);
+  });
+
+  it('should filter by projectIds when scope is assigned_companies and scopeColumn is project_id', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = { ...basePerms, scope: 'assigned_companies', companyIds: ['c1'], projectIds: ['p1', 'p2'] };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([{ project_id: { $in: ['p1', 'p2'] } }]);
+  });
+
+  it('should use default scopeColumn (project_id) for assigned_companies when not specified', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices' };
+    const perms = { ...basePerms, scope: 'assigned_companies', companyIds: ['c1'], projectIds: ['p3'] };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([{ project_id: { $in: ['p3'] } }]);
+  });
+
+  it('should bypass assigned_companies scope for super_user', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'projects', router: 'projects', scopeColumn: 'company_id' };
+    const perms = { ...basePerms, scope: 'assigned_companies', companyIds: ['c1'] };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms, 'super_user'), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+
+  it('should not add filter when companyIds is null with assigned_companies and company_id scopeColumn', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'projects', router: 'projects', scopeColumn: 'company_id' };
+    const perms = { ...basePerms, scope: 'assigned_companies', companyIds: null, projectIds: null };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+});

--- a/apps/nap-serv/tests/rbac/rbacStateFilters.test.js
+++ b/apps/nap-serv/tests/rbac/rbacStateFilters.test.js
@@ -1,0 +1,93 @@
+/**
+ * @file RBAC Layer 3 tests — record state filter enforcement via ViewController._applyRbacFilters
+ * @module tests/rbac/rbacStateFilters
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { describe, it, expect } from 'vitest';
+import ViewController from '../../src/lib/ViewController.js';
+
+function makeReq(perms, role = 'member') {
+  return {
+    user: { id: 'u1', role },
+    ctx: { perms, schema: 'acme' },
+  };
+}
+
+const basePerms = {
+  caps: {},
+  scope: 'all_projects',
+  projectIds: null,
+  companyIds: null,
+  stateFilters: {},
+  fieldGroups: {},
+};
+
+describe('ViewController._applyRbacFilters — Layer 3 (state filters)', () => {
+  it('should not add status filter when no stateFilters defined', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(basePerms), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+
+  it('should add status filter when stateFilters match the resource', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      stateFilters: { 'ar::ar-invoices': ['approved', 'sent'] },
+    };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([{ status: { $in: ['approved', 'sent'] } }]);
+  });
+
+  it('should not add filter for non-matching resource', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ap', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      stateFilters: { 'ar::ar-invoices': ['approved'] },
+    };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+
+  it('should bypass state filter for super_user', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      stateFilters: { 'ar::ar-invoices': ['approved'] },
+    };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms, 'super_user'), conditions, options);
+    expect(conditions).toEqual([]);
+  });
+
+  it('should combine scope and state filter conditions', () => {
+    const ctrl = new ViewController('test');
+    ctrl.rbacConfig = { module: 'ar', router: 'ar-invoices', scopeColumn: 'project_id' };
+    const perms = {
+      ...basePerms,
+      scope: 'assigned_projects',
+      projectIds: ['p1'],
+      stateFilters: { 'ar::ar-invoices': ['sent'] },
+    };
+    const conditions = [];
+    const options = {};
+    ctrl._applyRbacFilters(makeReq(perms), conditions, options);
+    expect(conditions).toEqual([
+      { project_id: { $in: ['p1'] } },
+      { status: { $in: ['sent'] } },
+    ]);
+  });
+});

--- a/apps/nap-serv/tests/unit/rbacQueryContext.test.js
+++ b/apps/nap-serv/tests/unit/rbacQueryContext.test.js
@@ -1,0 +1,122 @@
+/**
+ * @file Unit tests for RbacQueryContext — builds query modifiers from RBAC canon
+ * @module tests/unit/rbacQueryContext
+ *
+ * Copyright (c) 2025 NapSoft LLC. All rights reserved.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildQueryContext } from '../../src/utils/RbacQueryContext.js';
+
+describe('buildQueryContext', () => {
+  const basePerms = {
+    caps: {},
+    scope: 'all_projects',
+    projectIds: null,
+    companyIds: null,
+    stateFilters: {},
+    fieldGroups: {},
+  };
+
+  it('should return permissive defaults when perms are empty', () => {
+    const ctx = buildQueryContext(basePerms, 'ar', 'ar-invoices');
+    expect(ctx).toEqual({
+      scope: 'all_projects',
+      projectIds: null,
+      companyIds: null,
+      visibleStatuses: null,
+      allowedColumns: null,
+    });
+  });
+
+  it('should return permissive defaults when perms is null', () => {
+    const ctx = buildQueryContext(null, 'ar', 'ar-invoices');
+    expect(ctx).toEqual({
+      scope: 'all_projects',
+      projectIds: null,
+      companyIds: null,
+      visibleStatuses: null,
+      allowedColumns: null,
+    });
+  });
+
+  it('should extract scope and projectIds for assigned_projects', () => {
+    const perms = {
+      ...basePerms,
+      scope: 'assigned_projects',
+      projectIds: ['p1', 'p2'],
+    };
+    const ctx = buildQueryContext(perms, 'ar', 'ar-invoices');
+    expect(ctx.scope).toBe('assigned_projects');
+    expect(ctx.projectIds).toEqual(['p1', 'p2']);
+    expect(ctx.companyIds).toBeNull();
+  });
+
+  it('should extract scope, companyIds and projectIds for assigned_companies', () => {
+    const perms = {
+      ...basePerms,
+      scope: 'assigned_companies',
+      companyIds: ['c1', 'c2'],
+      projectIds: ['p1', 'p2', 'p3'],
+    };
+    const ctx = buildQueryContext(perms, 'ar', 'ar-invoices');
+    expect(ctx.scope).toBe('assigned_companies');
+    expect(ctx.companyIds).toEqual(['c1', 'c2']);
+    expect(ctx.projectIds).toEqual(['p1', 'p2', 'p3']);
+  });
+
+  it('should extract state filters for matching module::router', () => {
+    const perms = {
+      ...basePerms,
+      stateFilters: { 'ar::ar-invoices': ['approved', 'sent'] },
+    };
+    const ctx = buildQueryContext(perms, 'ar', 'ar-invoices');
+    expect(ctx.visibleStatuses).toEqual(['approved', 'sent']);
+  });
+
+  it('should return null visibleStatuses for non-matching module::router', () => {
+    const perms = {
+      ...basePerms,
+      stateFilters: { 'ar::ar-invoices': ['approved'] },
+    };
+    const ctx = buildQueryContext(perms, 'projects', 'projects');
+    expect(ctx.visibleStatuses).toBeNull();
+  });
+
+  it('should extract field groups for matching module::router', () => {
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['id', 'amount', 'status'] },
+    };
+    const ctx = buildQueryContext(perms, 'ar', 'ar-invoices');
+    expect(ctx.allowedColumns).toEqual(['id', 'amount', 'status']);
+  });
+
+  it('should return null allowedColumns for non-matching module::router', () => {
+    const perms = {
+      ...basePerms,
+      fieldGroups: { 'ar::ar-invoices': ['id', 'amount'] },
+    };
+    const ctx = buildQueryContext(perms, 'ap', 'ap-invoices');
+    expect(ctx.allowedColumns).toBeNull();
+  });
+
+  it('should handle all layers populated at once', () => {
+    const perms = {
+      caps: { 'ar::::': 'view' },
+      scope: 'assigned_projects',
+      projectIds: ['p1'],
+      companyIds: null,
+      stateFilters: { 'ar::ar-invoices': ['sent'] },
+      fieldGroups: { 'ar::ar-invoices': ['id', 'amount'] },
+    };
+    const ctx = buildQueryContext(perms, 'ar', 'ar-invoices');
+    expect(ctx).toEqual({
+      scope: 'assigned_projects',
+      projectIds: ['p1'],
+      companyIds: null,
+      visibleStatuses: ['sent'],
+      allowedColumns: ['id', 'amount'],
+    });
+  });
+});

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -186,8 +186,8 @@ The UI follows a four-zone layout architecture:
 ```
 
 - **Tenant Bar**: Tenant selector dropdown, user avatar with profile/settings dropdown
-- **Module Bar**: Displays the current module name on the left with breadcrumb navigation (e.g., `Settings > Manage Employees`), plus dynamic toolbar actions (tabs, filters, primary action buttons) on the right
-- **Sidebar**: Collapsible navigation with primary groups and sub-module items; supports flyout menus when collapsed
+- **Module Bar**: Displays the current module name on the left with breadcrumb navigation (e.g., `Admin > Manage Employees`), plus dynamic toolbar actions (tabs, filters, primary action buttons) on the right
+- **Sidebar**: Collapsible navigation with up to 3 levels of nesting (group → sub-module → leaf item); supports flyout menus when collapsed
 - **Data Viewport**: Main content area where page components render
 
 ### 2.4 Request Flow
@@ -1592,23 +1592,25 @@ All MUI component overrides defined in `theme.js`:
 
 ### 6.2 Navigation System
 
-Navigation is configured via `navigationConfig.js` with capability-based filtering:
+Navigation is configured via `navigationConfig.js` with capability-based filtering. The sidebar supports up to 3 levels of nesting: a child item with a `children` array (no `path`) renders as a collapsible sub-group; a child with a `path` (no `children`) renders as a leaf nav item.
 
 ```
-Primary Group -> Sub-modules
-  Settings (SettingsIcon)
-    +-- Manage Tenants (/tenant/manage-tenants)
+Primary Group -> Sub-modules -> Leaf items
+  Admin (AdminPanelSettingsIcon)
     +-- Manage Employees (/tenant/manage-employees)
-    +-- Manage Roles (/tenant/manage-roles)
+    +-- Roles (/tenant/manage-roles)
+    +-- Tenants (sub-group, NAP only)
+        +-- Manage Tenants (/tenant/manage-tenants)
+        +-- Manage Users (/tenant/manage-users)
 ```
 
-Extensible design: add new groups/modules to `NAV_ITEMS` array with optional `capability` guards.
+Extensible design: add new groups/modules to `NAV_ITEMS` array with optional `capability` guards. Sub-groups inherit capability filtering recursively — a sub-group is visible if any of its children pass the capability check.
 
 ### 6.3 Module Bar (Dynamic Toolbar)
 
 The Module Bar has two zones:
 
-- **Left zone**: Current module name and breadcrumb trail (e.g., `Settings > Manage Employees > Edit`). The module name is derived from the active navigation group; breadcrumbs reflect the current route hierarchy. Breadcrumb segments are clickable links for back-navigation.
+- **Left zone**: Current module name and breadcrumb trail (e.g., `Admin > Manage Employees > Edit`). The module name is derived from the active navigation group; breadcrumbs reflect the current route hierarchy. Breadcrumb segments are clickable links for back-navigation.
 - **Right zone**: Dynamic toolbar actions registered by page components via `useModuleToolbarRegistration()`:
   - **Tabs**: Toggle button groups with exclusive/non-exclusive selection
   - **Filters**: Text fields or select dropdowns
@@ -1665,7 +1667,7 @@ Based on the sidebar navigation config and server module structure:
 | **AR** | Clients, AR Invoices, Receipts, AR Aging | `/ar` |
 | **Accounting & GL** | Chart of Accounts, Journal Entries, Ledger, Intercompany | `/accounting` |
 | **Reports** | Budget vs Actual, Profitability, Cashflow, Margin Analysis, P&L, Balance Sheet | `/reports` |
-| **Settings** | Manage Tenants, Manage Employees, Manage Roles | `/tenant` |
+| **Admin** | Manage Employees, Roles, **Tenants** (Manage Tenants, Manage Users — NAP only) | `/tenant` |
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -42,6 +42,7 @@ nap/
   apps/
     nap-client/     # React SPA frontend
     nap-serv/       # Express API backend
+  docs/             # Project documentation  
   packages/
     shared/         # Shared utilities/constants
 ```

--- a/docs/auth-rbac.md
+++ b/docs/auth-rbac.md
@@ -1,3 +1,6 @@
 # Authentication & RBAC
 
-> Placeholder — see PRD.md §3.1 for full auth and RBAC specification.
+> See PRD.md §3.1 for auth specification, §3.1.2 for the four-layer RBAC model.
+> Architecture decision: [ADR-0013](./decisions/0013-four-layer-scoped-rbac.md).
+> Business rules: [rules/rbac.md](./rules/rbac.md) (BR-RBAC-001 through BR-RBAC-048).
+> UI visibility rules: [rules/ui-visibility.md](./rules/ui-visibility.md) (UI-VIS-001 through UI-VIS-004).

--- a/docs/decisions/0001-schema-per-tenant-isolation.md
+++ b/docs/decisions/0001-schema-per-tenant-isolation.md
@@ -1,0 +1,38 @@
+# 0001. Schema-per-Tenant Isolation over Row-Level Tenancy
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP is a multi-tenant ERP platform serving multiple customer organizations from a single deployment. Each tenant's financial, procurement, and operational data must be completely isolated from other tenants. The two dominant approaches for multi-tenant data isolation in PostgreSQL are:
+
+1. **Row-level tenancy** — all tenants share tables; a `tenant_id` column discriminates rows; queries must always include a tenant filter.
+2. **Schema-per-tenant** — each tenant gets a dedicated PostgreSQL schema containing a full copy of all business tables.
+
+The system also requires independent migration rollouts per tenant (for staggered upgrades) and the ability to drop or export a single tenant's data without touching others. Cross-tenant data leakage in a financial application is a critical risk that must be structurally prevented, not just conventionally avoided.
+
+## Decision
+
+Each tenant is provisioned a dedicated PostgreSQL schema (e.g., `acme`, `globex`). System-wide tables (`tenants`, `nap_users`, `nap_user_addresses`, `match_review_logs`) live in a separate `admin` schema. Tenant resolution happens per-request via the `x-tenant-code` header, and pg-schemata's `setSchemaName()` binds all subsequent queries to that schema. The `bootstrap()` function creates a new tenant schema and all its tables in a single transaction. `MigrationManager` applies pending migrations independently per schema.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Row-level tenancy (`tenant_id` column) | Single set of tables; simpler migrations; lower per-tenant overhead | Every query must include `WHERE tenant_id = ?`; one missed filter leaks data; shared indexes grow with all tenants; cannot independently migrate or export a single tenant |
+| Database-per-tenant | Strongest isolation; independent backups | Connection pool explosion; cross-tenant admin queries require multi-database joins; significant operational overhead |
+
+## Consequences
+
+**Positive:**
+- Complete data isolation — queries physically cannot touch another tenant's schema, eliminating cross-tenant leakage by construction
+- Independent schema migrations — tenants can be upgraded on different schedules
+- Clean tenant export/drop — `pg_dump` or `DROP SCHEMA CASCADE` operates on a single tenant without affecting others
+- No `WHERE tenant_id = ?` discipline required — developers cannot accidentally forget a filter because the query runs in the scoped schema
+
+**Negative:**
+- Schema proliferation — each tenant adds a full set of tables; DDL changes must be applied N times (mitigated by `MigrationManager` iterating over all schemas)
+- Cross-tenant reporting requires explicit `admin` schema joins or aggregation across schemas
+- Connection pool is shared but search_path must be set per-request, adding a small per-query overhead

--- a/docs/decisions/0002-pg-schemata-as-orm.md
+++ b/docs/decisions/0002-pg-schemata-as-orm.md
@@ -1,0 +1,42 @@
+# 0002. pg-schemata as ORM over Knex/Drizzle/Prisma
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP requires a data access layer that supports schema-per-tenant isolation, schema-driven DDL generation, built-in migration management, and tight integration with PostgreSQL-specific features (partial indexes, advisory locks, pgvector). Third-party ORMs and query builders each impose their own schema definition format and migration tooling, which may not align with the multi-schema tenancy model. NapSoft owns the pg-schemata library and can extend it as requirements evolve.
+
+## Decision
+
+Use pg-schemata as the sole ORM/query layer. It provides:
+
+- **`TableModel`** — writable CRUD with soft deletes, audit fields (`created_by`, `updated_by`, timestamps), Zod validation auto-generation, and Excel import/export
+- **`QueryModel`** — read-only access for SQL views
+- **`MigrationManager`** — SHA-256 checksummed migrations with PostgreSQL advisory locks and per-schema discovery
+- **`bootstrap()`** — atomic schema creation (all tables in a single transaction)
+- **Schema definitions** as plain JavaScript objects — the single source of truth for both DDL and runtime column sets
+- Keyset pagination via `findAfterCursor()`, aggregate query helpers (`SUM`, `AVG`), and a raw SQL escape hatch for complex queries
+- Pre/post hooks for cross-cutting concerns (e.g., GL posting after invoice approval)
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Knex.js | Mature query builder; large ecosystem; flexible migrations | No schema-driven DDL; migrations are imperative scripts; no built-in multi-schema support; no soft delete or audit field conventions |
+| Drizzle ORM | Type-safe; lightweight; Postgres-native | Newer ecosystem; schema definition tied to TypeScript; multi-schema tenancy requires manual wiring; no owned control over library |
+| Prisma | Excellent DX; auto-generated client; strong typing | Schema file (`schema.prisma`) is a separate DSL; multi-schema tenancy not natively supported; connection pool per-schema is expensive; no owned control |
+
+## Consequences
+
+**Positive:**
+- Full ownership — features (aggregate helpers, batch schema ops, connection tagging) are added on NapSoft's schedule, not waiting on upstream PRs
+- Postgres-first design — no abstraction leaks from supporting multiple databases
+- Schema definitions are the single source of truth for DDL, column sets, validation, and import/export
+- Built-in conventions (soft deletes, audit fields, keyset pagination) enforce consistency across all modules
+
+**Negative:**
+- Owned dependency means NapSoft bears all maintenance and documentation burden
+- Smaller community — no Stack Overflow answers or third-party plugins
+- New team members must learn pg-schemata's API rather than a widely-known ORM

--- a/docs/decisions/0003-jwt-in-httponly-cookies.md
+++ b/docs/decisions/0003-jwt-in-httponly-cookies.md
@@ -1,0 +1,41 @@
+# 0003. JWT in httpOnly Cookies over localStorage Tokens
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP's API requires stateless authentication that works across a React SPA frontend and an Express API backend. The two primary browser-based token storage strategies are localStorage (read by JavaScript, sent via `Authorization` header) and httpOnly cookies (set by the server, transmitted automatically by the browser). NAP handles sensitive financial data, making XSS-based token theft a critical threat to mitigate.
+
+## Decision
+
+Authentication tokens are stored as httpOnly cookies:
+
+- **`auth_token`** — short-lived JWT (15 min), signed with `iss: 'nap-serv'`, `aud: 'nap-serv-api'`, `sub: userId`, `ph: permissionHash`, `exp`
+- **`refresh_token`** — longer-lived JWT (7 days), used for full token rotation
+- Both cookies use `httpOnly`, `Secure` (in production), and `SameSite` attributes
+- Authentication flow: Passport Local Strategy with bcrypt → JWT signing → cookies set in response
+- Client-side: `AuthContext` manages user state; all API calls use `credentials: 'include'`; no token handling in JavaScript
+- Tenant context and permissions are resolved per-request by `authRedis` middleware — NOT embedded in the JWT (keeping tokens small and avoiding stale permission claims)
+- Permission staleness detection: SHA-256 hash of the user's policy set is stored as the `ph` JWT claim; `authRedis` compares it on each request and signals the client with `X-Token-Stale: 1` when permissions have changed
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| localStorage + `Authorization` header | Simple to implement; works across origins; no CSRF concern | Vulnerable to XSS — any injected script can read and exfiltrate the token; requires manual token management in client code; token not automatically sent |
+| Session cookies (server-side sessions) | No token in browser at all; easy to invalidate | Requires server-side session store; breaks stateless API design; sticky sessions or shared store needed for horizontal scaling |
+
+## Consequences
+
+**Positive:**
+- XSS protection — JavaScript cannot access httpOnly cookies, so injected scripts cannot steal tokens
+- Automatic transmission — browser sends cookies on every request without client-side logic
+- No client-side token management — eliminates an entire class of token-handling bugs
+- CSRF mitigated via `SameSite` cookie attribute
+
+**Negative:**
+- Cookie size limits (~4 KB) constrain JWT payload — resolved by keeping permissions out of the JWT and resolving them server-side
+- CSRF requires `SameSite` policy (or CSRF tokens) — accepted trade-off
+- Cross-origin API consumption (e.g., mobile apps) would need a different token strategy — not currently required

--- a/docs/decisions/0004-three-level-rbac.md
+++ b/docs/decisions/0004-three-level-rbac.md
@@ -1,0 +1,47 @@
+# 0004. Three-Level RBAC (none/view/full) over Boolean Permissions
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP requires role-based access control that distinguishes between users who should see data (e.g., a project manager reviewing invoices) and users who can modify it (e.g., an accountant approving payments). A boolean permission model (has access / no access) forces a binary choice — either a user can do everything on a resource or nothing. Financial ERP operations frequently need a middle ground: read-only access for oversight without mutation rights.
+
+## Decision
+
+Permissions use three ordered levels: `none` (0) < `view` (1) < `full` (2).
+
+**Data model** (per tenant schema): `roles`, `role_members`, `policies` tables. Each policy row specifies `(role_id, module, router, action, level)`.
+
+**Policy resolution** follows a specificity hierarchy (most specific wins):
+1. `module::router::action` (e.g., `ar::invoices::approve`)
+2. `module::router` (e.g., `ar::invoices`)
+3. `module` (e.g., `ar`)
+4. Default: `none`
+
+**Middleware chain:** `withMeta({ module, router, action })` annotates `req.resource` → `rbac(requiredLevel)` compares the resolved level against the required level → 403 on denial.
+
+**Default levels:** GET/HEAD require `view`; POST/PUT/PATCH/DELETE require `full`.
+
+**System roles:** `super_user` bypasses all checks (NapSoft-only); `admin` has full control within a tenant but is blocked from the `tenants` module.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Boolean permissions (has/no access) | Simpler model; fewer states to manage | Cannot distinguish read-only oversight from full mutation access; forces all-or-nothing per resource; common in CRUD apps but insufficient for financial workflows |
+| Fine-grained action-level booleans (e.g., `can_read`, `can_create`, `can_update`, `can_delete`, `can_approve`) | Maximum granularity per action | Exponential policy rows; complex UI for policy management; most NAP resources need only the read/write distinction |
+
+## Consequences
+
+**Positive:**
+- Granular read vs. write control — managers can view reports without risk of accidental mutations
+- Hierarchical policy resolution reduces policy row count — a single `module`-level policy covers all routers and actions unless overridden
+- Clean middleware integration — a single numeric comparison (`resolvedLevel >= requiredLevel`) handles all authorization checks
+- Audit-friendly — permission levels are easy to log and reason about
+
+**Negative:**
+- Three levels may occasionally be insufficient (e.g., `approve` as a distinct level above `full`) — mitigated by action-level policy granularity (`ar::invoices::approve` can have its own level)
+- Policy resolution hierarchy adds complexity compared to a flat permission lookup
+- Per-tenant RBAC tables mean policy changes must be applied within each tenant's schema independently

--- a/docs/decisions/0004-three-level-rbac.md
+++ b/docs/decisions/0004-three-level-rbac.md
@@ -1,7 +1,7 @@
 # 0004. Three-Level RBAC (none/view/full) over Boolean Permissions
 
 **Date:** 2025-02-17
-**Status:** accepted
+**Status:** superseded by [ADR-0013](./0013-four-layer-scoped-rbac.md)
 **Author:** NapSoft
 
 ## Context

--- a/docs/decisions/0005-keyset-pagination.md
+++ b/docs/decisions/0005-keyset-pagination.md
@@ -1,0 +1,39 @@
+# 0005. Keyset Pagination over Offset-Based Pagination
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP's list endpoints return potentially large result sets (invoices, journal entries, SKU catalogs) that must be paginated. The two standard approaches are offset-based (`LIMIT x OFFSET y`) and keyset-based (also called cursor-based: `WHERE id > :lastSeen ORDER BY id LIMIT x`). NAP is a multi-user ERP where records are frequently inserted and archived concurrently, meaning the dataset shifts between page requests.
+
+## Decision
+
+All list endpoints use keyset pagination via pg-schemata's `findAfterCursor()` method. Clients provide:
+
+- `cursor` — the last seen ID or composite sort value from the previous page
+- `limit` — page size
+- `orderBy` — sort column(s)
+- `columnWhitelist` — optional restriction on returned columns
+
+The API returns the result set plus the cursor value for the next page. First-page requests omit the cursor parameter.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Offset-based (`LIMIT/OFFSET`) | Simple to implement; page number navigation possible; widely understood | Performance degrades linearly with offset (database must scan and discard rows); concurrent inserts/deletes cause skipped or duplicated rows between pages |
+| Hybrid (offset for small sets, keyset for large) | Flexibility per endpoint | Inconsistent API contract; two pagination implementations to maintain; client must handle both patterns |
+
+## Consequences
+
+**Positive:**
+- Stable performance at any depth — the database seeks directly to the cursor position using an index, regardless of how deep into the result set the client has paginated
+- No skipped or duplicated rows — concurrent inserts and deletes do not shift page boundaries because pagination is anchored to a specific row, not a numeric offset
+- Consistent API contract — all list endpoints use the same cursor-based pattern
+
+**Negative:**
+- No arbitrary page jumping — clients cannot request "page 47" directly; they must traverse sequentially (acceptable for NAP's data grid use case with infinite scroll)
+- Compound sort keys (e.g., `created_at` + `id`) require careful cursor encoding
+- Slightly more complex client logic compared to simple page numbers

--- a/docs/decisions/0006-express-5.md
+++ b/docs/decisions/0006-express-5.md
@@ -1,0 +1,37 @@
+# 0006. Express 5 over Fastify/Koa
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP's backend requires an HTTP framework for its REST API. The framework must support ES Modules, middleware composition (CORS, cookie parsing, logging, authentication, RBAC), and async error handling without manual `try/catch` wrappers. The team has extensive experience with Express. Express 5 (the first major release since Express 4 in 2014) adds native async/await error propagation and other improvements.
+
+## Decision
+
+Use Express 5 with ES Modules as the HTTP framework. The request pipeline is:
+
+CORS → JSON/cookie parsing → Morgan logging → `authRedis()` middleware → route-level `withMeta()` + `rbac()` → handler → response
+
+Express 5's automatic async error handling means rejected promises in route handlers propagate to the error middleware without explicit `try/catch` or `next(err)` calls. The API runs on port 3000 with Vite's dev proxy forwarding `/api` requests from port 5173.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Fastify | Higher raw throughput; built-in schema validation; structured logging | Different middleware paradigm (hooks/plugins vs. `use()`); smaller ecosystem of middleware; team would need to learn a new framework; plugin encapsulation model adds complexity |
+| Koa | Cleaner async/await design (from the start); lightweight core | Smaller middleware ecosystem than Express; less community adoption; many Express middleware packages require Koa-specific ports |
+
+## Consequences
+
+**Positive:**
+- Mature ecosystem — vast library of compatible middleware (Passport, cors, cookie-parser, morgan, etc.)
+- Team familiarity — no ramp-up time; established patterns and conventions
+- Express 5 async error handling eliminates boilerplate `try/catch` in every route handler
+- Large community — extensive documentation, Stack Overflow support, and battle-tested in production
+
+**Negative:**
+- Lower raw throughput than Fastify (acceptable for NAP's expected load)
+- Express's middleware model is less structured than Fastify's plugin encapsulation — discipline required to avoid middleware ordering bugs
+- Express 5 was in beta for years; ecosystem compatibility may lag for some older middleware packages

--- a/docs/decisions/0007-redis-permission-caching.md
+++ b/docs/decisions/0007-redis-permission-caching.md
@@ -1,0 +1,42 @@
+# 0007. Redis for Permission Caching over In-Memory Caching
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP's RBAC system resolves a user's effective permissions on every request by evaluating their roles and policies against the requested resource. This resolution involves multiple database queries (roles → role_members → policies). Caching the resolved permission set avoids repeated database lookups. The cache must be consistent across multiple server instances (for horizontal scaling) and must survive individual process restarts.
+
+## Decision
+
+Resolved permission sets are cached in Redis at `perm:{userId}:{tenantCode}`. The `authRedis()` middleware reads from this cache on every request:
+
+1. Check Redis for `perm:{userId}:{tenantCode}`
+2. If cached, compare the SHA-256 permission hash against the JWT's `ph` claim
+3. If the hashes diverge, respond with `X-Token-Stale: 1` to signal the client to refresh its token
+4. If not cached, resolve permissions from the database, store in Redis with TTL
+
+Cache invalidation occurs when roles, role_members, or policies are mutated — the affected user's cache key is deleted.
+
+Redis connection is configured via `REDIS_URL` (dev: `redis://localhost:6379`).
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| In-memory cache (e.g., `Map` or `lru-cache`) | No external dependency; lowest latency; simplest implementation | Not shared across server instances — each process has its own cache; lost on process restart; inconsistent permissions during rolling deploys |
+| Database materialized view | Always consistent; no separate cache layer | Still a database query per request; refresh cost on every policy change; no TTL-based expiration |
+
+## Consequences
+
+**Positive:**
+- Shared across all server instances — permission changes are immediately visible regardless of which process handles the next request
+- Survives process restarts — cached permissions persist in Redis independently of the Node.js process lifecycle
+- TTL-based expiration provides a safety net against stale data even if explicit invalidation is missed
+- Permission hash comparison (`ph` claim) enables lightweight staleness detection without re-resolving on every request
+
+**Negative:**
+- Redis becomes a required infrastructure dependency — the application cannot start without a Redis connection
+- Network round-trip to Redis on every request (sub-millisecond on localhost; low single-digit ms in production)
+- Cache invalidation logic must be maintained alongside every role/policy mutation endpoint

--- a/docs/decisions/0008-soft-deletes.md
+++ b/docs/decisions/0008-soft-deletes.md
@@ -1,0 +1,44 @@
+# 0008. Soft Deletes over Hard Deletes
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP manages financial records (invoices, payments, journal entries) that are subject to audit requirements and regulatory retention. Deleting a record permanently can break referential integrity, destroy audit trails, and make it impossible to recover from accidental deletions. However, soft-deleted records must not appear in normal queries or violate uniqueness constraints against active records.
+
+## Decision
+
+All models use pg-schemata's `softDelete: true` option. Soft-deleted records are marked with a `deactivated_at` timestamp rather than being removed from the database.
+
+**Behavior:**
+- All read queries automatically exclude records where `deactivated_at IS NOT NULL`
+- `removeWhere()` sets `deactivated_at = NOW()` instead of issuing `DELETE`
+- `restoreWhere()` clears `deactivated_at` to reactivate a record
+- `findSoftDeleted()` returns only deactivated records (for admin recovery UIs)
+- `purgeSoftDeleteWhere()` is available for permanent removal when required (e.g., GDPR data erasure)
+
+**Uniqueness:** Partial unique indexes use `WHERE deactivated_at IS NULL` so that soft-deleted records do not conflict with active ones (e.g., a user's email can be reused after their account is archived).
+
+**Cascading:** Archive operations cascade to dependent records (e.g., archiving a tenant deactivates all its users).
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Hard deletes (`DELETE FROM`) | Simpler queries; no ghost data; reclaims storage immediately | Destroys audit trail; no undo without backups; breaks referential integrity if foreign keys reference deleted rows; regulatory risk for financial records |
+| History/audit table (hard delete + trigger-based archival) | Clean primary tables; full history preserved separately | Complex trigger maintenance; two-table queries for undo; history table schema must mirror primary table and be kept in sync |
+
+## Consequences
+
+**Positive:**
+- Full audit trail — every record's lifecycle is preserved in place
+- Undo capability — accidental archival is trivially reversible with `restoreWhere()`
+- Referential integrity preserved — foreign keys continue to resolve; no orphaned references
+- Regulatory compliance — financial records are retained as required
+
+**Negative:**
+- Tables grow indefinitely with soft-deleted records — mitigated by partial indexes that exclude deactivated rows from query plans
+- All unique constraints must use partial indexes (`WHERE deactivated_at IS NULL`) — a convention that must be consistently applied
+- `purgeSoftDeleteWhere()` exists as an escape hatch but must be carefully governed to avoid accidental permanent data loss

--- a/docs/decisions/0009-derived-cashflow-views.md
+++ b/docs/decisions/0009-derived-cashflow-views.md
@@ -1,0 +1,43 @@
+# 0009. Derived Cashflow Views over Dedicated Cashflow Tables
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP provides project profitability and cashflow reporting by linking AR invoices (revenue), AP invoices (costs), actual costs, and journal entries back to projects via `project_id` foreign keys. The reporting layer needs to present rolled-up metrics (revenue, costs, gross profit, margin %, net cashflow), monthly time series, cost breakdowns, and aging reports. The question is whether this reporting data should be computed on-the-fly from existing transactional tables or materialized into dedicated cashflow/profitability tables.
+
+## Decision
+
+Cashflow and profitability data is derived from existing transactional tables using PostgreSQL SQL views created at tenant provisioning and updated via migrations:
+
+- **`vw_project_profitability`** — rolled-up metrics: revenue (AR), costs (AP + actual costs), gross profit, margin %, net cashflow per project
+- **`vw_project_cashflow_monthly`** — monthly inflow/outflow time series per project
+- **`vw_project_cost_by_category`** — cost breakdown by activity category
+- **`vw_ar_aging`** — accounts receivable aging by client
+- **`vw_ap_aging`** — accounts payable aging by vendor
+
+The formula is: `PROJECT PROFITABILITY = Revenue (AR) - Costs (AP + Actual Costs)`.
+
+Report endpoints (`/api/reports/v1/project-profitability`, `/api/reports/v1/project-cashflow/:projectId`, etc.) query these views directly using `QueryModel`.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Dedicated cashflow tables (materialized separately) | Pre-computed for fast reads; can add indexes optimized for reporting | Data synchronization burden — must update cashflow tables on every AR/AP/cost mutation; eventual inconsistency risk if sync fails; dual-write complexity; storage duplication |
+| Materialized views with periodic refresh | Faster reads than plain views; no sync logic needed | Stale data between refreshes; `REFRESH MATERIALIZED VIEW` locks the view; refresh scheduling adds operational complexity |
+
+## Consequences
+
+**Positive:**
+- Single source of truth — views always reflect the current state of transactional data with no sync lag
+- No data synchronization logic — eliminates an entire class of dual-write bugs
+- Real-time accuracy — reports are always current as of the query moment
+- Simpler schema — no additional tables to migrate, back-fill, or maintain
+
+**Negative:**
+- Query performance depends on the size of underlying transactional tables — mitigated by indexes on `project_id` and date columns
+- Complex view definitions may be harder to optimize than pre-computed tables
+- High-frequency dashboard polling could create database load — mitigated by client-side caching and reasonable refresh intervals

--- a/docs/decisions/0010-conventional-commits.md
+++ b/docs/decisions/0010-conventional-commits.md
@@ -1,0 +1,47 @@
+# 0010. Conventional Commits over Freeform Messages
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP is a monorepo with two workspaces (`apps/nap-serv`, `apps/nap-client`) and a shared package. Commit history needs to be filterable by scope (which workspace or module was changed) and by type (feature, fix, refactor, etc.) to support code review, changelog generation, and release management. Freeform commit messages vary in format and provide no machine-parseable structure.
+
+## Decision
+
+All commits follow the Conventional Commits format: `<type>(<scope>): <subject>`
+
+**Types:** `feat`, `fix`, `refactor`, `test`, `chore`, `docs`
+
+**Scopes:** `serv`, `client`, `deps`, or specific modules (`ap`, `ar`, `accounting`)
+
+**Examples:**
+- `feat(serv): add AR aging SQL view and report endpoint`
+- `fix(client): correct tenant bar dropdown not updating on switch`
+- `refactor(serv): extract posting logic into PostingService`
+- `test(serv): add RBAC integration tests for AP module`
+- `chore(deps): bump pg-schemata to 1.3.1`
+- `docs: update PRD with cashflow module specification`
+
+**Enforcement:** Husky pre-commit hook rejects commits that touch files in both `apps/nap-client/` and `apps/nap-serv/` simultaneously, ensuring each commit is scoped to a single workspace. Cross-workspace changes (shared types, config) use `--no-verify` when necessary.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Freeform commit messages | No tooling required; no learning curve; maximum flexibility | No machine parsing; inconsistent format across developers; cannot auto-generate changelogs; difficult to filter history by scope or type |
+| Commitizen (interactive CLI prompt) | Guided commit message creation; enforces format interactively | Adds a CLI dependency; slower commit workflow; same underlying format (Conventional Commits) can be adopted without the tool |
+
+## Consequences
+
+**Positive:**
+- Parseable history — commits can be filtered by type and scope using standard tools (`git log --grep`)
+- Automated changelog potential — tools can generate release notes from structured commit messages
+- Scope-based filtering — quickly identify all changes to a specific module or workspace
+- Consistent format across all contributors
+
+**Negative:**
+- Learning curve for contributors unfamiliar with the convention
+- Requires discipline (or linting) to maintain — improperly formatted commits reduce the value of the convention
+- The Husky single-workspace enforcement occasionally requires `--no-verify` for legitimate cross-workspace changes

--- a/docs/decisions/0011-monorepo-npm-workspaces.md
+++ b/docs/decisions/0011-monorepo-npm-workspaces.md
@@ -1,0 +1,53 @@
+# 0011. Monorepo with npm Workspaces over Separate Repos
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP consists of a React SPA frontend, an Express API backend, and shared utilities (constants, type definitions). These packages have interdependencies — the client and server both consume shared types, and changes to shared code must be tested against both consumers. The repository structure must support atomic cross-package changes, unified tooling, and a single `npm install` for the entire project.
+
+## Decision
+
+Use a monorepo with npm workspaces (npm >= 10, shipping with Node 20):
+
+```
+nap/
+  apps/
+    nap-client/     # React SPA (Vite)
+    nap-serv/       # Express API (Node.js)
+  packages/
+    shared/         # Shared utilities and constants
+```
+
+**Root scripts:** `dev`, `build`, `lint`, `test`, `prepare` (Husky installation)
+
+**Workspace scripts:**
+- `npm -w apps/nap-serv run dev` — start Express via nodemon
+- `npm -w apps/nap-client run dev` — start Vite on port 5173
+- `npm install` at the root installs dependencies for all workspaces with hoisted `node_modules`
+
+**Build order:** Server first, then client (sequential).
+
+**Husky integration:** Pre-commit hook enforces single-workspace commits to keep git history cleanly scoped.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Separate repositories (one per package) | Clear ownership boundaries; independent CI/CD pipelines; simpler per-repo tooling | Shared code requires publishing to a registry or git submodules; cross-package changes require coordinated PRs; version drift between repos; no atomic changes |
+| Monorepo with Nx/Turborepo | Sophisticated build caching; dependency graph-aware task runner; remote cache support | Additional tooling complexity; overkill for a two-app monorepo; learning curve for the task runner; npm workspaces are sufficient for NAP's scale |
+
+## Consequences
+
+**Positive:**
+- Shared code in `packages/shared` is consumed directly — no publishing or version synchronization needed
+- Unified tooling — single `package.json` for root scripts, single CI configuration, single Husky setup
+- Atomic cross-package changes — a single commit can update shared types and both consumers simultaneously
+- Single `npm install` — no multi-repo checkout and install choreography
+
+**Negative:**
+- Husky pre-commit hook adds friction by blocking mixed client/server commits — requires `--no-verify` for legitimate cross-workspace changes
+- All developers must clone the entire repository even if they only work on one package
+- CI runs all workspace tests unless scoped manually — not yet an issue at current project size

--- a/docs/decisions/0012-pgvector-sku-matching.md
+++ b/docs/decisions/0012-pgvector-sku-matching.md
@@ -1,0 +1,47 @@
+# 0012. pgvector Embeddings for SKU Matching over Fuzzy String Matching
+
+**Date:** 2025-02-17
+**Status:** accepted
+**Author:** NapSoft
+
+## Context
+
+NAP's procurement module must match vendor-specific SKUs to a master catalog of internal SKUs. Vendors use inconsistent naming — abbreviations, synonyms, different languages, varying word order — making exact string matching impossible. The matching system must handle semantic equivalence (e.g., "SS 304 pipe 2in" matches "2-inch stainless steel 304 pipe") and scale with catalog growth without degrading match quality.
+
+## Decision
+
+Use pgvector with OpenAI `text-embedding-3-large` (3072-dimensional vectors) for semantic similarity matching:
+
+**Tables:**
+- `catalog_skus` — master SKU catalog with an `embedding` column (`vector(3072)`)
+- `vendor_skus` — vendor-specific SKUs with `embedding`, `confidence` (0.0–1.0), and FK to matched catalog SKU
+
+**Custom methods:**
+- `findBySku(vendor_id, vendor_sku)` — lookup by composite key
+- `getUnmatched()` — retrieve vendor SKUs without catalog matches
+- `refreshEmbeddings(vendorSkuBatches)` — batch update embeddings from the OpenAI API
+
+**Audit trail:** `match_review_logs` (in `admin` schema) records all SKU matching decisions (accept/reject/defer) with reviewer, timestamp, and confidence score.
+
+**Matching flow:** Vendor SKU description → embedding → cosine similarity against catalog SKU embeddings → ranked candidates → human review for low-confidence matches.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Fuzzy string matching (Levenshtein, trigram, `pg_trgm`) | No external API dependency; built into PostgreSQL; fast for simple typos | Brittle for abbreviations, synonyms, and cross-language variations; edit distance does not capture semantic meaning; quality degrades as catalog diversity grows |
+| Dedicated ML matching service (external microservice) | Full control over model; can use custom training data | Operational complexity of a separate service; network latency; deployment and scaling overhead; overkill when pgvector handles the workload in-database |
+
+## Consequences
+
+**Positive:**
+- Semantic similarity — embeddings capture meaning, not just character patterns; "SS 304" and "stainless steel 304" are recognized as equivalent
+- Language-agnostic — embeddings work across languages without separate dictionaries or transliteration
+- Scales with catalog size — vector similarity search with pgvector indexes (IVFFlat/HNSW) maintains performance as the catalog grows
+- In-database — no external matching service; queries and matching happen in PostgreSQL alongside transactional data
+
+**Negative:**
+- External API dependency — embedding generation requires calls to OpenAI; rate limits and costs apply
+- 3072-dimensional vectors consume significant storage per row
+- Embedding quality depends on the upstream model — model changes or deprecation require re-embedding the catalog
+- Human review required for low-confidence matches adds a manual step to the procurement workflow

--- a/docs/decisions/0013-four-layer-scoped-rbac.md
+++ b/docs/decisions/0013-four-layer-scoped-rbac.md
@@ -1,0 +1,135 @@
+# 0013. Four-Layer Scoped RBAC
+
+**Date:** 2025-02-18
+**Status:** accepted
+**Author:** NapSoft
+**Supersedes:** [ADR-0004](./0004-three-level-rbac.md) (Three-Level RBAC over Boolean Permissions)
+
+## Context
+
+ADR-0004 introduced a three-level permission model (`none`/`view`/`full`) with hierarchical policy resolution. This answered "can this role use this feature?" effectively, but as NAP grew into a full construction ERP with multi-project organizations, the flat model could not answer critical business questions:
+
+- Can this PM see **their** invoices but not other PMs' invoices?
+- Can a PM see invoices but not client financial details?
+- Can a controller see everything across **all** projects?
+- Can a CFO see reports but not edit anything?
+
+Layer 1 (policies) controls what a role can *do*, but it says nothing about *which data* that role can see, *which record states* are visible, or *which columns* are exposed. A construction firm with 30 projects and 8 project managers cannot give every PM access to every project's financials — scoping is essential.
+
+## Decision
+
+Evolve the permission model to four layers. Each layer **narrows** what the previous layer grants — layers 2-4 never expand access beyond what Layer 1 allows.
+
+| Layer | Question Answered | Mechanism |
+|-------|-------------------|-----------|
+| **1 — Role Policies** | What can this role DO? | Existing `policies` table (unchanged from ADR-0004) |
+| **2 — Data Scope** | HOW MUCH data? | `scope` column on `roles` + `project_members` join table |
+| **3 — Record State Filters** | Which record STATES are visible? | New `state_filters` table |
+| **4 — Field Groups** | Which COLUMNS are visible? | New `field_group_definitions` + `field_group_grants` tables |
+
+### Layer 1 — Role Policies (unchanged)
+
+The `none`/`view`/`full` permission model with hierarchical policy resolution from ADR-0004 remains exactly as designed. The three-level model, the specificity hierarchy (`module::router::action` > `module::router` > `module` > default), and the middleware chain are all retained.
+
+### Layer 2 — Data Scope
+
+The `roles` table gains a `scope` column with three tiers ordered by breadth:
+
+- `all_projects` (default, broadest): Role sees data across the entire tenant — no project filtering.
+- `assigned_companies`: Role only sees data from projects belonging to inter-companies the user is assigned to via `company_members`. The permission loader eagerly resolves both `companyIds` and the corresponding `projectIds` so downstream resources with either `company_id` or `project_id` scope columns can be filtered.
+- `assigned_projects` (narrowest): Role only sees data belonging to projects they are explicitly assigned to via `project_members`.
+
+A `project_members` table maps `(project_id, user_id)` with a `role` label (e.g., `member`, `lead`). A `company_members` table maps `(company_id, user_id)` for company-level scoping.
+
+When a user has multiple roles, the most permissive scope wins using `SCOPE_ORDER`: `all_projects` (2) > `assigned_companies` (1) > `assigned_projects` (0).
+
+### Layer 3 — Record State Filters
+
+A new `state_filters` table stores `(role_id, module, router, visible_statuses[])`. This controls which record states a role can see for a given resource — e.g., a PM may only see AR invoices with status `approved` or `sent`, not `draft` or `void`.
+
+When a user has multiple roles with state filters on the same resource, the **union** of visible statuses applies (most permissive merge).
+
+Empty state filters (no rows) means no filtering — all statuses are visible.
+
+### Layer 4 — Field Groups
+
+Two new tables:
+- `field_group_definitions`: Named groups of columns per resource — e.g., `(module: 'ar', router: 'invoices', group_name: 'summary', columns: ['id','number','status','amount'])`.
+- `field_group_grants`: Assigns field groups to roles.
+
+Definitions marked `is_default = true` are automatically granted to all roles. When a user has multiple roles, the **union** of all granted columns applies.
+
+Empty field group grants (no rows) means all columns are visible — the system is permissive by default.
+
+### Enforcement
+
+- **Middleware (Layer 1):** Unchanged — `rbac(requiredLevel)` gates route access.
+- **Service layer (Layers 2-4):** `ViewController` applies scope, state, and field filters before querying. Controllers opt in via `this.rbacConfig = { module, router, scopeColumn }`.
+- **System role bypass:** `super_user` and `admin` bypass all four layers entirely.
+
+### Permission Canon
+
+The permission loader (`RbacPolicies.js`) returns a "canon" object:
+
+```js
+{
+  caps: { 'projects::::': 'full', 'ar::::': 'view' },              // Layer 1
+  scope: 'assigned_companies',                                      // Layer 2
+  projectIds: ['uuid1', 'uuid2'],                                   // Layer 2
+  companyIds: ['company-uuid1'],                                    // Layer 2
+  stateFilters: { 'ar::ar-invoices': ['approved', 'sent'] },       // Layer 3
+  fieldGroups: { 'ar::ar-invoices': ['id', 'number', 'amount'] },  // Layer 4
+}
+```
+
+This canon is cached in Redis alongside the existing permission hash mechanism (ADR-0007). Hash changes from canon expansion trigger `X-Token-Stale` correctly.
+
+### Tenant Configurability
+
+All roles except `super_user` and `admin` are tenant-configurable. Tenants define their own roles, assign scopes, create state filters, and build field groups. The system seeds sensible defaults (`admin` with `all_projects`, `project_manager` with `assigned_projects`, `controller` with `assigned_companies`) but tenants can modify everything.
+
+### Router Naming Convention
+
+Router names in policies use URL path segments as the canonical convention (e.g., `ar-invoices`, not `invoices`). This ensures consistency between the `withMeta()` annotation on routes and the policy keys stored in the database. The `policy_catalog` table codifies all valid module/router/action combinations as discoverable reference data.
+
+### New Tables
+
+| Table | Schema | Purpose |
+|-------|--------|---------|
+| `project_members` | tenant | Maps users to projects for scope enforcement |
+| `company_members` | tenant | Maps users to inter-companies for `assigned_companies` scope enforcement |
+| `state_filters` | tenant | Restricts visible record statuses per role per resource |
+| `field_group_definitions` | tenant | Defines named column groups per resource |
+| `field_group_grants` | tenant | Assigns column groups to roles |
+| `policy_catalog` | tenant | Registry of valid module/router/action combinations for role configuration UI |
+
+### Modified Tables
+
+| Table | Change |
+|-------|--------|
+| `roles` | Added `scope varchar(32) NOT NULL DEFAULT 'all_projects'` with CHECK constraint (`all_projects`, `assigned_companies`, `assigned_projects`) |
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Keep flat RBAC + add ad-hoc WHERE clauses per controller | No schema changes; quick | Inconsistent enforcement; every controller implements its own scoping logic; easy to miss edge cases |
+| Full ABAC (attribute-based access control) | Maximum flexibility; can express any policy | Massive complexity; requires a policy language (Rego/Cedar); overkill for NAP's current needs; difficult for administrators to configure |
+| Row-level security (RLS) in PostgreSQL | Enforcement at DB layer; impossible to bypass from app code | Tight coupling to DB; harder to test; doesn't solve field-level or state-level filtering; poor DX with pg-schemata's dynamic schema model |
+| Single "scope" enum without project_members table | Simpler — no join table needed | Can't support partial project assignment; only works for "all or nothing" scoping |
+
+## Consequences
+
+**Positive:**
+- Answers all four ERP scoping questions without ABAC complexity
+- Backward compatible — Layer 1 behavior is identical to ADR-0004; layers 2-4 default to permissive (no data filtered) when unconfigured
+- Opt-in enforcement — controllers that don't declare `rbacConfig` are unaffected
+- Tenant-configurable — organizations define their own roles and scoping rules
+- Multi-role merge uses most-permissive strategy (scope: broadest wins; statuses/columns: union) — avoids accidental lockouts
+- Clean separation of concerns: middleware handles Layer 1, service layer handles Layers 2-4
+
+**Negative:**
+- Additional queries during permission loading (roles scope, project_members, state_filters, field_group_grants) — mitigated by Redis caching
+- Controllers must opt in to Layers 2-4 via `rbacConfig` — enforcement is not automatic
+- `project_members` table creates a cross-module dependency (core RBAC referencing projects) — mitigated by ALTER TABLE FK pattern
+- State filter and field group administration will need UI (not yet built)

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,40 @@
+# NAP Business Rules Registry
+
+This directory contains the authoritative source of business rules for the NAP platform.
+Each file covers one domain. Rules are written in plain English and linked to the code
+or database constraints that enforce them.
+
+## How to Use This Registry
+
+- **When implementing a feature:** Check the relevant domain file before writing validation logic.
+- **When changing behavior:** Update the rule here in the same PR as the code change.
+- **When reviewing code:** Reference the rule ID in PR comments (e.g., `BR-RBAC-004`).
+- **When writing code comments:** Cite the rule ID inline (e.g., `// BR-RBAC-004: super_user bypasses all checks`).
+
+## Rule ID Format
+
+`BR-{DOMAIN}-{NUMBER}`
+
+Example: `BR-RBAC-004`, `BR-AP-012`, `BR-GL-003`
+
+## Domain Files
+
+| Domain | File | Rule Count | Status |
+|---|---|---|---|
+| RBAC (Auth & Permissions) | [rbac.md](./rbac.md) | 21 | Active |
+| UI Visibility (cross-cutting) | [ui-visibility.md](./ui-visibility.md) | 1 | Active |
+| AP (Accounts Payable) | ap.md | — | Not started |
+| AR (Accounts Receivable) | ar.md | — | Not started |
+| General Ledger | gl.md | — | Not started |
+| Project / Budget Management | projects.md | — | Not started |
+| Procurement / BOM | procurement.md | — | Not started |
+| Cashflow / Profitability | cashflow.md | — | Not started |
+| Tenant Management | tenants.md | — | Not started |
+
+## Conventions
+
+- Rules are **append-only** within a file — never delete or renumber an existing rule.
+- If a rule changes, mark the old rule as superseded and add a new one.
+- Each rule must state what enforces it (middleware, DB constraint, service layer, etc.).
+- ADR references are included where a rule traces back to an architectural decision.
+- The Changelog at the bottom of each file tracks when rules were added or changed.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -21,7 +21,7 @@ Example: `BR-RBAC-004`, `BR-AP-012`, `BR-GL-003`
 
 | Domain | File | Rule Count | Status |
 |---|---|---|---|
-| RBAC (Auth & Permissions) | [rbac.md](./rbac.md) | 21 | Active |
+| RBAC (Auth & Permissions) | [rbac.md](./rbac.md) | 36 | Active |
 | UI Visibility (cross-cutting) | [ui-visibility.md](./ui-visibility.md) | 1 | Active |
 | AP (Accounts Payable) | ap.md | — | Not started |
 | AR (Accounts Receivable) | ar.md | — | Not started |

--- a/docs/rules/rbac.md
+++ b/docs/rules/rbac.md
@@ -1,0 +1,181 @@
+# Business Rules — RBAC (Role-Based Access Control)
+
+**Domain:** Authentication & Authorization
+**Last Updated:** 2025-02-17
+**Status:** Active — expand with enforcement details as implementation progresses
+**ADR Reference:** ADR-0004 (Three-level RBAC over boolean permissions)
+
+---
+
+## Rule Index
+
+| ID | Rule Summary |
+|---|---|
+| [BR-RBAC-001](#br-rbac-001) | Permission levels are strictly ordered: none < view < full |
+| [BR-RBAC-002](#br-rbac-002) | Policy resolution follows specificity hierarchy (most specific wins) |
+| [BR-RBAC-003](#br-rbac-003) | Default permission is none when no matching policy exists |
+| [BR-RBAC-004](#br-rbac-004) | super_user bypasses all permission checks globally |
+| [BR-RBAC-005](#br-rbac-005) | super_user role can only be assigned to NapSoft tenant users |
+| [BR-RBAC-006](#br-rbac-006) | admin role has full control within tenant, blocked from tenants module |
+| [BR-RBAC-007](#br-rbac-007) | GET/HEAD requests require view level minimum |
+| [BR-RBAC-008](#br-rbac-008) | Mutation requests (POST/PUT/PATCH/DELETE) require full level |
+| [BR-RBAC-009](#br-rbac-009) | Permissions are cached in Redis per user per tenant |
+| [BR-RBAC-010](#br-rbac-010) | JWT ph claim is used to detect stale cached permissions |
+| [BR-RBAC-011](#br-rbac-011) | Tenant context is resolved at request time, not embedded in JWT |
+| [BR-RBAC-012](#br-rbac-012) | Each tenant schema contains its own isolated copy of RBAC tables |
+| [BR-RBAC-013](#br-rbac-013) | super_user cannot be archived |
+| [BR-RBAC-014](#br-rbac-014) | Users cannot archive themselves |
+| [BR-RBAC-015](#br-rbac-015) | Restoring a user requires the parent tenant to be active |
+| [BR-RBAC-016](#br-rbac-016) | Root tenant (NAP) cannot be archived |
+| [BR-RBAC-017](#br-rbac-017) | At most one admin and one billing user per tenant |
+| [BR-RBAC-018](#br-rbac-018) | Email must be globally unique across all active users |
+| [BR-RBAC-019](#br-rbac-019) | User registration must use /register endpoint — standard POST is disabled |
+| [BR-RBAC-020](#br-rbac-020) | Passwords are always bcrypt-hashed — never stored in plaintext |
+| [BR-RBAC-021](#br-rbac-021) | Admin users can only access users belonging to their own tenant |
+
+---
+
+## Rules
+
+### BR-RBAC-001
+**Rule:** Permission levels are strictly ordered: `none` (0) < `view` (1) < `full` (2).
+**Enforcement:** RBAC middleware — `rbac(requiredLevel)` compares numeric level values.
+
+---
+
+### BR-RBAC-002
+**Rule:** Policy resolution follows a specificity hierarchy. The most specific matching policy wins.
+Resolution order:
+1. `module::router::action` (e.g., `ar::invoices::approve`)
+2. `module::router::` (e.g., `ar::invoices::`)
+3. `module::::` (e.g., `ar::::`)
+4. Default: `none`
+
+**Enforcement:** Permission resolver in `authRedis` middleware.
+
+---
+
+### BR-RBAC-003
+**Rule:** If no policy matches the requested `module::router::action`, the effective permission defaults to `none`. Access is denied.
+**Enforcement:** Policy resolution fallback in permission loader.
+
+---
+
+### BR-RBAC-004
+**Rule:** Users with the `super_user` role bypass all permission checks on all routes globally.
+**Enforcement:** RBAC middleware — short-circuits permission check when `role === 'super_user'`.
+
+---
+
+### BR-RBAC-005
+**Rule:** The `super_user` role can only be assigned to users belonging to the NapSoft tenant (`tenant_code = 'NAP'`).
+**Enforcement:** Server-side validation in user registration and role assignment endpoints.
+
+---
+
+### BR-RBAC-006
+**Rule:** The `admin` role grants full access within a tenant but is explicitly blocked from the `tenants` module (NapSoft-only operations).
+**Enforcement:** `requireNapsoftTenant` middleware on all `/api/tenants/` routes.
+**UI Behavior:** The "Manage Tenants" sidebar navigation item is not rendered for any user who is not a NapSoft employee. Visibility is determined by `isNapsoftEmployee()` checked against `AuthContext` — not by permission level. See [UI-VIS-001](./ui-visibility.md#ui-vis-001).
+
+---
+
+### BR-RBAC-007
+**Rule:** GET and HEAD requests require a minimum permission level of `view`.
+**Enforcement:** RBAC middleware default — `requiredLevel` defaults to `view` for read operations.
+
+---
+
+### BR-RBAC-008
+**Rule:** Mutation requests (POST, PUT, PATCH, DELETE) require a minimum permission level of `full`.
+**Enforcement:** RBAC middleware default — `requiredLevel` defaults to `full` for write operations.
+
+---
+
+### BR-RBAC-009
+**Rule:** Resolved permission sets are cached in Redis keyed by `perm:{userId}:{tenantCode}`. Cache is invalidated when roles or policies change.
+**Enforcement:** `authRedis` middleware reads from cache; cache is invalidated on role/policy mutation.
+
+---
+
+### BR-RBAC-010
+**Rule:** The JWT contains a `ph` (permissions hash) claim — a SHA-256 hash of the user's current policy set. If the cached permissions hash diverges from the JWT `ph` claim, the server responds with `X-Token-Stale: 1` to signal the client to refresh.
+**Enforcement:** `authRedis` middleware — ETag comparison on each request.
+
+---
+
+### BR-RBAC-011
+**Rule:** Tenant context (`tenant_code`, `schema_name`) is NOT embedded in the JWT. It is resolved at request time via the `x-tenant-code` header, Redis cache, and database lookup.
+**Enforcement:** `authRedis` middleware — see ADR-0003.
+
+---
+
+### BR-RBAC-012
+**Rule:** Each tenant's RBAC tables (`roles`, `role_members`, `policies`) live within that tenant's own PostgreSQL schema. There is no shared RBAC table across tenants.
+**Enforcement:** pg-schemata schema isolation — see ADR-0001.
+
+---
+
+### BR-RBAC-013
+**Rule:** A user with the `super_user` role cannot be archived.
+**Enforcement:** Server-side guard in the archive user endpoint.
+
+---
+
+### BR-RBAC-014
+**Rule:** A user cannot archive their own account.
+**Enforcement:** Server-side guard in the archive user endpoint — compares `req.user.id` against target user ID.
+
+---
+
+### BR-RBAC-015
+**Rule:** Restoring an archived user requires the user's parent tenant to be in `active` status.
+**Enforcement:** Server-side check in the restore user endpoint.
+
+---
+
+### BR-RBAC-016
+**Rule:** The root NapSoft tenant (`tenant_code = 'NAP'`) cannot be archived or deleted under any circumstances.
+**Enforcement:** Server-side guard in the archive tenant endpoint — returns 403.
+
+---
+
+### BR-RBAC-017
+**Rule:** At most one user per tenant may hold `tenant_role = 'admin'` and at most one may hold `tenant_role = 'billing'` at any time.
+**Enforcement:** Unique partial index on `(tenant_id, tenant_role) WHERE tenant_role IS NOT NULL` in `admin.nap_users`.
+
+---
+
+### BR-RBAC-018
+**Rule:** Email addresses must be globally unique across all active users. The same email cannot be registered to two active accounts, even across different tenants.
+**Enforcement:** Partial unique index on `email WHERE deactivated_at IS NULL` in `admin.nap_users`.
+
+---
+
+### BR-RBAC-019
+**Rule:** Users must be created via the `/register` endpoint. The standard POST endpoint for `nap_users` is disabled. Registration collects: email, user_name, full_name, password, phones (optional array), addresses (optional array), tenant_role (optional), tax_id (optional), notes (optional).
+**Enforcement:** Standard POST route not implemented for `nap_users`.
+
+---
+
+### BR-RBAC-020
+**Rule:** Passwords are never stored in plaintext. All passwords are hashed with bcrypt before storage, both on registration and on XLS import.
+**Enforcement:** Registration service and import handler — bcrypt hash applied before any `INSERT`.
+
+---
+
+### BR-RBAC-021
+**Rule:** An admin user can only read, create, modify, or archive users belonging to their own tenant. Cross-tenant user access is not permitted regardless of role.
+**Enforcement:** Structurally enforced by schema-per-tenant isolation (ADR-0001) — queries run within the tenant's own schema. Additionally enforced at the service layer by tenant context resolved from the request via `authRedis` middleware.
+
+> **Note:** This rule is implied by the architecture but stated explicitly here because it is non-obvious to developers unfamiliar with the schema isolation model. A developer working on user queries should not need to add a `WHERE tenant_id = ?` clause — but they should understand *why* it isn't needed.
+
+---
+
+## Changelog
+
+| Date | Change | Author |
+|---|---|---|
+| 2025-02-17 | Initial registry created — 20 rules from PRD §3.1 and §3.2 | NapSoft |
+| 2025-02-17 | BR-RBAC-006 updated — added UI Behavior note and link to ui-visibility.md | NapSoft |
+| 2025-02-17 | BR-RBAC-021 added — tenant scoping for admin user queries | NapSoft |

--- a/docs/rules/rbac.md
+++ b/docs/rules/rbac.md
@@ -1,9 +1,9 @@
 # Business Rules — RBAC (Role-Based Access Control)
 
 **Domain:** Authentication & Authorization
-**Last Updated:** 2025-02-17
-**Status:** Active — expand with enforcement details as implementation progresses
-**ADR Reference:** ADR-0004 (Three-level RBAC over boolean permissions)
+**Last Updated:** 2026-02-20
+**Status:** Active — four-layer scoped model implemented
+**ADR Reference:** ADR-0013 (Four-layer scoped RBAC) — supersedes ADR-0004
 
 ---
 
@@ -32,6 +32,33 @@
 | [BR-RBAC-019](#br-rbac-019) | User registration must use /register endpoint — standard POST is disabled |
 | [BR-RBAC-020](#br-rbac-020) | Passwords are always bcrypt-hashed — never stored in plaintext |
 | [BR-RBAC-021](#br-rbac-021) | Admin users can only access users belonging to their own tenant |
+| [BR-RBAC-022](#br-rbac-022) | RBAC uses four layers: policies, scope, state filters, field groups |
+| [BR-RBAC-023](#br-rbac-023) | Layers 2-4 only narrow access — they never expand beyond Layer 1 |
+| [BR-RBAC-024](#br-rbac-024) | Data scope is a property of the role: all_projects, assigned_companies, or assigned_projects |
+| [BR-RBAC-025](#br-rbac-025) | assigned_projects scope restricts data to the user's project_members entries |
+| [BR-RBAC-026](#br-rbac-026) | State filters restrict visible record statuses per role per resource |
+| [BR-RBAC-027](#br-rbac-027) | Field groups restrict visible columns per role per resource |
+| [BR-RBAC-028](#br-rbac-028) | Default field group definitions (is_default = true) are granted to all roles |
+| [BR-RBAC-029](#br-rbac-029) | Multi-role scope merge: most permissive scope wins (three-tier hierarchy) |
+| [BR-RBAC-030](#br-rbac-030) | Multi-role state filter merge: union of visible statuses |
+| [BR-RBAC-031](#br-rbac-031) | Multi-role field group merge: union of granted columns |
+| [BR-RBAC-032](#br-rbac-032) | super_user and admin bypass all four RBAC layers |
+| [BR-RBAC-033](#br-rbac-033) | Layers 2-4 are opt-in per controller via rbacConfig |
+| [BR-RBAC-034](#br-rbac-034) | Empty state filters or field groups mean no restriction (permissive default) |
+| [BR-RBAC-035](#br-rbac-035) | Cache invalidation on scope/filter/grant changes invalidates affected users |
+| [BR-RBAC-036](#br-rbac-036) | All roles except super_user and admin are tenant-configurable |
+| [BR-RBAC-037](#br-rbac-037) | Data scope has three tiers: all_projects > assigned_companies > assigned_projects |
+| [BR-RBAC-038](#br-rbac-038) | assigned_companies scope restricts data to projects belonging to the user's assigned inter-companies |
+| [BR-RBAC-039](#br-rbac-039) | Multi-role scope hierarchy: all_projects beats assigned_companies beats assigned_projects |
+| [BR-RBAC-040](#br-rbac-040) | The policy_catalog table provides a discoverable registry of valid module/router/action combinations |
+| [BR-RBAC-041](#br-rbac-041) | Router names in policies use URL path segments as the canonical convention |
+| [BR-RBAC-042](#br-rbac-042) | Changes to company_members must invalidate affected users' Redis permission cache |
+| [BR-RBAC-043](#br-rbac-043) | Cross-tenant access is restricted to NapSoft users via x-tenant-code header |
+| [BR-RBAC-044](#br-rbac-044) | User impersonation requires NapSoft tenant membership and is audit-logged |
+| [BR-RBAC-045](#br-rbac-045) | Tenants module routes require both NapSoft membership AND RBAC capability |
+| [BR-RBAC-046](#br-rbac-046) | Employee-driven user lifecycle: is_app_user toggle on employees controls nap_users creation |
+| [BR-RBAC-047](#br-rbac-047) | RBAC admin role is auto-assigned to tenant creator on tenant provisioning |
+| [BR-RBAC-048](#br-rbac-048) | Impersonation sessions are tracked via Redis and bounded to one active session per user |
 
 ---
 
@@ -46,8 +73,8 @@
 ### BR-RBAC-002
 **Rule:** Policy resolution follows a specificity hierarchy. The most specific matching policy wins.
 Resolution order:
-1. `module::router::action` (e.g., `ar::invoices::approve`)
-2. `module::router::` (e.g., `ar::invoices::`)
+1. `module::router::action` (e.g., `ar::ar-invoices::approve`)
+2. `module::router::` (e.g., `ar::ar-invoices::`)
 3. `module::::` (e.g., `ar::::`)
 4. Default: `none`
 
@@ -74,9 +101,9 @@ Resolution order:
 ---
 
 ### BR-RBAC-006
-**Rule:** The `admin` role grants full access within a tenant but is explicitly blocked from the `tenants` module (NapSoft-only operations).
-**Enforcement:** `requireNapsoftTenant` middleware on all `/api/tenants/` routes.
-**UI Behavior:** The "Manage Tenants" sidebar navigation item is not rendered for any user who is not a NapSoft employee. Visibility is determined by `isNapsoftEmployee()` checked against `AuthContext` — not by permission level. See [UI-VIS-001](./ui-visibility.md#ui-vis-001).
+**Rule:** The `admin` role grants full access within a tenant. For the `tenants` module, access requires both NapSoft membership AND an RBAC capability (`tenants::tenants::full`). The `admin` role is seeded with this capability, so NapSoft admins can manage tenants while non-NapSoft admins are blocked by `requireNapsoftTenant`.
+**Enforcement:** Dual gate on `/api/tenants/v1/tenants/` routes: `requireNapsoftTenant` middleware + `withMeta({ module: 'tenants', router: 'tenants' })` + `rbac()`. See also [BR-RBAC-045](#br-rbac-045).
+**UI Behavior:** The "Settings" sidebar navigation item (formerly "Manage Tenants") is not rendered for any user who is not a NapSoft employee. Visibility is determined by the `isNapSoftUser` flag in `AuthContext` (compares `tenant_code` against `VITE_NAPSOFT_TENANT`) — not by permission level. See [UI-VIS-001](./ui-visibility.md#ui-vis-001).
 
 ---
 
@@ -172,6 +199,167 @@ Resolution order:
 
 ---
 
+### BR-RBAC-022
+**Rule:** RBAC enforcement uses four layers: (1) Role Policies — what a role can do, (2) Data Scope — how much data the role sees, (3) Record State Filters — which record statuses are visible, (4) Field Groups — which columns are visible.
+**Enforcement:** Layer 1 via RBAC middleware; Layers 2-4 via `ViewController._applyRbacFilters()`.
+**ADR:** ADR-0013
+
+---
+
+### BR-RBAC-023
+**Rule:** Layers 2-4 only narrow the data set. They can never grant access to data, records, or columns that Layer 1 does not already permit. If Layer 1 denies access (`none`), Layers 2-4 are not evaluated.
+**Enforcement:** Middleware gate (Layer 1) runs before service-layer filters (Layers 2-4).
+
+---
+
+### BR-RBAC-024
+**Rule:** Each role has a `scope` property: `all_projects` (default), `assigned_companies`, or `assigned_projects`. This determines the breadth of data the role can see.
+**Enforcement:** `roles.scope` column with CHECK constraint. Stored in the permission canon and enforced at query time.
+
+---
+
+### BR-RBAC-025
+**Rule:** When `scope = 'assigned_projects'`, the user only sees data from projects they are explicitly assigned to via the `project_members` table. The `project_members` table maps `(project_id, user_id)` with a unique constraint on the pair.
+**Enforcement:** `ViewController._applyRbacFilters()` adds a `WHERE scopeColumn IN (projectIds)` condition when scope is `assigned_projects`.
+
+---
+
+### BR-RBAC-026
+**Rule:** State filters restrict which record statuses are visible to a role for a given resource. A `state_filters` row specifies `(role_id, module, router, visible_statuses[])`. Records with a status not in the visible list are excluded from query results.
+**Enforcement:** `ViewController._applyRbacFilters()` adds a `WHERE status IN (visibleStatuses)` condition.
+
+---
+
+### BR-RBAC-027
+**Rule:** Field groups restrict which columns are returned for a given resource. A field group definition lists a set of column names. A field group grant assigns a definition to a role. Only columns from granted field groups are included in query results.
+**Enforcement:** `ViewController._applyRbacFilters()` restricts `columnWhitelist`; `_filterRecordFields()` strips disallowed fields from single-record reads.
+
+---
+
+### BR-RBAC-028
+**Rule:** Field group definitions marked `is_default = true` are automatically granted to all roles, regardless of explicit `field_group_grants` rows. This ensures baseline column visibility without requiring a grant for every role.
+**Enforcement:** Permission loader (`RbacPolicies.js`) includes `is_default = true` definitions in the column set for every role.
+
+---
+
+### BR-RBAC-029
+**Rule:** When a user holds multiple roles, the effective scope is the **most permissive** across all roles. The hierarchy is: `all_projects` (broadest) > `assigned_companies` > `assigned_projects` (narrowest). If any role grants `all_projects`, the user sees all data regardless of other roles' scopes.
+**Enforcement:** Permission loader merges scopes using `SCOPE_ORDER` — highest value wins (`all_projects: 2`, `assigned_companies: 1`, `assigned_projects: 0`).
+
+---
+
+### BR-RBAC-030
+**Rule:** When a user holds multiple roles with state filters on the same resource, the effective visible statuses are the **union** of all roles' `visible_statuses` arrays for that resource.
+**Enforcement:** Permission loader merges state filters with `Set` union per `module::router` key.
+
+---
+
+### BR-RBAC-031
+**Rule:** When a user holds multiple roles with field group grants on the same resource, the effective visible columns are the **union** of all granted field groups' column lists for that resource.
+**Enforcement:** Permission loader merges field group columns with `Set` union per `module::router` key.
+
+---
+
+### BR-RBAC-032
+**Rule:** `super_user` and `admin` bypass all four RBAC layers entirely. They see all data, all statuses, and all columns with no scope restrictions. *(Supersedes the scope of BR-RBAC-004 and BR-RBAC-006 for Layers 2-4.)*
+**Enforcement:** `ViewController._applyRbacFilters()` checks `BYPASS_ROLES` set and returns early.
+
+---
+
+### BR-RBAC-033
+**Rule:** Layers 2-4 enforcement is opt-in per controller. A controller must declare `this.rbacConfig = { module, router, scopeColumn }` for scope, state, and field filtering to be applied. Controllers without `rbacConfig` are unaffected — only Layer 1 middleware applies.
+**Enforcement:** `ViewController._applyRbacFilters()` returns early if `this.rbacConfig` is null.
+
+---
+
+### BR-RBAC-034
+**Rule:** When no `state_filters` rows exist for a role on a given resource, all record statuses are visible. When no `field_group_grants` (and no `is_default` definitions) exist for a role on a given resource, all columns are visible. The system defaults to permissive when Layers 3-4 are unconfigured.
+**Enforcement:** Permission loader returns empty objects (`{}`) for stateFilters and fieldGroups when no data exists. `ViewController` skips filtering when the corresponding value is `null` or absent.
+
+---
+
+### BR-RBAC-035
+**Rule:** Changes to `project_members`, `company_members`, `state_filters`, `field_group_grants`, `field_group_definitions`, or `roles.scope` must invalidate the affected users' Redis permission cache so that the updated canon is rebuilt on the next request.
+**Enforcement:** `rbacCacheInvalidation.js` — `invalidateUserPermissions()` clears a single user's cache; `invalidateRolePermissions()` finds all users with a given role and invalidates each.
+
+---
+
+### BR-RBAC-036
+**Rule:** All tenant roles except `super_user` and `admin` are fully tenant-configurable. Tenants may create, modify, and delete roles, assign scopes, define state filters, and build field groups. `super_user` and `admin` are system roles with `is_system = true` and `is_immutable = true`.
+**Enforcement:** Seed logic marks `super_user` and `admin` as system/immutable. Role management endpoints should reject modifications to immutable roles.
+
+### BR-RBAC-037
+**Rule:** Data scope has three tiers ordered by breadth: `all_projects` (broadest) > `assigned_companies` > `assigned_projects` (narrowest). This hierarchy determines the data visibility for each role.
+**Enforcement:** `SCOPE_ORDER` constant in `RbacPolicies.js` — `{ assigned_projects: 0, assigned_companies: 1, all_projects: 2 }`.
+
+---
+
+### BR-RBAC-038
+**Rule:** When `scope = 'assigned_companies'`, the user only sees data from projects belonging to inter-companies they are explicitly assigned to via the `company_members` table. The permission loader eagerly resolves both `companyIds` (from `company_members`) and `projectIds` (projects belonging to those companies) so downstream resources with either `company_id` or `project_id` scope columns can be filtered.
+**Enforcement:** `RbacPolicies.js` queries `company_members` for the user's companies, then resolves `projectIds` from the `projects` table where `company_id IN (companyIds)`. `ViewController._applyRbacFilters()` uses the appropriate ID list based on `rbacConfig.scopeColumn`.
+
+---
+
+### BR-RBAC-039
+**Rule:** Multi-role scope hierarchy: `all_projects` beats `assigned_companies` beats `assigned_projects`. When a user holds multiple roles, the broadest scope wins. If any role grants `all_projects`, the user sees all data. If the broadest scope is `assigned_companies`, the user sees data from their assigned companies' projects.
+**Enforcement:** Permission loader uses `SCOPE_ORDER` to select the winning scope across all roles.
+
+---
+
+### BR-RBAC-040
+**Rule:** The `policy_catalog` table provides a discoverable registry of all valid `module/router/action` combinations. This is seed-only reference data used by the role configuration UI to present valid options when building policies. It has no runtime enforcement role — it is purely for discovery.
+**Enforcement:** Seeded via `seed_policy_catalog.js`. No audit fields, no tenant_code — static reference data shared across all tenants.
+
+---
+
+### BR-RBAC-041
+**Rule:** Router names in policies use URL path segments as the canonical convention (e.g., `ar-invoices`, not `invoices`). This ensures consistency between the `withMeta()` annotation on routes and the policy keys stored in the database.
+**Enforcement:** Convention enforced by `seed_policy_catalog.js` entries, `withMeta()` annotations on routers, and policy seed data.
+
+---
+
+### BR-RBAC-042
+**Rule:** Changes to `company_members` must invalidate the affected users' Redis permission cache so that the updated `companyIds` and `projectIds` are rebuilt on the next request.
+**Enforcement:** Same mechanism as BR-RBAC-035 — `invalidateUserPermissions()` called when `company_members` rows are added, removed, or modified.
+
+---
+
+### BR-RBAC-043
+**Rule:** Cross-tenant access is restricted to NapSoft users. When a request includes an `x-tenant-code` header that differs from the user's home tenant (from JWT or DB), only users whose home tenant matches the `NAPSOFT_TENANT` env var (default `'NAP'`) are permitted to assume the requested tenant context. Non-NapSoft users silently fall back to their home tenant.
+**Enforcement:** `authRedis` middleware — `resolveTenantContext()` validates cross-tenant requests and sets `is_cross_tenant` flag on `req.user`.
+
+---
+
+### BR-RBAC-044
+**Rule:** NapSoft users can impersonate any user in any tenant. Impersonation swaps `req.user` and `req.ctx` to the target user's identity and permissions for the duration of the session. Every impersonation session is recorded in `admin.impersonation_logs` with `impersonator_id`, `target_user_id`, `target_tenant_code`, `reason`, `started_at`, and `ended_at`. The impersonator's real identity is preserved on the impersonated request as `req.user.impersonated_by`.
+**Enforcement:** `authRedis` middleware reads `imp:{userId}` Redis key. Impersonation endpoints require `requireNapsoftTenant` middleware. Audit log insertion occurs in `adminController.startImpersonation()`.
+
+---
+
+### BR-RBAC-045
+**Rule:** Tenants module routes (`/api/tenants/v1/tenants/*`) require both NapSoft membership (via `requireNapsoftTenant` middleware) AND an RBAC capability on `tenants::tenants` (via `withMeta` + `rbac` middleware). This dual gate ensures that even within NapSoft, only users with the appropriate RBAC role (e.g., `admin`) can manage tenants. The `admin` role is seeded with `tenants::tenants::full` and `tenants::nap-users::full` policies.
+**Enforcement:** `tenantsRouter.js` applies `[requireNapsoftTenant, withMeta({ module: 'tenants', router: 'tenants' }), rbac()]` middleware chain. BR-RBAC-006 updated — admin role is no longer blanket-blocked from tenants module; access is now policy-driven.
+
+---
+
+### BR-RBAC-046
+**Rule:** App user accounts (`admin.nap_users`) are driven by the employee entity. Employees have an `is_app_user` boolean and `email` field. When `is_app_user` is toggled on, a corresponding `nap_users` record is created with status `'invited'` and a temporary password. When toggled off, the `nap_users` record is deactivated. The `nap_users.employee_id` FK links back to the originating employee.
+**Enforcement:** `employeesController.js` handles the `is_app_user` lifecycle in create and update methods.
+
+---
+
+### BR-RBAC-047
+**Rule:** When a new tenant is provisioned, the RBAC seed automatically creates `admin` and `project_manager` roles with default policies. The user who created the tenant is auto-assigned the `admin` role as their primary role via `role_members`. This ensures the creating user has immediate access to manage the new tenant's RBAC configuration.
+**Enforcement:** `seed_rbac.js` — inserts `role_members` row linking `createdBy` user to the `admin` role with `is_primary: true`.
+
+---
+
+### BR-RBAC-048
+**Rule:** Only one impersonation session may be active per impersonator at any time. Starting a new impersonation while one is already active returns `409 Conflict`. The impersonator must explicitly exit the current session before starting a new one. Active sessions are tracked via `imp:{userId}` Redis keys.
+**Enforcement:** `adminController.startImpersonation()` checks for existing `imp:{userId}` key before creating a new session. `adminController.endImpersonation()` deletes the key and timestamps `ended_at` in the audit log.
+
+---
+
 ## Changelog
 
 | Date | Change | Author |
@@ -179,3 +367,12 @@ Resolution order:
 | 2025-02-17 | Initial registry created — 20 rules from PRD §3.1 and §3.2 | NapSoft |
 | 2025-02-17 | BR-RBAC-006 updated — added UI Behavior note and link to ui-visibility.md | NapSoft |
 | 2025-02-17 | BR-RBAC-021 added — tenant scoping for admin user queries | NapSoft |
+| 2025-02-18 | ADR reference updated from ADR-0004 to ADR-0013 (four-layer scoped RBAC) | NapSoft |
+| 2025-02-18 | BR-RBAC-022 through BR-RBAC-036 added — Layers 2-4 (scope, state filters, field groups), multi-role merge semantics, opt-in enforcement, cache invalidation, tenant configurability | NapSoft |
+| 2025-02-18 | BR-RBAC-004/006 scope expanded by BR-RBAC-032 — super_user and admin now bypass all four layers, not just Layer 1 | NapSoft |
+| 2026-02-20 | BR-RBAC-024 updated — scope now includes `assigned_companies` (three-tier hierarchy) | NapSoft |
+| 2026-02-20 | BR-RBAC-029 updated — three-tier scope merge with SCOPE_ORDER | NapSoft |
+| 2026-02-20 | BR-RBAC-035 updated — added `company_members` to cache invalidation list | NapSoft |
+| 2026-02-20 | BR-RBAC-037 through BR-RBAC-042 added — three-tier scope hierarchy, assigned_companies, policy_catalog, router naming convention, company_members cache invalidation | NapSoft |
+| 2026-02-21 | BR-RBAC-006 updated — admin role now uses RBAC capability `tenants::tenants` instead of blanket block; dual gate with requireNapsoftTenant | NapSoft |
+| 2026-02-21 | BR-RBAC-043 through BR-RBAC-048 added — cross-tenant access, impersonation with audit logging, tenants RBAC gate, employee-driven user lifecycle, auto-role assignment, impersonation session uniqueness | NapSoft |

--- a/docs/rules/ui-visibility.md
+++ b/docs/rules/ui-visibility.md
@@ -1,9 +1,9 @@
 # Business Rules — UI Visibility
 
 **Domain:** Cross-cutting — Frontend permission-driven rendering
-**Last Updated:** 2025-02-17
+**Last Updated:** 2026-02-21
 **Status:** Active — add a rule here whenever a UI element is conditionally shown, hidden, or disabled based on permissions, role, or tenant context
-**ADR Reference:** ADR-0004 (Three-level RBAC over boolean permissions)
+**ADR Reference:** [ADR-0013](../decisions/0013-four-layer-scoped-rbac.md) (supersedes [ADR-0004](../decisions/0004-three-level-rbac.md))
 
 ---
 
@@ -34,20 +34,59 @@ of a permission rule — always pair a UI-VIS rule with its corresponding BR-RBA
 
 | ID | Element | Condition | Domain Rule |
 |---|---|---|---|
-| [UI-VIS-001](#ui-vis-001) | "Manage Tenants" sidebar nav item | Hidden unless `isNapsoftEmployee()` | BR-RBAC-006 |
+| [UI-VIS-001](#ui-vis-001) | "Settings" sidebar nav item | Hidden unless `isNapSoftUser` | BR-RBAC-006 |
+| [UI-VIS-002](#ui-vis-002) | TenantPicker dropdown in TenantBar | Shown only for NapSoft users (`isNapSoftUser`) | BR-RBAC-043 |
+| [UI-VIS-003](#ui-vis-003) | "Impersonate User..." menu item in TenantBar | Shown only for NapSoft users, hidden during active impersonation | BR-RBAC-044 |
+| [UI-VIS-004](#ui-vis-004) | ImpersonationBanner above TenantBar | Shown only during active impersonation session | BR-RBAC-044, BR-RBAC-048 |
 
 ---
 
 ## Rules
 
 ### UI-VIS-001
-**Element:** "Manage Tenants" sidebar navigation item
+**Element:** "Settings" sidebar navigation item
 **Location:** Sidebar — primary navigation group
-**Condition:** Rendered only when `isNapsoftEmployee()` returns `true` for the current user
-**How determined:** `isNapsoftEmployee()` checks `tenant_code`, company name, or email domain against env vars (`NAPSOFT_TENANT`, `VITE_NAPSOFT_COMPANY`, `VITE_NAPSOFT_EMAIL_DOMAIN`) via `AuthContext`
+**Condition:** Rendered only when `isNapSoftUser` is `true` in `AuthContext`
+**How determined:** `isNapSoftUser` is a computed flag in `AuthContext` — checks user's `tenant_code` against `import.meta.env.VITE_NAPSOFT_TENANT`
 **When hidden:** All non-NapSoft tenant users — including tenant `admin` roles
-**Server enforcement:** `requireNapsoftTenant` middleware on all `/api/tenants/` routes
-**Domain rule:** [BR-RBAC-006](./rbac.md#br-rbac-006)
+**Server enforcement:** `requireNapsoftTenant` middleware on all `/api/tenants/` routes; RBAC middleware requires `tenants::tenants` capability
+**Domain rule:** [BR-RBAC-006](./rbac.md#br-rbac-006), [BR-RBAC-045](./rbac.md#br-rbac-045)
+
+---
+
+### UI-VIS-002
+**Element:** TenantPicker dropdown in TenantBar
+**Location:** TenantBar — left side, replaces the static tenant code chip
+**Condition:** Rendered only when `isNapSoftUser` is `true` in `AuthContext` AND no impersonation session is active
+**How determined:** `isNapSoftUser` is a computed flag in `AuthContext` — checks user's `tenant_code` against `import.meta.env.VITE_NAPSOFT_TENANT`
+**When hidden:** All non-NapSoft users see a static `<Chip>` with their tenant code. During active impersonation, NapSoft users also see the static chip (picker is replaced).
+**Behavior:** Fetches the list of active tenants from `GET /tenants/v1/admin/schemas`. Selecting a tenant calls `assumeTenant()` in `AuthContext`, which sets the `x-tenant-code` header on subsequent API requests. Selecting "Exit" resets to the user's home tenant.
+**Server enforcement:** `requireNapsoftTenant` middleware on `/admin/schemas`; `authRedis` validates that only NapSoft users may send a cross-tenant `x-tenant-code` header — non-NapSoft users' headers are silently ignored
+**Domain rule:** [BR-RBAC-043](./rbac.md#br-rbac-043)
+
+---
+
+### UI-VIS-003
+**Element:** "Impersonate User..." menu item in TenantBar user dropdown
+**Location:** TenantBar → Avatar dropdown menu, below "Change Password", above "Sign Out"
+**Condition:** Rendered only when `isNapSoftUser` is `true` AND `impersonation?.active` is `false`
+**How determined:** Both flags come from `AuthContext`. `isNapSoftUser` checks the home tenant; `impersonation.active` is hydrated from the `/auth/me` response.
+**When hidden:** All non-NapSoft users never see this menu item. NapSoft users in an active impersonation session also do not see it (they must exit impersonation via the `ImpersonationBanner` first).
+**Behavior:** Opens `<ImpersonateDialog>` — a two-step modal: (1) select target tenant via Autocomplete, (2) select target user within that tenant, optionally enter a reason. Submitting calls `POST /tenants/v1/admin/impersonate` and refreshes the auth context.
+**Server enforcement:** `requireNapsoftTenant` middleware on `/admin/impersonate`; impersonation state stored in Redis (`imp:{userId}`) and audited in `admin.impersonation_logs`
+**Domain rule:** [BR-RBAC-044](./rbac.md#br-rbac-044)
+
+---
+
+### UI-VIS-004
+**Element:** ImpersonationBanner above TenantBar
+**Location:** Top of `LayoutShell`, rendered above `<TenantBar>`
+**Condition:** Rendered only when `impersonation?.active` is `true` in `AuthContext`
+**How determined:** The `/auth/me` response includes an `impersonation` object with `{ active: true, impersonated_by }` when an impersonation session is live. `AuthContext` hydrates this on login and after `refreshUser()`.
+**When hidden:** Hidden for all users when no impersonation session is active — including NapSoft users who are not currently impersonating anyone.
+**Behavior:** Displays an amber/warning banner showing "Impersonating: {email} ({tenant_code})" with an "Exit Impersonation" button. Clicking the button calls `POST /tenants/v1/admin/exit-impersonation`, which clears the Redis key and timestamps the audit log, then refreshes the auth context to restore the original user identity.
+**Server enforcement:** Impersonation session uniqueness enforced by partial index on `impersonation_logs (impersonator_id) WHERE ended_at IS NULL`; exit endpoint validates the Redis key exists before clearing
+**Domain rule:** [BR-RBAC-044](./rbac.md#br-rbac-044), [BR-RBAC-048](./rbac.md#br-rbac-048)
 
 ---
 
@@ -56,3 +95,5 @@ of a permission rule — always pair a UI-VIS rule with its corresponding BR-RBA
 | Date | Change | Author |
 |---|---|---|
 | 2025-02-17 | File created — UI-VIS-001 from BR-RBAC-006 discussion | NapSoft |
+| 2026-02-21 | Updated UI-VIS-001 label from "Manage Tenants" to "Settings", added BR-RBAC-045 reference | NapSoft |
+| 2026-02-21 | Added UI-VIS-002 (TenantPicker), UI-VIS-003 (Impersonate menu), UI-VIS-004 (ImpersonationBanner) | NapSoft |

--- a/docs/rules/ui-visibility.md
+++ b/docs/rules/ui-visibility.md
@@ -1,0 +1,58 @@
+# Business Rules — UI Visibility
+
+**Domain:** Cross-cutting — Frontend permission-driven rendering
+**Last Updated:** 2025-02-17
+**Status:** Active — add a rule here whenever a UI element is conditionally shown, hidden, or disabled based on permissions, role, or tenant context
+**ADR Reference:** ADR-0004 (Three-level RBAC over boolean permissions)
+
+---
+
+## Purpose
+
+UI visibility rules document when and why navigation items, buttons, pages, and form
+fields are conditionally rendered or disabled in the frontend. These rules are business
+rules — not implementation details — because they define what users are allowed to *see*,
+not just what the server will accept.
+
+Every permission-driven UI behavior should have an entry here so that:
+- Frontend developers know the intended behavior before touching a component
+- Backend developers understand the full surface area of a permission change
+- QA can verify both the server enforcement and the UI enforcement independently
+
+---
+
+## Visibility vs. Access
+
+UI visibility is a UX concern — hiding elements the user cannot use reduces confusion.
+It is **not** a security control. The server enforces access via middleware on every
+request regardless of what the UI renders. Never rely on hidden UI as the sole enforcement
+of a permission rule — always pair a UI-VIS rule with its corresponding BR-RBAC rule.
+
+---
+
+## Rule Index
+
+| ID | Element | Condition | Domain Rule |
+|---|---|---|---|
+| [UI-VIS-001](#ui-vis-001) | "Manage Tenants" sidebar nav item | Hidden unless `isNapsoftEmployee()` | BR-RBAC-006 |
+
+---
+
+## Rules
+
+### UI-VIS-001
+**Element:** "Manage Tenants" sidebar navigation item
+**Location:** Sidebar — primary navigation group
+**Condition:** Rendered only when `isNapsoftEmployee()` returns `true` for the current user
+**How determined:** `isNapsoftEmployee()` checks `tenant_code`, company name, or email domain against env vars (`NAPSOFT_TENANT`, `VITE_NAPSOFT_COMPANY`, `VITE_NAPSOFT_EMAIL_DOMAIN`) via `AuthContext`
+**When hidden:** All non-NapSoft tenant users — including tenant `admin` roles
+**Server enforcement:** `requireNapsoftTenant` middleware on all `/api/tenants/` routes
+**Domain rule:** [BR-RBAC-006](./rbac.md#br-rbac-006)
+
+---
+
+## Changelog
+
+| Date | Change | Author |
+|---|---|---|
+| 2025-02-17 | File created — UI-VIS-001 from BR-RBAC-006 discussion | NapSoft |


### PR DESCRIPTION
## Summary
- **PRD schema redesign:** Stripped `nap_users` to pure identity/auth, replaced `employee_id` with polymorphic `entity_type` + `entity_id` pair supporting employee/vendor/client/contact logins
- **RBAC overhaul:** Dropped `role_members` junction table — roles stored as `text[]` array on entity tables; added `self` scope for portal access filtering; three system roles (super_user, admin, support) with no bypass
- **Entity unification:** `roles` and `is_app_user` on all four entity tables (vendors, clients, employees, contacts); contacts promoted to first-class entities; clients gain `email`/`tax_id`; AR Clients merged into unified clients
- **4-layer scoped RBAC implementation:** policies, data scope, state filters, field groups with full enforcement via `ViewController._applyRbacFilters()`
- **ADR decision records and business rules registry** added under `docs/decisions/` and `docs/rules/`

## Test plan
- [ ] Verify PRD internal consistency — no stale `employee_id` on `nap_users`, no orphaned `role_members` references
- [ ] Review RBAC scope hierarchy: `all_projects` > `assigned_companies` > `assigned_projects` > `self`
- [ ] Confirm `roles text[]` + `is_app_user` present on all four entity tables
- [ ] Verify tenant provisioning creates employee with `roles: ['admin']` and `nap_users` with `entity_type: 'employee'`
- [ ] Review migration order for correct dependency sequencing