### PR TITLE
refactor: extract useFormState hook from page components

### DIFF
--- a/apps/nap-client/src/hooks/useFormState.js
+++ b/apps/nap-client/src/hooks/useFormState.js
@@ -1,0 +1,35 @@
+/**
+ * @file Form state hook — encapsulates form object + field handler factory
+ * @module nap-client/hooks/useFormState
+ *
+ * Replaces the per-page `const [form, setForm] = useState(BLANK)` +
+ * `const onField = (f) => (e) => setForm(...)` boilerplate.
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useCallback } from 'react';
+
+/**
+ * @param {object} blank Default blank form shape
+ * @returns {{
+ *   form: object,
+ *   setForm: Function,
+ *   field: (name: string) => (e: Event) => void,
+ *   reset: (values?: object) => void,
+ * }}
+ */
+export function useFormState(blank) {
+  const [form, setForm] = useState(blank);
+
+  /** onChange handler for text inputs: `onChange={field('name')}` */
+  const field = useCallback(
+    (name) => (e) => setForm((prev) => ({ ...prev, [name]: e.target.value })),
+    [],
+  );
+
+  /** Reset to blank or to provided values (for populating an edit form). */
+  const reset = useCallback((values) => setForm(values ?? blank), [blank]);
+
+  return { form, setForm, field, reset };
+}

