### PR TITLE
refactor: extract shared form constants and format utils

### DIFF
--- a/apps/nap-client/src/components/shared/EmailsSection.jsx
+++ b/apps/nap-client/src/components/shared/EmailsSection.jsx
@@ -14,8 +14,7 @@ import Typography from '@mui/material/Typography';
 
 import FieldRow from './FieldRow.jsx';
 import { detailGridSx } from '../../config/layoutTokens.js';
-
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
+import { cap } from '../../utils/format.js';
 
 export default function EmailsSection({ emails, showLogin = false }) {
   if (!emails?.length) return null;

--- a/apps/nap-client/src/hooks/useArchiveRestore.js
+++ b/apps/nap-client/src/hooks/useArchiveRestore.js
@@ -11,8 +11,7 @@
 
 import { useState } from 'react';
 
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
-const defaultErrMsg = (err) => err.payload?.error || err.payload?.message || err.message;
+import { cap, errMsg as defaultErrMsg } from '../utils/format.js';
 
 /**
  * @param {Object}   opts

--- a/apps/nap-client/src/pages/AP/ApInvoicesPage.jsx
+++ b/apps/nap-client/src/pages/AP/ApInvoicesPage.jsx
@@ -36,10 +36,9 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
 import { resolveLevel } from '@nap/shared';
 import { apInvoiceApi } from '../../services/apApi.js';
+import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
 
 const STATUS_OPTS = ['open', 'approved', 'paid', 'voided'];
-const cap = (s) => (s ? s.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const BLANK_CREATE = { vendor_id: '', invoice_number: '', invoice_date: '', due_date: '', total_amount: '', status: 'open', notes: '' };
 const BLANK_EDIT = { invoice_number: '', invoice_date: '', due_date: '', total_amount: '', status: 'open', notes: '' };
@@ -95,7 +94,6 @@ export default function ApInvoicesPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const [importOpen, setImportOpen] = useState(false);
 
@@ -259,7 +257,7 @@ export default function ApInvoicesPage() {
         <TextField label="Due Date" type="date" value={createForm.due_date} onChange={onCreateField('due_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Total Amount" type="number" required value={createForm.total_amount} onChange={onCreateField('total_amount')} />
         <TextField label="Status" select value={createForm.status} onChange={onCreateField('status')}>
-          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{cap(s)}</MenuItem>)}
+          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{capSnake(s)}</MenuItem>)}
         </TextField>
         <TextField label="Notes" multiline minRows={2} value={createForm.notes} onChange={onCreateField('notes')} />
       </FormDialog>
@@ -271,7 +269,7 @@ export default function ApInvoicesPage() {
         <TextField label="Due Date" type="date" value={editForm.due_date} onChange={onEditField('due_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Total Amount" type="number" value={editForm.total_amount} onChange={onEditField('total_amount')} />
         <TextField label="Status" select value={editForm.status} onChange={onEditField('status')}>
-          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{cap(s)}</MenuItem>)}
+          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{capSnake(s)}</MenuItem>)}
         </TextField>
         <TextField label="Notes" multiline minRows={2} value={editForm.notes} onChange={onEditField('notes')} />
       </FormDialog>

--- a/apps/nap-client/src/pages/AP/CreditMemosPage.jsx
+++ b/apps/nap-client/src/pages/AP/CreditMemosPage.jsx
@@ -34,10 +34,9 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
 import { resolveLevel } from '@nap/shared';
 import { apCreditMemoApi } from '../../services/apApi.js';
+import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
 
 const STATUS_OPTS = ['open', 'applied', 'voided'];
-const cap = (s) => (s ? s.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const BLANK_CREATE = { vendor_id: '', ap_invoice_id: '', credit_number: '', credit_date: '', amount: '', reason: '', status: 'open' };
 const BLANK_EDIT = { credit_number: '', credit_date: '', amount: '', reason: '', status: 'open' };
@@ -93,7 +92,6 @@ export default function CreditMemosPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const [importOpen, setImportOpen] = useState(false);
 
@@ -250,7 +248,7 @@ export default function CreditMemosPage() {
         <TextField label="Credit Date" type="date" required value={createForm.credit_date} onChange={onCreateField('credit_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Amount" type="number" required value={createForm.amount} onChange={onCreateField('amount')} />
         <TextField label="Status" select value={createForm.status} onChange={onCreateField('status')}>
-          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{cap(s)}</MenuItem>)}
+          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{capSnake(s)}</MenuItem>)}
         </TextField>
         <TextField label="Reason" multiline minRows={2} value={createForm.reason} onChange={onCreateField('reason')} />
       </FormDialog>
@@ -261,7 +259,7 @@ export default function CreditMemosPage() {
         <TextField label="Credit Date" type="date" value={editForm.credit_date} onChange={onEditField('credit_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Amount" type="number" value={editForm.amount} onChange={onEditField('amount')} />
         <TextField label="Status" select value={editForm.status} onChange={onEditField('status')}>
-          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{cap(s)}</MenuItem>)}
+          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{capSnake(s)}</MenuItem>)}
         </TextField>
         <TextField label="Reason" multiline minRows={2} value={editForm.reason} onChange={onEditField('reason')} />
       </FormDialog>

--- a/apps/nap-client/src/pages/AP/PaymentsPage.jsx
+++ b/apps/nap-client/src/pages/AP/PaymentsPage.jsx
@@ -33,10 +33,9 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
 import { resolveLevel } from '@nap/shared';
 import { paymentApi } from '../../services/apApi.js';
+import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
 
 const METHOD_OPTS = ['check', 'ach', 'wire'];
-const cap = (s) => (s ? s.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const BLANK_CREATE = { vendor_id: '', ap_invoice_id: '', payment_date: '', amount: '', method: 'check', reference: '', notes: '' };
 const BLANK_EDIT = { payment_date: '', amount: '', method: 'check', reference: '', notes: '' };
@@ -46,7 +45,7 @@ const columns = [
   { field: 'vendor_id', headerName: 'Vendor', width: 120, valueGetter: (params) => params.row.vendor_id?.slice(0, 8) ?? '\u2014' },
   { field: 'payment_date', headerName: 'Date', width: 120, valueGetter: (params) => fmtDate(params.row.payment_date) },
   { field: 'amount', headerName: 'Amount', width: 140, renderCell: (params) => <CurrencyCell value={params.value} /> },
-  { field: 'method', headerName: 'Method', width: 120, valueGetter: (params) => cap(params.row.method) },
+  { field: 'method', headerName: 'Method', width: 120, valueGetter: (params) => capSnake(params.row.method) },
   { field: 'reference', headerName: 'Reference', flex: 1, minWidth: 160 },
 ];
 
@@ -92,7 +91,6 @@ export default function PaymentsPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const [importOpen, setImportOpen] = useState(false);
 
@@ -227,7 +225,7 @@ export default function PaymentsPage() {
               <FieldRow label="Payment Date" value={fmtDate(viewPayment.payment_date)} />
               <FieldRow label="Vendor" value={viewPayment.vendor_id?.slice(0, 8) || '\u2014'} />
               <FieldRow label="Amount" value={viewPayment.amount != null ? Number(viewPayment.amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
-              <FieldRow label="Method" value={cap(viewPayment.method)} />
+              <FieldRow label="Method" value={capSnake(viewPayment.method)} />
               <FieldRow label="Reference" value={viewPayment.reference || '\u2014'} />
               <FieldRow label="Created" value={fmtDate(viewPayment.created_at)} />
               <FieldRow label="Updated" value={fmtDate(viewPayment.updated_at)} />
@@ -245,7 +243,7 @@ export default function PaymentsPage() {
         <TextField label="Payment Date" type="date" required value={createForm.payment_date} onChange={onCreateField('payment_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Amount" type="number" required value={createForm.amount} onChange={onCreateField('amount')} />
         <TextField label="Method" select value={createForm.method} onChange={onCreateField('method')}>
-          {METHOD_OPTS.map((m) => <MenuItem key={m} value={m}>{cap(m)}</MenuItem>)}
+          {METHOD_OPTS.map((m) => <MenuItem key={m} value={m}>{capSnake(m)}</MenuItem>)}
         </TextField>
         <TextField label="Reference" value={createForm.reference} onChange={onCreateField('reference')} />
         <TextField label="Notes" multiline minRows={2} value={createForm.notes} onChange={onCreateField('notes')} />
@@ -256,7 +254,7 @@ export default function PaymentsPage() {
         <TextField label="Payment Date" type="date" value={editForm.payment_date} onChange={onEditField('payment_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Amount" type="number" value={editForm.amount} onChange={onEditField('amount')} />
         <TextField label="Method" select value={editForm.method} onChange={onEditField('method')}>
-          {METHOD_OPTS.map((m) => <MenuItem key={m} value={m}>{cap(m)}</MenuItem>)}
+          {METHOD_OPTS.map((m) => <MenuItem key={m} value={m}>{capSnake(m)}</MenuItem>)}
         </TextField>
         <TextField label="Reference" value={editForm.reference} onChange={onEditField('reference')} />
         <TextField label="Notes" multiline minRows={2} value={editForm.notes} onChange={onEditField('notes')} />

--- a/apps/nap-client/src/pages/AR/ArInvoicesPage.jsx
+++ b/apps/nap-client/src/pages/AR/ArInvoicesPage.jsx
@@ -40,10 +40,9 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
 import { resolveLevel } from '@nap/shared';
 import { arInvoiceApi } from '../../services/arApi.js';
+import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
 
 const STATUS_OPTS = ['open', 'sent', 'paid', 'voided'];
-const cap = (s) => (s ? s.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const BLANK_CREATE = { client_id: '', invoice_number: '', invoice_date: '', due_date: '', total_amount: '', status: 'open', notes: '' };
 const BLANK_EDIT = { invoice_number: '', invoice_date: '', due_date: '', total_amount: '', status: 'open', notes: '' };
@@ -100,7 +99,6 @@ export default function ArInvoicesPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const [importOpen, setImportOpen] = useState(false);
 
@@ -275,7 +273,7 @@ export default function ArInvoicesPage() {
         <TextField label="Due Date" type="date" value={createForm.due_date} onChange={onCreateField('due_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Total Amount" type="number" required value={createForm.total_amount} onChange={onCreateField('total_amount')} />
         <TextField label="Status" select value={createForm.status} onChange={onCreateField('status')}>
-          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{cap(s)}</MenuItem>)}
+          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{capSnake(s)}</MenuItem>)}
         </TextField>
         <TextField label="Notes" multiline minRows={2} value={createForm.notes} onChange={onCreateField('notes')} />
       </FormDialog>
@@ -287,7 +285,7 @@ export default function ArInvoicesPage() {
         <TextField label="Due Date" type="date" value={editForm.due_date} onChange={onEditField('due_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Total Amount" type="number" value={editForm.total_amount} onChange={onEditField('total_amount')} />
         <TextField label="Status" select value={editForm.status} onChange={onEditField('status')}>
-          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{cap(s)}</MenuItem>)}
+          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{capSnake(s)}</MenuItem>)}
         </TextField>
         <TextField label="Notes" multiline minRows={2} value={editForm.notes} onChange={onEditField('notes')} />
       </FormDialog>

--- a/apps/nap-client/src/pages/AR/ReceiptsPage.jsx
+++ b/apps/nap-client/src/pages/AR/ReceiptsPage.jsx
@@ -36,10 +36,9 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
 import { resolveLevel } from '@nap/shared';
 import { receiptApi } from '../../services/arApi.js';
+import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
 
 const METHOD_OPTS = ['check', 'ach', 'wire'];
-const cap = (s) => (s ? s.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const BLANK_CREATE = { client_id: '', ar_invoice_id: '', receipt_date: '', amount: '', method: 'check', reference: '', notes: '' };
 const BLANK_EDIT = { receipt_date: '', amount: '', method: 'check', reference: '', notes: '' };
@@ -49,7 +48,7 @@ const columns = [
   { field: 'client_id', headerName: 'Client', width: 120, valueGetter: (params) => params.row.client_id?.slice(0, 8) ?? '\u2014' },
   { field: 'receipt_date', headerName: 'Date', width: 120, valueGetter: (params) => fmtDate(params.row.receipt_date) },
   { field: 'amount', headerName: 'Amount', width: 140, renderCell: (params) => <CurrencyCell value={params.value} /> },
-  { field: 'method', headerName: 'Method', width: 120, valueGetter: (params) => cap(params.row.method) },
+  { field: 'method', headerName: 'Method', width: 120, valueGetter: (params) => capSnake(params.row.method) },
   { field: 'reference', headerName: 'Reference', flex: 1, minWidth: 160 },
 ];
 
@@ -95,7 +94,6 @@ export default function ReceiptsPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const [importOpen, setImportOpen] = useState(false);
 
@@ -230,7 +228,7 @@ export default function ReceiptsPage() {
               <FieldRow label="Receipt Date" value={fmtDate(viewReceipt.receipt_date)} />
               <FieldRow label="Client" value={viewReceipt.client_id?.slice(0, 8) || '\u2014'} />
               <FieldRow label="Amount" value={viewReceipt.amount != null ? Number(viewReceipt.amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
-              <FieldRow label="Method" value={cap(viewReceipt.method)} />
+              <FieldRow label="Method" value={capSnake(viewReceipt.method)} />
               <FieldRow label="Reference" value={viewReceipt.reference || '\u2014'} />
               <FieldRow label="Created" value={fmtDate(viewReceipt.created_at)} />
               <FieldRow label="Updated" value={fmtDate(viewReceipt.updated_at)} />
@@ -248,7 +246,7 @@ export default function ReceiptsPage() {
         <TextField label="Receipt Date" type="date" required value={createForm.receipt_date} onChange={onCreateField('receipt_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Amount" type="number" required value={createForm.amount} onChange={onCreateField('amount')} />
         <TextField label="Method" select value={createForm.method} onChange={onCreateField('method')}>
-          {METHOD_OPTS.map((m) => <MenuItem key={m} value={m}>{cap(m)}</MenuItem>)}
+          {METHOD_OPTS.map((m) => <MenuItem key={m} value={m}>{capSnake(m)}</MenuItem>)}
         </TextField>
         <TextField label="Reference" value={createForm.reference} onChange={onCreateField('reference')} />
         <TextField label="Notes" multiline minRows={2} value={createForm.notes} onChange={onCreateField('notes')} />
@@ -259,7 +257,7 @@ export default function ReceiptsPage() {
         <TextField label="Receipt Date" type="date" value={editForm.receipt_date} onChange={onEditField('receipt_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Amount" type="number" value={editForm.amount} onChange={onEditField('amount')} />
         <TextField label="Method" select value={editForm.method} onChange={onEditField('method')}>
-          {METHOD_OPTS.map((m) => <MenuItem key={m} value={m}>{cap(m)}</MenuItem>)}
+          {METHOD_OPTS.map((m) => <MenuItem key={m} value={m}>{capSnake(m)}</MenuItem>)}
         </TextField>
         <TextField label="Reference" value={editForm.reference} onChange={onEditField('reference')} />
         <TextField label="Notes" multiline minRows={2} value={editForm.notes} onChange={onEditField('notes')} />

--- a/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
@@ -37,14 +37,12 @@ import { chartOfAccountsApi } from '../../services/accountingApi.js';
 import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { cap, fmtDate, errMsg } from '../../utils/format.js';
 
 const ACCT_TYPES = ['asset', 'liability', 'equity', 'income', 'expense', 'cash', 'bank'];
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
 
 const BLANK_CREATE = { code: '', name: '', type: 'asset', is_active: true, cash_basis: false };
 const BLANK_EDIT = { name: '', type: 'asset', is_active: true, cash_basis: false };
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
@@ -105,7 +103,6 @@ export default function ChartOfAccountsPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Accounting/JournalEntriesPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/JournalEntriesPage.jsx
@@ -36,10 +36,9 @@ import { journalEntryApi } from '../../services/accountingApi.js';
 import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
 
 const STATUS_OPTS = ['pending', 'posted', 'reversed'];
-const cap = (s) => (s ? s.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const BLANK_CREATE = { entry_date: '', description: '', status: 'pending', source_type: '' };
 const BLANK_EDIT = { entry_date: '', description: '', status: 'pending', source_type: '' };
@@ -49,7 +48,7 @@ const columns = [
   { field: 'entry_date', headerName: 'Date', width: 120, valueGetter: (params) => fmtDate(params.row.entry_date) },
   { field: 'description', headerName: 'Description', flex: 1, minWidth: 200 },
   { field: 'status', headerName: 'Status', width: 120, renderCell: ({ value }) => <StatusBadge status={value} /> },
-  { field: 'source_type', headerName: 'Source', width: 140, valueGetter: (params) => cap(params.row.source_type || '') },
+  { field: 'source_type', headerName: 'Source', width: 140, valueGetter: (params) => capSnake(params.row.source_type || '') },
 ];
 
 export default function JournalEntriesPage() {
@@ -95,7 +94,6 @@ export default function JournalEntriesPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
@@ -288,7 +286,7 @@ export default function JournalEntriesPage() {
               <FieldRow label="Status">
                 <StatusBadge status={viewEntry.status} />
               </FieldRow>
-              <FieldRow label="Source Type" value={cap(viewEntry.source_type || '') || '\u2014'} />
+              <FieldRow label="Source Type" value={capSnake(viewEntry.source_type || '') || '\u2014'} />
               <FieldRow label="Created" value={fmtDate(viewEntry.created_at)} />
               <FieldRow label="Updated" value={fmtDate(viewEntry.updated_at)} />
             </Box>
@@ -301,7 +299,7 @@ export default function JournalEntriesPage() {
         <TextField label="Entry Date" type="date" required value={createForm.entry_date} onChange={onCreateField('entry_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Description" multiline minRows={2} value={createForm.description} onChange={onCreateField('description')} />
         <TextField label="Status" select value={createForm.status} onChange={onCreateField('status')}>
-          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{cap(s)}</MenuItem>)}
+          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{capSnake(s)}</MenuItem>)}
         </TextField>
         <TextField label="Source Type" value={createForm.source_type} onChange={onCreateField('source_type')} />
       </FormDialog>
@@ -311,7 +309,7 @@ export default function JournalEntriesPage() {
         <TextField label="Entry Date" type="date" value={editForm.entry_date} onChange={onEditField('entry_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Description" multiline minRows={2} value={editForm.description} onChange={onEditField('description')} />
         <TextField label="Status" select value={editForm.status} onChange={onEditField('status')}>
-          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{cap(s)}</MenuItem>)}
+          {STATUS_OPTS.map((s) => <MenuItem key={s} value={s}>{capSnake(s)}</MenuItem>)}
         </TextField>
         <TextField label="Source Type" value={editForm.source_type} onChange={onEditField('source_type')} />
       </FormDialog>

--- a/apps/nap-client/src/pages/Accounting/LedgerPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/LedgerPage.jsx
@@ -12,8 +12,7 @@ import { DataGrid } from '@mui/x-data-grid';
 import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
 import { useLedgerBalances } from '../../hooks/useAccounting.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
+import { fmtDate } from '../../utils/format.js';
 
 const columns = [
   { field: 'account_id', headerName: 'Account', width: 140, valueGetter: (params) => params.row.account_id?.slice(0, 8) ?? '\u2014' },

--- a/apps/nap-client/src/pages/Activities/ActivitiesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/ActivitiesPage.jsx
@@ -45,11 +45,10 @@ import { activityApi } from '../../services/activityApi.js';
 import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { fmtDate, errMsg } from '../../utils/format.js';
 
 const BLANK_CREATE = { code: '', name: '', category_id: '', is_active: true };
 const BLANK_EDIT = { code: '', name: '', category_id: '', is_active: true };
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 export default function ActivitiesPage() {
   const { user } = useAuth();
@@ -117,7 +116,6 @@ export default function ActivitiesPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Activities/BudgetManagementPage.jsx
+++ b/apps/nap-client/src/pages/Activities/BudgetManagementPage.jsx
@@ -40,13 +40,12 @@ import { useActivities } from '../../hooks/useActivities.js';
 import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { fmtDate, errMsg } from '../../utils/format.js';
 
 const BLANK_CREATE = { deliverable_id: '', activity_id: '', budgeted_amount: '', status: 'draft' };
 const BLANK_EDIT = { budgeted_amount: '', status: '' };
 
 const STATUSES = ['draft', 'submitted', 'approved', 'locked', 'rejected'];
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 export default function BudgetManagementPage() {
   const { user } = useAuth();
@@ -98,7 +97,6 @@ export default function BudgetManagementPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Activities/CategoriesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/CategoriesPage.jsx
@@ -44,14 +44,12 @@ import { categoryApi } from '../../services/categoryApi.js';
 import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { cap, fmtDate, errMsg } from '../../utils/format.js';
 
 const TYPES = ['labor', 'material', 'subcontract', 'equipment', 'other'];
 
 const BLANK_CREATE = { code: '', name: '', type: 'labor' };
 const BLANK_EDIT = { code: '', name: '', type: '' };
-
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
@@ -101,7 +99,6 @@ export default function CategoriesPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Activities/CostTrackingPage.jsx
+++ b/apps/nap-client/src/pages/Activities/CostTrackingPage.jsx
@@ -35,13 +35,12 @@ import { useActivities } from '../../hooks/useActivities.js';
 import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, formFullSpanSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { fmtDate, errMsg } from '../../utils/format.js';
 
 const BLANK_CREATE = { activity_id: '', project_id: '', amount: '', currency: 'USD', reference: '', incurred_on: '' };
 const BLANK_EDIT = { amount: '', currency: '', reference: '', approval_status: '', incurred_on: '' };
 
 const APPROVAL_STATUSES = ['pending', 'approved', 'rejected'];
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 export default function CostTrackingPage() {
   const { user } = useAuth();
@@ -88,7 +87,6 @@ export default function CostTrackingPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Activities/DeliverablesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/DeliverablesPage.jsx
@@ -43,13 +43,12 @@ import { deliverableApi } from '../../services/deliverableApi.js';
 import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, formFullSpanSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { fmtDate, errMsg } from '../../utils/format.js';
 
 const BLANK_CREATE = { name: '', description: '', status: 'pending', start_date: '', end_date: '' };
 const BLANK_EDIT = { name: '', description: '', status: '', start_date: '', end_date: '' };
 
 const STATUSES = ['pending', 'released', 'finished', 'canceled'];
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const columns = [
   { field: 'name', headerName: 'Name', flex: 1, minWidth: 200 },
@@ -105,7 +104,6 @@ export default function DeliverablesPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/BOM/CatalogPage.jsx
+++ b/apps/nap-client/src/pages/BOM/CatalogPage.jsx
@@ -39,11 +39,10 @@ import { catalogSkuApi } from '../../services/bomApi.js';
 import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, formFullSpanSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { fmtDate, errMsg } from '../../utils/format.js';
 
 const BLANK_CREATE = { catalog_sku: '', description: '', category: '', sub_category: '' };
 const BLANK_EDIT = { catalog_sku: '', description: '', category: '', sub_category: '' };
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const columns = [
   { field: 'catalog_sku', headerName: 'SKU', width: 160 },
@@ -101,7 +100,6 @@ export default function CatalogPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/BOM/VendorSkuMatchingPage.jsx
+++ b/apps/nap-client/src/pages/BOM/VendorSkuMatchingPage.jsx
@@ -28,6 +28,7 @@ import {
 } from '../../hooks/useBom.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
+import { errMsg } from '../../utils/format.js';
 
 const confidenceColor = (val) => {
   if (val >= 0.85) return 'success';
@@ -83,7 +84,6 @@ export default function VendorSkuMatchingPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const handleFindMatches = async () => {
     if (!selection.selected) return;

--- a/apps/nap-client/src/pages/Core/ClientsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ClientsPage.jsx
@@ -62,6 +62,8 @@ import {
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import { useRoles } from '../../hooks/useRoles.js';
 import { TAX_TYPES, COUNTRIES, resolveLevel } from '@nap/shared';
+import { cap, fmtDate, errMsg } from '../../utils/format.js';
+import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
 import { clientApi } from '../../services/clientApi.js';
 import { pageContainerSx, formGridSx, formGroupCardSx, formFullSpanSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
@@ -70,18 +72,6 @@ import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 const BLANK_CREATE = { name: '', code: '', is_active: true, is_app_user: false, roles: [] };
 const BLANK_EDIT = { name: '', code: '', is_active: true, is_app_user: false, roles: [] };
 
-const PHONE_TYPES = ['cell', 'work', 'home', 'fax', 'other'];
-const EMAIL_LABELS = ['work', 'personal', 'billing', 'other'];
-const BLANK_PHONE = { country_code: 'US', phone_type: 'cell', phone_number: '', is_primary: false };
-const BLANK_EMAIL = { email: '', label: 'work', is_primary: false };
-const BLANK_ADDRESS = {
-  label: '', address_line_1: '', address_line_2: '', address_line_3: '', city: '',
-  state_province: '', postal_code: '', country_code: 'US',
-};
-const BLANK_TAX_ID = { country_code: 'US', tax_type: 'TIN', tax_value: '' };
-
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
@@ -178,7 +168,6 @@ export default function ClientsPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Core/CompaniesPage.jsx
+++ b/apps/nap-client/src/pages/Core/CompaniesPage.jsx
@@ -45,6 +45,8 @@ import {
 } from '../../hooks/useTaxIdentifiers.js';
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import { TAX_TYPES, COUNTRIES, resolveLevel } from '@nap/shared';
+import { fmtDate, errMsg } from '../../utils/format.js';
+import { BLANK_ADDRESS, BLANK_TAX_ID } from '../../utils/formConstants.js';
 import { companyApi } from '../../services/companyApi.js';
 import {
   pageContainerSx, formGridSx, formGroupCardSx, formFullSpanSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx,
@@ -54,14 +56,6 @@ import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 
 const BLANK_CREATE = { name: '', code: '', is_active: true };
 const BLANK_EDIT = { name: '', code: '', is_active: true };
-const BLANK_ADDRESS = {
-  label: '', address_line_1: '', address_line_2: '', address_line_3: '',
-  city: '', state_province: '', postal_code: '', country_code: 'US',
-};
-const BLANK_TAX_ID = { country_code: 'US', tax_type: 'TIN', tax_value: '' };
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
-
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
   { field: 'name', headerName: 'Company Name', flex: 1, minWidth: 200 },
@@ -150,7 +144,6 @@ export default function CompaniesPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Core/ContactsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ContactsPage.jsx
@@ -59,6 +59,8 @@ import {
 } from '../../hooks/useTaxIdentifiers.js';
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import { TAX_TYPES, COUNTRIES, resolveLevel } from '@nap/shared';
+import { cap, fmtDate, errMsg } from '../../utils/format.js';
+import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
 import { contactApi } from '../../services/contactApi.js';
 import { pageContainerSx, formGridSx, formGroupCardSx, formFullSpanSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
@@ -67,18 +69,6 @@ import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 const BLANK_CREATE = { name: '', code: '', is_active: true };
 const BLANK_EDIT = { name: '', code: '', is_active: true };
 
-const PHONE_TYPES = ['cell', 'work', 'home', 'fax', 'other'];
-const EMAIL_LABELS = ['work', 'personal', 'billing', 'other'];
-const BLANK_PHONE = { country_code: 'US', phone_type: 'cell', phone_number: '', is_primary: false };
-const BLANK_EMAIL = { email: '', label: 'work', is_primary: false };
-const BLANK_ADDRESS = {
-  label: '', address_line_1: '', address_line_2: '', address_line_3: '', city: '',
-  state_province: '', postal_code: '', country_code: 'US',
-};
-const BLANK_TAX_ID = { country_code: 'US', tax_type: 'TIN', tax_value: '' };
-
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
@@ -168,7 +158,7 @@ export default function ContactsPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
+
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/nap-client/src/pages/Core/EmployeesPage.jsx
@@ -61,6 +61,8 @@ import {
 } from '../../hooks/useTaxIdentifiers.js';
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import { TAX_TYPES, COUNTRIES } from '@nap/shared';
+import { cap, fmtDate, errMsg } from '../../utils/format.js';
+import { BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
 import { employeeApi } from '../../services/employeeApi.js';
 import { pageContainerSx, formGridSx, formGroupCardSx, formFullSpanSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
@@ -77,18 +79,7 @@ const BLANK_EDIT = {
   is_app_user: false, password: '', roles: [], is_primary_contact: false, is_billing_contact: false,
 };
 
-const PHONE_TYPES = ['cell', 'work', 'home', 'fax', 'other'];
-const EMAIL_LABELS = ['work', 'personal', 'billing', 'other'];
-const BLANK_PHONE = { country_code: 'US', phone_type: 'cell', phone_number: '', is_primary: false };
 const BLANK_EMAIL = { email: '', label: 'work', is_primary: false, is_login: false };
-const BLANK_ADDRESS = {
-  label: '', address_line_1: '', address_line_2: '', address_line_3: '', city: '',
-  state_province: '', postal_code: '', country_code: 'US',
-};
-const BLANK_TAX_ID = { country_code: 'US', tax_type: 'TIN', tax_value: '' };
-
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const columns = [
   { field: 'code', headerName: 'Code', width: 100 },
@@ -195,7 +186,7 @@ export default function EmployeesPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
+
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Core/VendorsPage.jsx
+++ b/apps/nap-client/src/pages/Core/VendorsPage.jsx
@@ -69,7 +69,8 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import { useActivePaymentTerms } from '../../hooks/usePaymentTerms.js';
 import { useRoles } from '../../hooks/useRoles.js';
 import { TAX_TYPES, COUNTRIES, resolveLevel } from '@nap/shared';
-import { formatByPattern } from '../../utils/formatByPattern.js';
+import { cap, fmtDate, fmtPhone, errMsg } from '../../utils/format.js';
+import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
 import { vendorApi } from '../../services/vendorApi.js';
 import { emailApi } from '../../services/emailApi.js';
 import { phoneNumberApi } from '../../services/phoneNumberApi.js';
@@ -81,25 +82,10 @@ import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 
 const BLANK_CREATE = { name: '', code: '', payment_term_id: '', notes: '', is_active: true };
 const BLANK_EDIT = { name: '', code: '', payment_term_id: '', notes: '', is_active: true };
-const BLANK_EMAIL = { email: '', label: 'work', is_primary: false };
-const BLANK_PHONE = { country_code: 'US', phone_type: 'cell', phone_number: '', is_primary: false };
-const BLANK_ADDRESS = {
-  label: '', address_line_1: '', address_line_2: '', address_line_3: '', city: '',
-  state_province: '', postal_code: '', country_code: 'US',
-};
-const BLANK_TAX_ID = { country_code: 'US', tax_type: 'TIN', tax_value: '' };
-const fmtPhone = (p) => formatByPattern(p.phone_number, COUNTRIES.find((c) => c.code === p.country_code)?.placeholder);
-
 const BLANK_CONTACT_FORM = {
   first_name: '', last_name: '', position: '', department: '',
   is_app_user: false, roles: [], password: '',
 };
-
-const PHONE_TYPES = ['cell', 'work', 'home', 'fax', 'other'];
-const EMAIL_LABELS = ['work', 'personal', 'billing', 'other'];
-
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const dialogSx = {
   '& .MuiDialogTitle-root + .MuiDialogContent-root': { paddingTop: '16px' },
@@ -267,7 +253,6 @@ export default function VendorsPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Projects/ChangeOrdersPage.jsx
+++ b/apps/nap-client/src/pages/Projects/ChangeOrdersPage.jsx
@@ -33,13 +33,12 @@ import { changeOrderApi } from '../../services/changeOrderApi.js';
 import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { fmtDate, errMsg } from '../../utils/format.js';
 
 const BLANK_CREATE = { unit_id: '', co_number: '', title: '', reason: '', total_amount: '' };
 const BLANK_EDIT = { co_number: '', title: '', reason: '', total_amount: '' };
 
 const STATUS_MAP = { draft: 'active', submitted: 'active', approved: 'active', rejected: 'suspended' };
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const columns = [
   { field: 'co_number', headerName: 'CO #', width: 120 },
@@ -94,7 +93,6 @@ export default function ChangeOrdersPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Projects/ProjectDetailPage.jsx
+++ b/apps/nap-client/src/pages/Projects/ProjectDetailPage.jsx
@@ -28,6 +28,7 @@ import { useTasks, useCreateTask, useUpdateTask, useArchiveTask, useRestoreTask 
 import { useCostItems, useCreateCostItem, useUpdateCostItem, useArchiveCostItem, useRestoreCostItem } from '../../hooks/useCostItems.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
+import { errMsg } from '../../utils/format.js';
 
 /* ── column definitions ───────────────────────── */
 const unitCols = [
@@ -118,7 +119,6 @@ export default function ProjectDetailPage() {
   /* ── Toast ──────────────────────────────────── */
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   /* ── Toolbar ────────────────────────────────── */
   const toolbar = useMemo(() => ({ tabs: [], filters: [], primaryActions: [] }), []);

--- a/apps/nap-client/src/pages/Projects/ProjectsPage.jsx
+++ b/apps/nap-client/src/pages/Projects/ProjectsPage.jsx
@@ -35,13 +35,12 @@ import { projectApi } from '../../services/projectApi.js';
 import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { fmtDate, errMsg } from '../../utils/format.js';
 
 const BLANK_CREATE = { project_code: '', name: '', description: '', notes: '', contract_amount: '' };
 const BLANK_EDIT = { project_code: '', name: '', description: '', notes: '', contract_amount: '' };
 
 const STATUS_MAP = { planning: 'active', budgeting: 'active', released: 'active', complete: 'suspended' };
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 const columns = [
   { field: 'project_code', headerName: 'Code', width: 130 },
@@ -97,7 +96,6 @@ export default function ProjectsPage() {
 
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Settings/CompanyInfoPage.jsx
+++ b/apps/nap-client/src/pages/Settings/CompanyInfoPage.jsx
@@ -40,6 +40,7 @@ import {
   useArchiveTaxIdentifier,
 } from '../../hooks/useCompanyInfo.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
+import { cap, errMsg } from '../../utils/format.js';
 
 /* ── Constants ──────────────────────────────────────────────────── */
 
@@ -58,8 +59,6 @@ const BLANK_ADDRESS = {
 };
 
 const BLANK_TAX = { country_code: 'US', tax_type: 'EIN', tax_value: '' };
-
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
 
 /* ── SetupCompanyForm (legacy tenants without a self-company) ── */
 
@@ -433,10 +432,7 @@ export default function CompanyInfoPage() {
   /* ── snackbar ─────────────────────────────────────────────── */
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errToast = useCallback(
-    (err) => toast(err.payload?.error || err.payload?.message || err.message, 'error'),
-    [toast],
-  );
+  const errToast = useCallback((err) => toast(errMsg(err), 'error'), [toast]);
 
   /* ── toolbar (empty — settings pages have no toolbar actions) */
   const toolbar = useMemo(() => ({ tabs: [], filters: [], primaryActions: [] }), []);

--- a/apps/nap-client/src/pages/Settings/PaymentTermsPage.jsx
+++ b/apps/nap-client/src/pages/Settings/PaymentTermsPage.jsx
@@ -33,6 +33,7 @@ import { paymentTermApi } from '../../services/paymentTermApi.js';
 import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
+import { fmtDate, errMsg } from '../../utils/format.js';
 
 const BLANK_CREATE = { label: '', term: 30, units: 'days' };
 const BLANK_EDIT = { label: '', term: 30, units: 'days', is_active: true };
@@ -40,9 +41,6 @@ const UNITS_OPTIONS = [
   { value: 'days', label: 'Days' },
   { value: 'months', label: 'Months' },
 ];
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
-const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
 const columns = [
   { field: 'label', headerName: 'Label', flex: 1, minWidth: 180 },

--- a/apps/nap-client/src/pages/Tenant/CreateTenantWizard.jsx
+++ b/apps/nap-client/src/pages/Tenant/CreateTenantWizard.jsx
@@ -26,6 +26,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import StepperFormDialog from '../../components/shared/StepperFormDialog.jsx';
 import PasswordField from '../../components/shared/PasswordField.jsx';
 import { useCreateTenant } from '../../hooks/useTenants.js';
+import { cap } from '../../utils/format.js';
 
 /* ── Constants ──────────────────────────────────────────────────── */
 
@@ -62,8 +63,6 @@ const BLANK_FORM = {
   admin_email: '',
   admin_password: '',
 };
-
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
 
 /* ── Component ──────────────────────────────────────────────────── */
 

--- a/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
@@ -38,6 +38,7 @@ import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContex
 import { useRoles, useCreateRole, useUpdateRole } from '../../hooks/useRoles.js';
 import { masterDetailSx, masterPanelSx, detailPanelSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
+import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
 
 import PolicyEditor from './PolicyEditor.jsx';
 import StateFilterEditor from './StateFilterEditor.jsx';
@@ -47,18 +48,6 @@ import FieldGroupDefinitionEditor from './FieldGroupDefinitionEditor.jsx';
 /* ── Enums ────────────────────────────────────────────────────── */
 
 const SCOPE_OPTS = ['all_projects', 'assigned_companies', 'assigned_projects', 'self'];
-
-/* ── Helpers ──────────────────────────────────────────────────── */
-
-const cap = (s) =>
-  s
-    ? s
-        .split('_')
-        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-        .join(' ')
-    : '';
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 /* ── Empty form shapes ────────────────────────────────────────── */
 
@@ -121,7 +110,6 @@ export default function ManageRolesPage() {
   /* ── snackbar ──────────────────────────────────────────────── */
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   /* ── field change factories ────────────────────────────────── */
   const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
@@ -219,7 +207,7 @@ export default function ManageRolesPage() {
               {selection.selected.is_immutable && <Chip label="Immutable" size="small" color="warning" />}
             </Box>
             <Typography variant="body2" color="text.secondary">
-              {selection.selected.code} &middot; Scope: {cap(selection.selected.scope)}
+              {selection.selected.code} &middot; Scope: {capSnake(selection.selected.scope)}
             </Typography>
             {selection.selected.description && (
               <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
@@ -309,7 +297,7 @@ export default function ManageRolesPage() {
         <TextField label="Scope" select value={createForm.scope} onChange={onCreateField('scope')}>
           {SCOPE_OPTS.map((s) => (
             <MenuItem key={s} value={s}>
-              {cap(s)}
+              {capSnake(s)}
             </MenuItem>
           ))}
         </TextField>
@@ -330,7 +318,7 @@ export default function ManageRolesPage() {
         <TextField label="Scope" select value={editForm.scope} onChange={onEditField('scope')}>
           {SCOPE_OPTS.map((s) => (
             <MenuItem key={s} value={s}>
-              {cap(s)}
+              {capSnake(s)}
             </MenuItem>
           ))}
         </TextField>

--- a/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
@@ -53,6 +53,7 @@ import {
 } from '../../hooks/useTenants.js';
 import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, formFullSpanSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
+import { cap, fmtDate, errMsg } from '../../utils/format.js';
 
 /* ── Enums ────────────────────────────────────────────────────── */
 
@@ -69,11 +70,6 @@ const BLANK_EDIT = {
   max_users: 5,
   notes: '',
 };
-
-/* ── Helpers ──────────────────────────────────────────────────── */
-
-const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
 
 /* ── Column definitions ───────────────────────────────────────── */
 
@@ -186,7 +182,6 @@ export default function ManageTenantsPage() {
   /* ── snackbar ────────────────────────────────────────────── */
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   /* ── field change factories ──────────────────────────────── */
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));

--- a/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
@@ -34,6 +34,7 @@ import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContex
 import { useUsers, useUpdateUser } from '../../hooks/useUsers.js';
 import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
+import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
 
 /* ── Enums ────────────────────────────────────────────────────── */
 
@@ -62,18 +63,6 @@ const PW_RULES = [
   { label: 'A special character', test: (p) => /[^A-Za-z0-9]/.test(p) },
 ];
 
-/* ── Helpers ──────────────────────────────────────────────────── */
-
-const cap = (s) =>
-  s
-    ? s
-        .split('_')
-        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-        .join(' ')
-    : '';
-
-const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
-
 /* ── Column definitions ───────────────────────────────────────── */
 
 const columns = [
@@ -82,7 +71,7 @@ const columns = [
     field: 'entity_type',
     headerName: 'Entity Type',
     width: 140,
-    valueGetter: (params) => cap(params.row.entity_type) || '\u2014',
+    valueGetter: (params) => capSnake(params.row.entity_type) || '\u2014',
   },
   {
     field: 'status',
@@ -132,7 +121,6 @@ export default function ManageUsersPage() {
   /* ── snackbar ────────────────────────────────────────────── */
   const [snack, setSnack] = useState({ open: false, msg: '', sev: 'success' });
   const toast = useCallback((msg, sev = 'success') => setSnack({ open: true, msg, sev }), []);
-  const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;
 
   /* ── field change factories ──────────────────────────────── */
   const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
@@ -218,7 +206,7 @@ export default function ManageUsersPage() {
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
                 <FieldRow label="Email" value={viewUser.email} />
-                <FieldRow label="Entity Type" value={cap(viewUser.entity_type) || '\u2014'} />
+                <FieldRow label="Entity Type" value={capSnake(viewUser.entity_type) || '\u2014'} />
                 <FieldRow label="Status">
                   <StatusBadge status={viewUser.status} />
                 </FieldRow>
@@ -244,7 +232,7 @@ export default function ManageUsersPage() {
         <TextField label="Status" select value={editForm.status} onChange={onEditField('status')}>
           {STATUS_OPTS.map((s) => (
             <MenuItem key={s} value={s}>
-              {cap(s)}
+              {capSnake(s)}
             </MenuItem>
           ))}
         </TextField>

--- a/apps/nap-client/src/utils/formConstants.js
+++ b/apps/nap-client/src/utils/formConstants.js
@@ -1,0 +1,20 @@
+/**
+ * @file Shared blank-form shapes and option lists for entity sub-collections
+ * @module nap-client/utils/formConstants
+ *
+ * Centralises the default objects used by email, phone, address, and
+ * tax-identifier sub-forms across Core entity pages.
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+export const BLANK_EMAIL = { email: '', label: 'work', is_primary: false };
+export const BLANK_PHONE = { country_code: 'US', phone_type: 'cell', phone_number: '', is_primary: false };
+export const BLANK_ADDRESS = {
+  label: '', address_line_1: '', address_line_2: '', address_line_3: '', city: '',
+  state_province: '', postal_code: '', country_code: 'US',
+};
+export const BLANK_TAX_ID = { country_code: 'US', tax_type: 'TIN', tax_value: '' };
+
+export const PHONE_TYPES = ['cell', 'work', 'home', 'fax', 'other'];
+export const EMAIL_LABELS = ['work', 'personal', 'billing', 'other'];

--- a/apps/nap-client/src/utils/format.js
+++ b/apps/nap-client/src/utils/format.js
@@ -1,0 +1,53 @@
+/**
+ * @file Shared display-formatting helpers
+ * @module nap-client/utils/format
+ *
+ * Pure functions used across pages for consistent text formatting.
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import { COUNTRIES } from '@nap/shared';
+import { formatByPattern } from './formatByPattern.js';
+
+/**
+ * Capitalise the first letter of a string.
+ * @param {string} s
+ * @returns {string}
+ */
+export const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
+
+/**
+ * Convert a snake_case string to Title Case words.
+ * @param {string} s
+ * @returns {string}
+ */
+export const capSnake = (s) =>
+  s
+    ? s
+        .split('_')
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ')
+    : '';
+
+/**
+ * Format an ISO date string for display; returns an em-dash when falsy.
+ * @param {string|null|undefined} v
+ * @returns {string}
+ */
+export const fmtDate = (v) => (v ? new Date(v).toLocaleDateString() : '\u2014');
+
+/**
+ * Format a phone-number object using its country placeholder pattern.
+ * @param {{ phone_number: string, country_code: string }} p
+ * @returns {string}
+ */
+export const fmtPhone = (p) =>
+  formatByPattern(p.phone_number, COUNTRIES.find((c) => c.code === p.country_code)?.placeholder);
+
+/**
+ * Extract a user-friendly error message from an API error object.
+ * @param {Error & { payload?: { error?: string, message?: string } }} err
+ * @returns {string}
+ */
+export const errMsg = (err) => err.payload?.error || err.payload?.message || err.message;


### PR DESCRIPTION
## Summary
- Extract duplicated `BLANK_EMAIL`, `BLANK_PHONE`, `BLANK_ADDRESS`, `BLANK_TAX_ID`, `PHONE_TYPES`, `EMAIL_LABELS` into `formConstants.js`
- Extract duplicated `cap`, `fmtDate`, `errMsg` helpers into `format.js`
- Remove identical copies from 31 page/component files (net -50 lines)

## Test plan
- [x] Verify all pages that use form sub-collections (emails, phones, addresses, tax IDs) render correctly
- [x] Verify date formatting and capitalization display unchanged
- [x] Verify error toast messages still display properly