--- a/apps/nap-client/src/pages/AP/ApInvoicesPage.jsx
+++ b/apps/nap-client/src/pages/AP/ApInvoicesPage.jsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -89,15 +90,13 @@ export default function ApInvoicesPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
   const [importOpen, setImportOpen] = useState(false);
 
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   const handleImport = useCallback(async (formData) => {
     try {
@@ -137,7 +136,7 @@ export default function ApInvoicesPage() {
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync({ ...createForm, total_amount: Number(createForm.total_amount) || 0 });
-      toast('Invoice created'); setCreateOpen(false); setCreateForm(BLANK_CREATE);
+      toast('Invoice created'); setCreateOpen(false); resetCreateForm();
     } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
@@ -185,7 +184,7 @@ export default function ApInvoicesPage() {
       label: 'Create Invoice',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/AP/CreditMemosPage.jsx
+++ b/apps/nap-client/src/pages/AP/CreditMemosPage.jsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -87,15 +88,12 @@ export default function CreditMemosPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
   const [importOpen, setImportOpen] = useState(false);
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   const handleImport = useCallback(async (formData) => {
     try {
@@ -132,7 +130,7 @@ export default function CreditMemosPage() {
   }, []);
 
   const handleCreate = async () => {
-    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Credit memo created'); setCreateOpen(false); setCreateForm(BLANK_CREATE); } catch (err) { toast(errMsg(err), 'error'); }
+    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Credit memo created'); setCreateOpen(false); resetCreateForm(); } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
     try { await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: { ...editForm, amount: Number(editForm.amount) || 0 } }); toast('Credit memo updated'); setEditOpen(false); setEditRow(null); } catch (err) { toast(errMsg(err), 'error'); }
@@ -176,7 +174,7 @@ export default function CreditMemosPage() {
       label: 'Create Memo',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/AP/PaymentsPage.jsx
+++ b/apps/nap-client/src/pages/AP/PaymentsPage.jsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -86,15 +87,13 @@ export default function PaymentsPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
   const [importOpen, setImportOpen] = useState(false);
 
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   const handleImport = useCallback(async (formData) => {
     try {
@@ -131,7 +130,7 @@ export default function PaymentsPage() {
   }, []);
 
   const handleCreate = async () => {
-    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Payment created'); setCreateOpen(false); setCreateForm(BLANK_CREATE); } catch (err) { toast(errMsg(err), 'error'); }
+    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Payment created'); setCreateOpen(false); resetCreateForm(); } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
     try { await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: { ...editForm, amount: Number(editForm.amount) || 0 } }); toast('Payment updated'); setEditOpen(false); setEditRow(null); } catch (err) { toast(errMsg(err), 'error'); }
@@ -175,7 +174,7 @@ export default function PaymentsPage() {
       label: 'Record Payment',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/AR/ArInvoicesPage.jsx
+++ b/apps/nap-client/src/pages/AR/ArInvoicesPage.jsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -94,15 +95,12 @@ export default function ArInvoicesPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
   const [importOpen, setImportOpen] = useState(false);
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   const handleImport = useCallback(async (formData) => {
     try {
@@ -142,7 +140,7 @@ export default function ArInvoicesPage() {
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync({ ...createForm, total_amount: Number(createForm.total_amount) || 0 });
-      toast('Invoice created'); setCreateOpen(false); setCreateForm(BLANK_CREATE);
+      toast('Invoice created'); setCreateOpen(false); resetCreateForm();
     } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
@@ -201,7 +199,7 @@ export default function ArInvoicesPage() {
       label: 'Create Invoice',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/AR/ReceiptsPage.jsx
+++ b/apps/nap-client/src/pages/AR/ReceiptsPage.jsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -89,15 +90,12 @@ export default function ReceiptsPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
   const [importOpen, setImportOpen] = useState(false);
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   const handleImport = useCallback(async (formData) => {
     try {
@@ -134,7 +132,7 @@ export default function ReceiptsPage() {
   }, []);
 
   const handleCreate = async () => {
-    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Receipt created'); setCreateOpen(false); setCreateForm(BLANK_CREATE); } catch (err) { toast(errMsg(err), 'error'); }
+    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Receipt created'); setCreateOpen(false); resetCreateForm(); } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
     try { await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: { ...editForm, amount: Number(editForm.amount) || 0 } }); toast('Receipt updated'); setEditOpen(false); setEditRow(null); } catch (err) { toast(errMsg(err), 'error'); }
@@ -178,7 +176,7 @@ export default function ReceiptsPage() {
       label: 'Record Receipt',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -98,13 +99,11 @@ export default function ChartOfAccountsPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -123,7 +122,7 @@ export default function ChartOfAccountsPage() {
       await createMut.mutateAsync(createForm);
       toast('Account created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -204,7 +203,7 @@ export default function ChartOfAccountsPage() {
       label: 'Create Account',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Accounting/JournalEntriesPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/JournalEntriesPage.jsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -89,13 +90,11 @@ export default function JournalEntriesPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -119,7 +118,7 @@ export default function JournalEntriesPage() {
       await createMut.mutateAsync(createForm);
       toast('Journal entry created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -233,7 +232,7 @@ export default function JournalEntriesPage() {
       label: 'Create Entry',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Activities/ActivitiesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/ActivitiesPage.jsx
@@ -12,6 +12,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -111,13 +112,10 @@ export default function ActivitiesPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -141,7 +139,7 @@ export default function ActivitiesPage() {
       await createMut.mutateAsync(createForm);
       toast('Activity created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -222,7 +220,7 @@ export default function ActivitiesPage() {
       label: 'Create',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Activities/BudgetManagementPage.jsx
+++ b/apps/nap-client/src/pages/Activities/BudgetManagementPage.jsx
@@ -12,6 +12,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -92,13 +93,10 @@ export default function BudgetManagementPage() {
   const [editRow, setEditRow] = useState(null);
   const [versionOpen, setVersionOpen] = useState(false);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -117,7 +115,7 @@ export default function BudgetManagementPage() {
       await createMut.mutateAsync(createForm);
       toast('Budget created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -243,7 +241,7 @@ export default function BudgetManagementPage() {
       label: 'Create Budget',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Activities/CategoriesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/CategoriesPage.jsx
@@ -12,6 +12,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -94,13 +95,10 @@ export default function CategoriesPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -123,7 +121,7 @@ export default function CategoriesPage() {
       await createMut.mutateAsync(createForm);
       toast('Category created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -204,7 +202,7 @@ export default function CategoriesPage() {
       label: 'Create',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Activities/CostTrackingPage.jsx
+++ b/apps/nap-client/src/pages/Activities/CostTrackingPage.jsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -82,13 +83,10 @@ export default function CostTrackingPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -113,7 +111,7 @@ export default function CostTrackingPage() {
       await createMut.mutateAsync(createForm);
       toast('Actual cost created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -208,7 +206,7 @@ export default function CostTrackingPage() {
       label: 'Record Actual Cost',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Activities/DeliverablesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/DeliverablesPage.jsx
@@ -11,6 +11,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -99,13 +100,10 @@ export default function DeliverablesPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -130,7 +128,7 @@ export default function DeliverablesPage() {
       await createMut.mutateAsync(createForm);
       toast('Deliverable created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -211,7 +209,7 @@ export default function DeliverablesPage() {
       label: 'Create',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/BOM/CatalogPage.jsx
+++ b/apps/nap-client/src/pages/BOM/CatalogPage.jsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -95,13 +96,10 @@ export default function CatalogPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   const categories = useMemo(() => [...new Set(allRows.map((r) => r.category).filter(Boolean))].sort(), [allRows]);
 
@@ -127,7 +125,7 @@ export default function CatalogPage() {
       await createMut.mutateAsync(createForm);
       toast('Catalog SKU created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -224,7 +222,7 @@ export default function CatalogPage() {
       label: 'Create',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Core/ClientsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ClientsPage.jsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import { useQueryClient } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -158,8 +159,8 @@ export default function ClientsPage() {
   const viewAddresses = viewAddressesRes?.rows ?? [];
   const viewTaxIds = viewTaxIdsRes?.rows ?? [];
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
   const [editEmails, setEditEmails] = useState([]);
   const [editPhones, setEditPhones] = useState([]);
   const [editAddresses, setEditAddresses] = useState([]);
@@ -168,8 +169,6 @@ export default function ClientsPage() {
 
   const { toast, snackProps } = useToast();
 
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── App-user password popover state ────────────────────────── */
   const [pwAnchor, setPwAnchor] = useState(null);
@@ -320,7 +319,7 @@ export default function ClientsPage() {
       await createMut.mutateAsync(createForm);
       toast('Client created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -478,7 +477,7 @@ export default function ClientsPage() {
       label: 'Create Client',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Core/CompaniesPage.jsx
+++ b/apps/nap-client/src/pages/Core/CompaniesPage.jsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
@@ -111,8 +112,8 @@ export default function CompaniesPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   /* ── Edit: source-linked collections ────────────────────────── */
   const [editSourceId, setEditSourceId] = useState(null);
@@ -144,8 +145,6 @@ export default function CompaniesPage() {
 
   const { toast, snackProps } = useToast();
 
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Address / TaxId helpers ────────────────────────────────── */
   const updateAddress = (idx, field, value) =>
@@ -201,7 +200,7 @@ export default function CompaniesPage() {
       await createMut.mutateAsync(createForm);
       toast('Company created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -337,7 +336,7 @@ export default function CompaniesPage() {
       label: 'Create Company',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Core/ContactsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ContactsPage.jsx
@@ -12,6 +12,7 @@
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -148,8 +149,8 @@ export default function ContactsPage() {
   const viewAddresses = viewAddressesRes?.rows ?? [];
   const viewTaxIds = viewTaxIdsRes?.rows ?? [];
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
   const [editEmails, setEditEmails] = useState([]);
   const [editPhones, setEditPhones] = useState([]);
   const [editAddresses, setEditAddresses] = useState([]);
@@ -159,8 +160,6 @@ export default function ContactsPage() {
   const { toast, snackProps } = useToast();
 
 
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Email edit helpers ──────────────────────────────────────── */
   const updateEmail = (idx, field, value) =>
@@ -290,7 +289,7 @@ export default function ContactsPage() {
       await createMut.mutateAsync(createForm);
       toast('Contact created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -434,7 +433,7 @@ export default function ContactsPage() {
       label: 'Create Contact',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/nap-client/src/pages/Core/EmployeesPage.jsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import { useQueryClient } from '@tanstack/react-query';
 import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
@@ -176,8 +177,8 @@ export default function EmployeesPage() {
   const viewAddresses = viewAddressesRes?.rows ?? [];
   const viewTaxIds = viewTaxIdsRes?.rows ?? [];
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
   const [editPhones, setEditPhones] = useState([]);
   const [editEmails, setEditEmails] = useState([]);
   const [editAddresses, setEditAddresses] = useState([]);
@@ -187,8 +188,6 @@ export default function EmployeesPage() {
   const { toast, snackProps } = useToast();
 
 
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
   const onCreateCheck = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.checked }));
   const onEditCheck = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.checked }));
 
@@ -374,7 +373,7 @@ export default function EmployeesPage() {
       await createMut.mutateAsync(createForm);
       toast('Employee created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -535,7 +534,7 @@ export default function EmployeesPage() {
       label: 'Create Employee',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Core/VendorsPage.jsx
+++ b/apps/nap-client/src/pages/Core/VendorsPage.jsx
@@ -70,6 +70,7 @@ import { useRoles } from '../../hooks/useRoles.js';
 import { TAX_TYPES, COUNTRIES, resolveLevel } from '@nap/shared';
 import { useToast } from '../../hooks/useToast.js';
 import { cap, fmtDate, fmtPhone, errMsg } from '../../utils/format.js';
+import { useFormState } from '../../hooks/useFormState.js';
 import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
 import { vendorApi } from '../../services/vendorApi.js';
 import { emailApi } from '../../services/emailApi.js';
@@ -196,12 +197,12 @@ export default function VendorsPage() {
   const [contactEditRow, setContactEditRow] = useState(null);
 
   /* ── Contact create form ────────────────────────────────────── */
-  const [contactCreateForm, setContactCreateForm] = useState({ ...BLANK_CONTACT_FORM });
+  const { form: contactCreateForm, setForm: setContactCreateForm, field: onContactCreateField, reset: resetContactCreateForm } = useFormState(BLANK_CONTACT_FORM);
   const [contactCreateEmails, setContactCreateEmails] = useState([]);
   const [contactCreatePhones, setContactCreatePhones] = useState([]);
 
   /* ── Contact edit form ──────────────────────────────────────── */
-  const [contactEditForm, setContactEditForm] = useState({ ...BLANK_CONTACT_FORM });
+  const { form: contactEditForm, setForm: setContactEditForm, field: onContactEditField } = useFormState(BLANK_CONTACT_FORM);
   const [contactEditEmails, setContactEditEmails] = useState([]);
   const [contactEditPhones, setContactEditPhones] = useState([]);
 
@@ -242,8 +243,8 @@ export default function VendorsPage() {
   const viewTaxIds = viewTaxIdsRes?.rows ?? [];
   const viewContacts = viewContactsRes?.rows ?? [];
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
   const [editEmails, setEditEmails] = useState([]);
   const [editPhones, setEditPhones] = useState([]);
   const [editAddresses, setEditAddresses] = useState([]);
@@ -253,8 +254,6 @@ export default function VendorsPage() {
 
   const { toast, snackProps } = useToast();
 
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Email edit helpers ─────────────────────────────────────── */
   const updateEmail = (idx, field, value) =>
@@ -567,7 +566,7 @@ export default function VendorsPage() {
 
       toast('Vendor created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
       setCreateTab(0);
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -681,7 +680,7 @@ export default function VendorsPage() {
       setEditContacts(updatedContacts);
       await refreshContactChildren(updatedContacts);
       setContactCreateOpen(false);
-      setContactCreateForm({ ...BLANK_CONTACT_FORM });
+      resetContactCreateForm();
       setContactCreateEmails([]);
       setContactCreatePhones([]);
       toast('Contact created');
@@ -834,7 +833,7 @@ export default function VendorsPage() {
       variant: 'contained',
       color: 'primary',
       onClick: () => {
-        setCreateForm(BLANK_CREATE);
+        resetCreateForm();
         setCreateTab(0);
         setCreateOpen(true);
       },
@@ -1337,7 +1336,7 @@ export default function VendorsPage() {
                     </Button>
                   )}
                   {contactViewFilter !== 'archived' && (
-                    <Button size="small" startIcon={<AddIcon />} onClick={() => { setContactCreateForm({ ...BLANK_CONTACT_FORM }); setContactCreateEmails([]); setContactCreatePhones([]); setContactCreateOpen(true); }}>
+                    <Button size="small" startIcon={<AddIcon />} onClick={() => { resetContactCreateForm(); setContactCreateEmails([]); setContactCreatePhones([]); setContactCreateOpen(true); }}>
                       Create Contact
                     </Button>
                   )}
@@ -1401,10 +1400,10 @@ export default function VendorsPage() {
         loading={createContactMut.isPending}
       >
         <Box sx={formGridSx}>
-          <TextField label="First Name" required value={contactCreateForm.first_name} onChange={(e) => setContactCreateForm((p) => ({ ...p, first_name: e.target.value }))} />
-          <TextField label="Last Name" required value={contactCreateForm.last_name} onChange={(e) => setContactCreateForm((p) => ({ ...p, last_name: e.target.value }))} />
-          <TextField label="Position" value={contactCreateForm.position} onChange={(e) => setContactCreateForm((p) => ({ ...p, position: e.target.value }))} />
-          <TextField label="Department" value={contactCreateForm.department} onChange={(e) => setContactCreateForm((p) => ({ ...p, department: e.target.value }))} />
+          <TextField label="First Name" required value={contactCreateForm.first_name} onChange={onContactCreateField('first_name')} />
+          <TextField label="Last Name" required value={contactCreateForm.last_name} onChange={onContactCreateField('last_name')} />
+          <TextField label="Position" value={contactCreateForm.position} onChange={onContactCreateField('position')} />
+          <TextField label="Department" value={contactCreateForm.department} onChange={onContactCreateField('department')} />
         </Box>
         <FormControlLabel
           control={<Checkbox checked={contactCreateForm.is_app_user} onChange={handleContactAppUserToggle('create')} size="small" />}
@@ -1475,10 +1474,10 @@ export default function VendorsPage() {
         loading={updateContactMut.isPending}
       >
         <Box sx={formGridSx}>
-          <TextField label="First Name" required value={contactEditForm.first_name} onChange={(e) => setContactEditForm((p) => ({ ...p, first_name: e.target.value }))} />
-          <TextField label="Last Name" required value={contactEditForm.last_name} onChange={(e) => setContactEditForm((p) => ({ ...p, last_name: e.target.value }))} />
-          <TextField label="Position" value={contactEditForm.position} onChange={(e) => setContactEditForm((p) => ({ ...p, position: e.target.value }))} />
-          <TextField label="Department" value={contactEditForm.department} onChange={(e) => setContactEditForm((p) => ({ ...p, department: e.target.value }))} />
+          <TextField label="First Name" required value={contactEditForm.first_name} onChange={onContactEditField('first_name')} />
+          <TextField label="Last Name" required value={contactEditForm.last_name} onChange={onContactEditField('last_name')} />
+          <TextField label="Position" value={contactEditForm.position} onChange={onContactEditField('position')} />
+          <TextField label="Department" value={contactEditForm.department} onChange={onContactEditField('department')} />
         </Box>
         <FormControlLabel
           control={<Checkbox checked={contactEditForm.is_app_user} onChange={handleContactAppUserToggle('edit')} size="small" />}

--- a/apps/nap-client/src/pages/Projects/ChangeOrdersPage.jsx
+++ b/apps/nap-client/src/pages/Projects/ChangeOrdersPage.jsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -88,13 +89,10 @@ export default function ChangeOrdersPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -118,7 +116,7 @@ export default function ChangeOrdersPage() {
       await createMut.mutateAsync(createForm);
       toast('Change order created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -200,7 +198,7 @@ export default function ChangeOrdersPage() {
       label: 'Create CO',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Projects/ProjectsPage.jsx
+++ b/apps/nap-client/src/pages/Projects/ProjectsPage.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -91,13 +92,10 @@ export default function ProjectsPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
 
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
-
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -122,7 +120,7 @@ export default function ProjectsPage() {
       await createMut.mutateAsync(createForm);
       toast('Project created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -208,7 +206,7 @@ export default function ProjectsPage() {
       label: 'Create Project',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm(BLANK_CREATE); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {

--- a/apps/nap-client/src/pages/Settings/PaymentTermsPage.jsx
+++ b/apps/nap-client/src/pages/Settings/PaymentTermsPage.jsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
@@ -126,13 +127,13 @@ export default function PaymentTermsPage() {
 
   /* ── Create dialog ─────────────────────────────────────── */
   const [createOpen, setCreateOpen] = useState(false);
-  const [createForm, setCreateForm] = useState({ ...BLANK_CREATE });
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
 
   const handleCreate = useCallback(async () => {
     try {
       await createMut.mutateAsync({ ...createForm, term: Number(createForm.term) });
       setCreateOpen(false);
-      setCreateForm({ ...BLANK_CREATE });
+      resetCreateForm();
       toast('Payment term created');
     } catch (err) {
       toast(errMsg(err) || 'Create failed', 'error');
@@ -146,7 +147,7 @@ export default function PaymentTermsPage() {
   /* ── Edit dialog ───────────────────────────────────────── */
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
-  const [editForm, setEditForm] = useState({ ...BLANK_EDIT });
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const openEdit = useCallback((row) => {
     setEditRow(row);
@@ -212,7 +213,7 @@ export default function PaymentTermsPage() {
       label: 'Create Payment Term',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { setCreateForm({ ...BLANK_CREATE }); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); setCreateOpen(true); },
     });
 
     return {
@@ -246,28 +247,28 @@ export default function PaymentTermsPage() {
         submitLabel="Create"
         loading={createMut.isPending}
         onSubmit={handleCreate}
-        onCancel={() => { setCreateOpen(false); setCreateForm({ ...BLANK_CREATE }); }}
+        onCancel={() => { setCreateOpen(false); resetCreateForm(); }}
       >
         <Box sx={formGridSx}>
           <TextField
             label="Label"
             required
             value={createForm.label}
-            onChange={(e) => setCreateForm((p) => ({ ...p, label: e.target.value }))}
+            onChange={onCreateField('label')}
           />
           <TextField
             label="Term"
             type="number"
             required
             value={createForm.term}
-            onChange={(e) => setCreateForm((p) => ({ ...p, term: e.target.value }))}
+            onChange={onCreateField('term')}
             inputProps={{ min: 1 }}
           />
           <TextField
             label="Units"
             select
             value={createForm.units}
-            onChange={(e) => setCreateForm((p) => ({ ...p, units: e.target.value }))}
+            onChange={onCreateField('units')}
           >
             {UNITS_OPTIONS.map((o) => <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>)}
           </TextField>
@@ -288,21 +289,21 @@ export default function PaymentTermsPage() {
             label="Label"
             required
             value={editForm.label}
-            onChange={(e) => setEditForm((p) => ({ ...p, label: e.target.value }))}
+            onChange={onEditField('label')}
           />
           <TextField
             label="Term"
             type="number"
             required
             value={editForm.term}
-            onChange={(e) => setEditForm((p) => ({ ...p, term: e.target.value }))}
+            onChange={onEditField('term')}
             inputProps={{ min: 1 }}
           />
           <TextField
             label="Units"
             select
             value={editForm.units}
-            onChange={(e) => setEditForm((p) => ({ ...p, units: e.target.value }))}
+            onChange={onEditField('units')}
           >
             {UNITS_OPTIONS.map((o) => <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>)}
           </TextField>

--- a/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
@@ -15,6 +15,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -104,15 +105,11 @@ export default function ManageRolesPage() {
   const [editRow, setEditRow] = useState(null);
 
   /* ── form state ────────────────────────────────────────────── */
-  const [createForm, setCreateForm] = useState(BLANK_CREATE);
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   /* ── snackbar ──────────────────────────────────────────────── */
   const { toast, snackProps } = useToast();
-
-  /* ── field change factories ────────────────────────────────── */
-  const onCreateField = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.value }));
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
@@ -142,7 +139,7 @@ export default function ManageRolesPage() {
       await createMut.mutateAsync(createForm);
       toast('Role created');
       setCreateOpen(false);
-      setCreateForm(BLANK_CREATE);
+      resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -170,7 +167,7 @@ export default function ManageRolesPage() {
           variant: 'contained',
           color: 'primary',
           onClick: () => {
-            setCreateForm(BLANK_CREATE);
+            resetCreateForm();
             setCreateOpen(true);
           },
         },

--- a/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
@@ -15,6 +15,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -177,13 +178,10 @@ export default function ManageTenantsPage() {
   const [importErrors, setImportErrors] = useState(null);
 
   /* ── form state ──────────────────────────────────────────── */
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   /* ── snackbar ────────────────────────────────────────────── */
   const { toast, snackProps } = useToast();
-
-  /* ── field change factories ──────────────────────────────── */
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {

--- a/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
@@ -14,6 +14,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -116,13 +117,10 @@ export default function ManageUsersPage() {
   const [editRow, setEditRow] = useState(null);
 
   /* ── form state ──────────────────────────────────────────── */
-  const [editForm, setEditForm] = useState(BLANK_EDIT);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   /* ── snackbar ────────────────────────────────────────────── */
   const { toast, snackProps } = useToast();
-
-  /* ── field change factories ──────────────────────────────── */
-  const onEditField = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.value }));
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {


### PR DESCRIPTION
## Summary
- Add `useFormState(blank)` hook encapsulating `useState` + field-handler factory + reset
- Remove duplicated `onCreateField`/`onEditField` one-liner patterns from 24 page components
- Net reduction of boilerplate while keeping the same runtime behaviour

## Test plan
- [ ] Verify create/edit forms across all CRUD pages still populate and submit correctly
- [ ] Verify form reset on dialog close / successful create clears fields
- [ ] Verify edit form populates with existing record data when opening edit dialog