### PR TITLE
refactor: extract useDialogState hook from page components

### DIFF
--- a/apps/nap-client/src/hooks/useDialogState.js
+++ b/apps/nap-client/src/hooks/useDialogState.js
@@ -1,0 +1,28 @@
+/**
+ * @file Dialog state hook — encapsulates open/close + associated data
+ * @module nap-client/hooks/useDialogState
+ *
+ * Replaces the per-dialog `const [open, setOpen] = useState(false)` +
+ * `const [row, setRow] = useState(null)` pairs.
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useCallback } from 'react';
+
+/**
+ * @returns {{
+ *   isOpen: boolean,
+ *   data: any,
+ *   open: (data?: any) => void,
+ *   close: () => void,
+ * }}
+ */
+export function useDialogState() {
+  const [state, setState] = useState({ isOpen: false, data: null });
+
+  const open = useCallback((data = null) => setState({ isOpen: true, data }), []);
+  const close = useCallback(() => setState({ isOpen: false, data: null }), []);
+
+  return { isOpen: state.isOpen, data: state.data, open, close };
+}

--- a/apps/nap-client/src/pages/AP/ApInvoicesPage.jsx
+++ b/apps/nap-client/src/pages/AP/ApInvoicesPage.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -84,25 +85,23 @@ export default function ApInvoicesPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewInvoice, setViewInvoice] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
 
 
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -119,30 +118,28 @@ export default function ApInvoicesPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewInvoice(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       invoice_number: row.invoice_number ?? '', invoice_date: row.invoice_date?.slice(0, 10) ?? '',
       due_date: row.due_date?.slice(0, 10) ?? '', total_amount: row.total_amount ?? '',
       status: row.status ?? 'open', notes: row.notes ?? '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync({ ...createForm, total_amount: Number(createForm.total_amount) || 0 });
-      toast('Invoice created'); setCreateOpen(false); resetCreateForm();
+      toast('Invoice created'); createDialog.close(); resetCreateForm();
     } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: { ...editForm, total_amount: Number(editForm.total_amount) || 0 } });
-      toast('Invoice updated'); setEditOpen(false); setEditRow(null);
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: { ...editForm, total_amount: Number(editForm.total_amount) || 0 } });
+      toast('Invoice updated'); editDialog.close();
     } catch (err) { toast(errMsg(err), 'error'); }
   };
 
@@ -177,14 +174,14 @@ export default function ApInvoicesPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create Invoice',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -211,42 +208,42 @@ export default function ApInvoicesPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Invoice Details</span>
-            {viewInvoice && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewInvoice.invoice_number}
+                {viewDialog.data.invoice_number}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewInvoice && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="Invoice Number" value={viewInvoice.invoice_number || '\u2014'} />
-              <FieldRow label="Vendor" value={viewInvoice.vendor_id?.slice(0, 8) || '\u2014'} />
-              <FieldRow label="Invoice Date" value={fmtDate(viewInvoice.invoice_date)} />
-              <FieldRow label="Due Date" value={fmtDate(viewInvoice.due_date)} />
-              <FieldRow label="Total Amount" value={viewInvoice.total_amount != null ? Number(viewInvoice.total_amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
+              <FieldRow label="Invoice Number" value={viewDialog.data.invoice_number || '\u2014'} />
+              <FieldRow label="Vendor" value={viewDialog.data.vendor_id?.slice(0, 8) || '\u2014'} />
+              <FieldRow label="Invoice Date" value={fmtDate(viewDialog.data.invoice_date)} />
+              <FieldRow label="Due Date" value={fmtDate(viewDialog.data.due_date)} />
+              <FieldRow label="Total Amount" value={viewDialog.data.total_amount != null ? Number(viewDialog.data.total_amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
               <FieldRow label="Status">
-                <StatusBadge status={viewInvoice.status} />
+                <StatusBadge status={viewDialog.data.status} />
               </FieldRow>
-              <FieldRow label="Created" value={fmtDate(viewInvoice.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewInvoice.updated_at)} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Create AP Invoice Dialog ─────────────────────────────── */}
-      <FormDialog open={createOpen} title="Create AP Invoice" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create AP Invoice" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Vendor" select required value={createForm.vendor_id} onChange={onCreateField('vendor_id')}>
           {vendors.map((v) => <MenuItem key={v.id} value={v.id}>{v.code ? `${v.code} \u2014 ${v.name}` : v.name}</MenuItem>)}
         </TextField>
@@ -261,7 +258,7 @@ export default function ApInvoicesPage() {
       </FormDialog>
 
       {/* ── Edit AP Invoice Dialog ───────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit AP Invoice" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit AP Invoice" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <TextField label="Invoice Number" required value={editForm.invoice_number} onChange={onEditField('invoice_number')} />
         <TextField label="Invoice Date" type="date" value={editForm.invoice_date} onChange={onEditField('invoice_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Due Date" type="date" value={editForm.due_date} onChange={onEditField('due_date')} InputLabelProps={{ shrink: true }} />
@@ -275,7 +272,7 @@ export default function ApInvoicesPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importOpen} title="Import AP Invoices" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import AP Invoices" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/nap-client/src/pages/AP/CreditMemosPage.jsx
+++ b/apps/nap-client/src/pages/AP/CreditMemosPage.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -82,24 +83,22 @@ export default function CreditMemosPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewMemo, setViewMemo] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
 
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -116,24 +115,22 @@ export default function CreditMemosPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewMemo(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       credit_number: row.credit_number ?? '', credit_date: row.credit_date?.slice(0, 10) ?? '',
       amount: row.amount ?? '', reason: row.reason ?? '', status: row.status ?? 'open',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
-    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Credit memo created'); setCreateOpen(false); resetCreateForm(); } catch (err) { toast(errMsg(err), 'error'); }
+    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Credit memo created'); createDialog.close(); resetCreateForm(); } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
-    try { await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: { ...editForm, amount: Number(editForm.amount) || 0 } }); toast('Credit memo updated'); setEditOpen(false); setEditRow(null); } catch (err) { toast(errMsg(err), 'error'); }
+    try { await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: { ...editForm, amount: Number(editForm.amount) || 0 } }); toast('Credit memo updated'); editDialog.close(); } catch (err) { toast(errMsg(err), 'error'); }
   };
 
   const { setArchiveOpen, setRestoreOpen, archiveConfirmProps, restoreConfirmProps } = useArchiveRestore({
@@ -167,14 +164,14 @@ export default function CreditMemosPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create Memo',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -201,42 +198,42 @@ export default function CreditMemosPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Credit Memo Details</span>
-            {viewMemo && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewMemo.credit_number}
+                {viewDialog.data.credit_number}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewMemo && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="Credit Number" value={viewMemo.credit_number || '\u2014'} />
-              <FieldRow label="Vendor" value={viewMemo.vendor_id?.slice(0, 8) || '\u2014'} />
-              <FieldRow label="Credit Date" value={fmtDate(viewMemo.credit_date)} />
-              <FieldRow label="Amount" value={viewMemo.amount != null ? Number(viewMemo.amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
+              <FieldRow label="Credit Number" value={viewDialog.data.credit_number || '\u2014'} />
+              <FieldRow label="Vendor" value={viewDialog.data.vendor_id?.slice(0, 8) || '\u2014'} />
+              <FieldRow label="Credit Date" value={fmtDate(viewDialog.data.credit_date)} />
+              <FieldRow label="Amount" value={viewDialog.data.amount != null ? Number(viewDialog.data.amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
               <FieldRow label="Status">
-                <StatusBadge status={viewMemo.status} />
+                <StatusBadge status={viewDialog.data.status} />
               </FieldRow>
-              <FieldRow label="Reason" value={viewMemo.reason || '\u2014'} />
-              <FieldRow label="Created" value={fmtDate(viewMemo.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewMemo.updated_at)} />
+              <FieldRow label="Reason" value={viewDialog.data.reason || '\u2014'} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Create Credit Memo Dialog ────────────────────────────── */}
-      <FormDialog open={createOpen} title="Create Credit Memo" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Credit Memo" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Vendor" select required value={createForm.vendor_id} onChange={onCreateField('vendor_id')}>
           {vendors.map((v) => <MenuItem key={v.id} value={v.id}>{v.code ? `${v.code} \u2014 ${v.name}` : v.name}</MenuItem>)}
         </TextField>
@@ -251,7 +248,7 @@ export default function CreditMemosPage() {
       </FormDialog>
 
       {/* ── Edit Credit Memo Dialog ──────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Credit Memo" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Credit Memo" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <TextField label="Credit Number" value={editForm.credit_number} onChange={onEditField('credit_number')} />
         <TextField label="Credit Date" type="date" value={editForm.credit_date} onChange={onEditField('credit_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Amount" type="number" value={editForm.amount} onChange={onEditField('amount')} />
@@ -264,7 +261,7 @@ export default function CreditMemosPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importOpen} title="Import Credit Memos" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import Credit Memos" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/nap-client/src/pages/AP/PaymentsPage.jsx
+++ b/apps/nap-client/src/pages/AP/PaymentsPage.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -81,25 +82,23 @@ export default function PaymentsPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewPayment, setViewPayment] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
 
 
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -116,24 +115,22 @@ export default function PaymentsPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewPayment(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       payment_date: row.payment_date?.slice(0, 10) ?? '', amount: row.amount ?? '',
       method: row.method ?? 'check', reference: row.reference ?? '', notes: row.notes ?? '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
-    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Payment created'); setCreateOpen(false); resetCreateForm(); } catch (err) { toast(errMsg(err), 'error'); }
+    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Payment created'); createDialog.close(); resetCreateForm(); } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
-    try { await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: { ...editForm, amount: Number(editForm.amount) || 0 } }); toast('Payment updated'); setEditOpen(false); setEditRow(null); } catch (err) { toast(errMsg(err), 'error'); }
+    try { await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: { ...editForm, amount: Number(editForm.amount) || 0 } }); toast('Payment updated'); editDialog.close(); } catch (err) { toast(errMsg(err), 'error'); }
   };
 
   const { setArchiveOpen, setRestoreOpen, archiveConfirmProps, restoreConfirmProps } = useArchiveRestore({
@@ -167,14 +164,14 @@ export default function PaymentsPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Record Payment',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -201,39 +198,39 @@ export default function PaymentsPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Payment Details</span>
-            {viewPayment && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewPayment.reference || viewPayment.id?.slice(0, 8)}
+                {viewDialog.data.reference || viewDialog.data.id?.slice(0, 8)}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewPayment && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="Payment Date" value={fmtDate(viewPayment.payment_date)} />
-              <FieldRow label="Vendor" value={viewPayment.vendor_id?.slice(0, 8) || '\u2014'} />
-              <FieldRow label="Amount" value={viewPayment.amount != null ? Number(viewPayment.amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
-              <FieldRow label="Method" value={capSnake(viewPayment.method)} />
-              <FieldRow label="Reference" value={viewPayment.reference || '\u2014'} />
-              <FieldRow label="Created" value={fmtDate(viewPayment.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewPayment.updated_at)} />
+              <FieldRow label="Payment Date" value={fmtDate(viewDialog.data.payment_date)} />
+              <FieldRow label="Vendor" value={viewDialog.data.vendor_id?.slice(0, 8) || '\u2014'} />
+              <FieldRow label="Amount" value={viewDialog.data.amount != null ? Number(viewDialog.data.amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
+              <FieldRow label="Method" value={capSnake(viewDialog.data.method)} />
+              <FieldRow label="Reference" value={viewDialog.data.reference || '\u2014'} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Record Payment Dialog ────────────────────────────────── */}
-      <FormDialog open={createOpen} title="Record Payment" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Record Payment" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Vendor" select required value={createForm.vendor_id} onChange={onCreateField('vendor_id')}>
           {vendors.map((v) => <MenuItem key={v.id} value={v.id}>{v.code ? `${v.code} \u2014 ${v.name}` : v.name}</MenuItem>)}
         </TextField>
@@ -248,7 +245,7 @@ export default function PaymentsPage() {
       </FormDialog>
 
       {/* ── Edit Payment Dialog ──────────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Payment" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Payment" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <TextField label="Payment Date" type="date" value={editForm.payment_date} onChange={onEditField('payment_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Amount" type="number" value={editForm.amount} onChange={onEditField('amount')} />
         <TextField label="Method" select value={editForm.method} onChange={onEditField('method')}>
@@ -261,7 +258,7 @@ export default function PaymentsPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importOpen} title="Import Payments" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import Payments" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/nap-client/src/pages/AR/ArInvoicesPage.jsx
+++ b/apps/nap-client/src/pages/AR/ArInvoicesPage.jsx
@@ -10,6 +10,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -89,24 +90,22 @@ export default function ArInvoicesPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewInvoice, setViewInvoice] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
 
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -123,30 +122,28 @@ export default function ArInvoicesPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewInvoice(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       invoice_number: row.invoice_number ?? '', invoice_date: row.invoice_date?.slice(0, 10) ?? '',
       due_date: row.due_date?.slice(0, 10) ?? '', total_amount: row.total_amount ?? '',
       status: row.status ?? 'open', notes: row.notes ?? '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync({ ...createForm, total_amount: Number(createForm.total_amount) || 0 });
-      toast('Invoice created'); setCreateOpen(false); resetCreateForm();
+      toast('Invoice created'); createDialog.close(); resetCreateForm();
     } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: { ...editForm, total_amount: Number(editForm.total_amount) || 0 } });
-      toast('Invoice updated'); setEditOpen(false); setEditRow(null);
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: { ...editForm, total_amount: Number(editForm.total_amount) || 0 } });
+      toast('Invoice updated'); editDialog.close();
     } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleApprove = async () => {
@@ -192,14 +189,14 @@ export default function ArInvoicesPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create Invoice',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -226,42 +223,42 @@ export default function ArInvoicesPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Invoice Details</span>
-            {viewInvoice && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewInvoice.invoice_number}
+                {viewDialog.data.invoice_number}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewInvoice && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="Invoice Number" value={viewInvoice.invoice_number || '\u2014'} />
-              <FieldRow label="Client" value={viewInvoice.client_id?.slice(0, 8) || '\u2014'} />
-              <FieldRow label="Invoice Date" value={fmtDate(viewInvoice.invoice_date)} />
-              <FieldRow label="Due Date" value={fmtDate(viewInvoice.due_date)} />
-              <FieldRow label="Total Amount" value={viewInvoice.total_amount != null ? Number(viewInvoice.total_amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
+              <FieldRow label="Invoice Number" value={viewDialog.data.invoice_number || '\u2014'} />
+              <FieldRow label="Client" value={viewDialog.data.client_id?.slice(0, 8) || '\u2014'} />
+              <FieldRow label="Invoice Date" value={fmtDate(viewDialog.data.invoice_date)} />
+              <FieldRow label="Due Date" value={fmtDate(viewDialog.data.due_date)} />
+              <FieldRow label="Total Amount" value={viewDialog.data.total_amount != null ? Number(viewDialog.data.total_amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
               <FieldRow label="Status">
-                <StatusBadge status={viewInvoice.status} />
+                <StatusBadge status={viewDialog.data.status} />
               </FieldRow>
-              <FieldRow label="Created" value={fmtDate(viewInvoice.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewInvoice.updated_at)} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Create AR Invoice Dialog ─────────────────────────────── */}
-      <FormDialog open={createOpen} title="Create AR Invoice" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create AR Invoice" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Client" select required value={createForm.client_id} onChange={onCreateField('client_id')}>
           {clients.map((c) => <MenuItem key={c.id} value={c.id}>{c.client_code ? `${c.client_code} \u2014 ${c.name}` : c.name}</MenuItem>)}
         </TextField>
@@ -276,7 +273,7 @@ export default function ArInvoicesPage() {
       </FormDialog>
 
       {/* ── Edit AR Invoice Dialog ───────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit AR Invoice" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit AR Invoice" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <TextField label="Invoice Number" value={editForm.invoice_number} onChange={onEditField('invoice_number')} />
         <TextField label="Invoice Date" type="date" value={editForm.invoice_date} onChange={onEditField('invoice_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Due Date" type="date" value={editForm.due_date} onChange={onEditField('due_date')} InputLabelProps={{ shrink: true }} />
@@ -290,7 +287,7 @@ export default function ArInvoicesPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importOpen} title="Import AR Invoices" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import AR Invoices" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/nap-client/src/pages/AR/ReceiptsPage.jsx
+++ b/apps/nap-client/src/pages/AR/ReceiptsPage.jsx
@@ -10,6 +10,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -84,24 +85,22 @@ export default function ReceiptsPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewReceipt, setViewReceipt] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const { toast, snackProps } = useToast();
 
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
 
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -118,24 +117,22 @@ export default function ReceiptsPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewReceipt(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       receipt_date: row.receipt_date?.slice(0, 10) ?? '', amount: row.amount ?? '',
       method: row.method ?? 'check', reference: row.reference ?? '', notes: row.notes ?? '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
-    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Receipt created'); setCreateOpen(false); resetCreateForm(); } catch (err) { toast(errMsg(err), 'error'); }
+    try { await createMut.mutateAsync({ ...createForm, amount: Number(createForm.amount) || 0 }); toast('Receipt created'); createDialog.close(); resetCreateForm(); } catch (err) { toast(errMsg(err), 'error'); }
   };
   const handleUpdate = async () => {
-    try { await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: { ...editForm, amount: Number(editForm.amount) || 0 } }); toast('Receipt updated'); setEditOpen(false); setEditRow(null); } catch (err) { toast(errMsg(err), 'error'); }
+    try { await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: { ...editForm, amount: Number(editForm.amount) || 0 } }); toast('Receipt updated'); editDialog.close(); } catch (err) { toast(errMsg(err), 'error'); }
   };
 
   const { setArchiveOpen, setRestoreOpen, archiveConfirmProps, restoreConfirmProps } = useArchiveRestore({
@@ -169,14 +166,14 @@ export default function ReceiptsPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Record Receipt',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -203,39 +200,39 @@ export default function ReceiptsPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Receipt Details</span>
-            {viewReceipt && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewReceipt.reference || viewReceipt.id?.slice(0, 8)}
+                {viewDialog.data.reference || viewDialog.data.id?.slice(0, 8)}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewReceipt && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="Receipt Date" value={fmtDate(viewReceipt.receipt_date)} />
-              <FieldRow label="Client" value={viewReceipt.client_id?.slice(0, 8) || '\u2014'} />
-              <FieldRow label="Amount" value={viewReceipt.amount != null ? Number(viewReceipt.amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
-              <FieldRow label="Method" value={capSnake(viewReceipt.method)} />
-              <FieldRow label="Reference" value={viewReceipt.reference || '\u2014'} />
-              <FieldRow label="Created" value={fmtDate(viewReceipt.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewReceipt.updated_at)} />
+              <FieldRow label="Receipt Date" value={fmtDate(viewDialog.data.receipt_date)} />
+              <FieldRow label="Client" value={viewDialog.data.client_id?.slice(0, 8) || '\u2014'} />
+              <FieldRow label="Amount" value={viewDialog.data.amount != null ? Number(viewDialog.data.amount).toLocaleString(undefined, { style: 'currency', currency: 'USD' }) : '\u2014'} />
+              <FieldRow label="Method" value={capSnake(viewDialog.data.method)} />
+              <FieldRow label="Reference" value={viewDialog.data.reference || '\u2014'} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Record Receipt Dialog ────────────────────────────────── */}
-      <FormDialog open={createOpen} title="Record Receipt" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Record Receipt" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Client" select required value={createForm.client_id} onChange={onCreateField('client_id')}>
           {clients.map((c) => <MenuItem key={c.id} value={c.id}>{c.client_code ? `${c.client_code} \u2014 ${c.name}` : c.name}</MenuItem>)}
         </TextField>
@@ -250,7 +247,7 @@ export default function ReceiptsPage() {
       </FormDialog>
 
       {/* ── Edit Receipt Dialog ──────────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Receipt" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Receipt" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <TextField label="Receipt Date" type="date" value={editForm.receipt_date} onChange={onEditField('receipt_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Amount" type="number" value={editForm.amount} onChange={onEditField('amount')} />
         <TextField label="Method" select value={editForm.method} onChange={onEditField('method')}>
@@ -263,7 +260,7 @@ export default function ReceiptsPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importOpen} title="Import Receipts" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import Receipts" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
@@ -10,6 +10,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -92,12 +93,10 @@ export default function ChartOfAccountsPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewAccount, setViewAccount] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -107,21 +106,19 @@ export default function ChartOfAccountsPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewAccount(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({ name: row.name ?? '', type: row.type ?? 'asset', is_active: row.is_active ?? true, cash_basis: row.cash_basis ?? false });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Account created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -130,10 +127,9 @@ export default function ChartOfAccountsPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Account updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -143,7 +139,7 @@ export default function ChartOfAccountsPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -196,14 +192,14 @@ export default function ChartOfAccountsPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create Account',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -230,42 +226,42 @@ export default function ChartOfAccountsPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Account Details</span>
-            {viewAccount && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewAccount.name}
+                {viewDialog.data.name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewAccount && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewAccount.code || '\u2014'} />
-                <FieldRow label="Name" value={viewAccount.name} />
-                <FieldRow label="Type" value={cap(viewAccount.type)} />
-                <FieldRow label="Cash Basis" value={viewAccount.cash_basis ? 'Yes' : 'No'} />
+                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
+                <FieldRow label="Name" value={viewDialog.data.name} />
+                <FieldRow label="Type" value={cap(viewDialog.data.type)} />
+                <FieldRow label="Cash Basis" value={viewDialog.data.cash_basis ? 'Yes' : 'No'} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewAccount.deactivated_at ? 'archived' : 'active'} />
+                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
                 </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewAccount.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewAccount.updated_at)} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
-      <FormDialog open={createOpen} title="Create Account" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Account" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Account Code" required value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
         <TextField label="Account Name" required value={createForm.name} onChange={onCreateField('name')} />
         <TextField label="Type" select value={createForm.type} onChange={onCreateField('type')}>
@@ -273,8 +269,8 @@ export default function ChartOfAccountsPage() {
         </TextField>
       </FormDialog>
 
-      <FormDialog open={editOpen} title="Edit Account" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
-        {editRow && <TextField label="Account Code" value={editRow.code} disabled />}
+      <FormDialog open={editDialog.isOpen} title="Edit Account" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
+        {editDialog.data && <TextField label="Account Code" value={editDialog.data.code} disabled />}
         <TextField label="Account Name" required value={editForm.name} onChange={onEditField('name')} />
         <TextField label="Type" select value={editForm.type} onChange={onEditField('type')}>
           {ACCT_TYPES.map((t) => <MenuItem key={t} value={t}>{cap(t)}</MenuItem>)}
@@ -282,11 +278,11 @@ export default function ChartOfAccountsPage() {
       </FormDialog>
 
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Chart of Accounts"
         loading={importMut.isPending}
         onSubmit={handleImport}
-        onCancel={() => setImportOpen(false)}
+        onCancel={importDialog.close}
       />
 
       <ConfirmDialog {...archiveConfirmProps} />

--- a/apps/nap-client/src/pages/Accounting/JournalEntriesPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/JournalEntriesPage.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -83,12 +84,10 @@ export default function JournalEntriesPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewEntry, setViewEntry] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -98,26 +97,24 @@ export default function JournalEntriesPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewEntry(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       entry_date: row.entry_date?.slice(0, 10) ?? '',
       description: row.description ?? '',
       status: row.status ?? 'pending',
       source_type: row.source_type ?? '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Journal entry created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -126,10 +123,9 @@ export default function JournalEntriesPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Entry updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -157,7 +153,7 @@ export default function JournalEntriesPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -210,7 +206,7 @@ export default function JournalEntriesPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
@@ -232,7 +228,7 @@ export default function JournalEntriesPage() {
       label: 'Create Entry',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -259,41 +255,41 @@ export default function JournalEntriesPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Journal Entry Details</span>
-            {viewEntry && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewEntry.description}
+                {viewDialog.data.description}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewEntry && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="ID" value={viewEntry.id?.slice(0, 8) || '\u2014'} />
-              <FieldRow label="Entry Date" value={fmtDate(viewEntry.entry_date)} />
-              <FieldRow label="Description" value={viewEntry.description || '\u2014'} />
+              <FieldRow label="ID" value={viewDialog.data.id?.slice(0, 8) || '\u2014'} />
+              <FieldRow label="Entry Date" value={fmtDate(viewDialog.data.entry_date)} />
+              <FieldRow label="Description" value={viewDialog.data.description || '\u2014'} />
               <FieldRow label="Status">
-                <StatusBadge status={viewEntry.status} />
+                <StatusBadge status={viewDialog.data.status} />
               </FieldRow>
-              <FieldRow label="Source Type" value={capSnake(viewEntry.source_type || '') || '\u2014'} />
-              <FieldRow label="Created" value={fmtDate(viewEntry.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewEntry.updated_at)} />
+              <FieldRow label="Source Type" value={capSnake(viewDialog.data.source_type || '') || '\u2014'} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Create Journal Entry Dialog ───────────────────────────── */}
-      <FormDialog open={createOpen} title="Create Journal Entry" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Journal Entry" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Entry Date" type="date" required value={createForm.entry_date} onChange={onCreateField('entry_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Description" multiline minRows={2} value={createForm.description} onChange={onCreateField('description')} />
         <TextField label="Status" select value={createForm.status} onChange={onCreateField('status')}>
@@ -303,7 +299,7 @@ export default function JournalEntriesPage() {
       </FormDialog>
 
       {/* ── Edit Journal Entry Dialog ─────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Journal Entry" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Journal Entry" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <TextField label="Entry Date" type="date" value={editForm.entry_date} onChange={onEditField('entry_date')} InputLabelProps={{ shrink: true }} />
         <TextField label="Description" multiline minRows={2} value={editForm.description} onChange={onEditField('description')} />
         <TextField label="Status" select value={editForm.status} onChange={onEditField('status')}>
@@ -313,11 +309,11 @@ export default function JournalEntriesPage() {
       </FormDialog>
 
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Journal Entries"
         loading={importMut.isPending}
         onSubmit={handleImport}
-        onCancel={() => setImportOpen(false)}
+        onCancel={importDialog.close}
       />
 
       <ConfirmDialog {...archiveConfirmProps} />

--- a/apps/nap-client/src/pages/Activities/ActivitiesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/ActivitiesPage.jsx
@@ -13,6 +13,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -105,12 +106,10 @@ export default function ActivitiesPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewActivity, setViewActivity] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -119,26 +118,24 @@ export default function ActivitiesPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewActivity(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       code: row.code || '',
       name: row.name || '',
       category_id: row.category_id || '',
       is_active: row.is_active ?? true,
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Activity created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -147,10 +144,9 @@ export default function ActivitiesPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Activity updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -160,7 +156,7 @@ export default function ActivitiesPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -213,14 +209,14 @@ export default function ActivitiesPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -247,34 +243,34 @@ export default function ActivitiesPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Activity Details</span>
-            {viewActivity && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewActivity.name}
+                {viewDialog.data.name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewActivity && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewActivity.code || '\u2014'} />
-                <FieldRow label="Name" value={viewActivity.name} />
-                <FieldRow label="Category" value={catMap[viewActivity.category_id]?.name || '\u2014'} />
+                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
+                <FieldRow label="Name" value={viewDialog.data.name} />
+                <FieldRow label="Category" value={catMap[viewDialog.data.category_id]?.name || '\u2014'} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewActivity.deactivated_at ? 'archived' : 'active'} />
+                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
                 </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewActivity.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewActivity.updated_at)} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
             </Box>
           )}
@@ -282,7 +278,7 @@ export default function ActivitiesPage() {
       </Dialog>
 
       {/* Create Dialog */}
-      <FormDialog open={createOpen} title="Create Activity" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Activity" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Code" required value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
           <TextField label="Name" required value={createForm.name} onChange={onCreateField('name')} inputProps={{ maxLength: 64 }} />
@@ -297,7 +293,7 @@ export default function ActivitiesPage() {
       </FormDialog>
 
       {/* Edit Dialog */}
-      <FormDialog open={editOpen} title="Edit Activity" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Activity" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Code" required value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
           <TextField label="Name" required value={editForm.name} onChange={onEditField('name')} inputProps={{ maxLength: 64 }} />
@@ -312,11 +308,11 @@ export default function ActivitiesPage() {
       </FormDialog>
 
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Activities"
         loading={importMut.isPending}
         onSubmit={handleImport}
-        onCancel={() => setImportOpen(false)}
+        onCancel={importDialog.close}
       />
 
       <ConfirmDialog {...archiveConfirmProps} />

--- a/apps/nap-client/src/pages/Activities/BudgetManagementPage.jsx
+++ b/apps/nap-client/src/pages/Activities/BudgetManagementPage.jsx
@@ -13,6 +13,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -85,13 +86,11 @@ export default function BudgetManagementPage() {
   const { selectedRows, allActive } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewBudget, setViewBudget] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
-  const [versionOpen, setVersionOpen] = useState(false);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
+  const versionDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -100,21 +99,19 @@ export default function BudgetManagementPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewBudget(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({ budgeted_amount: row.budgeted_amount || '', status: row.status || '' });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Budget created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -123,10 +120,9 @@ export default function BudgetManagementPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Budget updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -136,7 +132,7 @@ export default function BudgetManagementPage() {
     try {
       await newVersionMut.mutateAsync({ budget_id: selection.selected.id });
       toast('New budget version created');
-      setVersionOpen(false);
+      versionDialog.close();
       selection.clearSelection();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -147,7 +143,7 @@ export default function BudgetManagementPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -227,21 +223,21 @@ export default function BudgetManagementPage() {
       label: 'New Version',
       variant: 'outlined',
       disabled: !canNewVersion,
-      onClick: () => setVersionOpen(true),
+      onClick: () => versionDialog.open(),
     });
 
     if (canExport) {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create Budget',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -269,39 +265,39 @@ export default function BudgetManagementPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Budget Details</span>
-            {viewBudget && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {deliverableMap[viewBudget.deliverable_id] || viewBudget.deliverable_id}
+                {deliverableMap[viewDialog.data.deliverable_id] || viewDialog.data.deliverable_id}
                 {' / '}
-                {activityMap[viewBudget.activity_id] || viewBudget.activity_id}
+                {activityMap[viewDialog.data.activity_id] || viewDialog.data.activity_id}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewBudget && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Deliverable" value={deliverableMap[viewBudget.deliverable_id] || viewBudget.deliverable_id} />
-                <FieldRow label="Activity" value={activityMap[viewBudget.activity_id] || viewBudget.activity_id} />
-                <FieldRow label="Budgeted Amount" value={viewBudget.budgeted_amount} />
-                <FieldRow label="Version" value={viewBudget.version} />
-                <FieldRow label="Is Current" value={viewBudget.is_current ? 'Yes' : 'No'} />
+                <FieldRow label="Deliverable" value={deliverableMap[viewDialog.data.deliverable_id] || viewDialog.data.deliverable_id} />
+                <FieldRow label="Activity" value={activityMap[viewDialog.data.activity_id] || viewDialog.data.activity_id} />
+                <FieldRow label="Budgeted Amount" value={viewDialog.data.budgeted_amount} />
+                <FieldRow label="Version" value={viewDialog.data.version} />
+                <FieldRow label="Is Current" value={viewDialog.data.is_current ? 'Yes' : 'No'} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewBudget.status} />
+                  <StatusBadge status={viewDialog.data.status} />
                 </FieldRow>
-                <FieldRow label="Approved At" value={fmtDate(viewBudget.approved_at)} />
-                <FieldRow label="Created" value={fmtDate(viewBudget.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewBudget.updated_at)} />
+                <FieldRow label="Approved At" value={fmtDate(viewDialog.data.approved_at)} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
             </Box>
           )}
@@ -309,7 +305,7 @@ export default function BudgetManagementPage() {
       </Dialog>
 
       {/* Create Dialog */}
-      <FormDialog open={createOpen} title="Create Budget" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Budget" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Deliverable" required select value={createForm.deliverable_id} onChange={onCreateField('deliverable_id')}>
             {deliverables.map((d) => <MenuItem key={d.id} value={d.id}>{d.name}</MenuItem>)}
@@ -322,7 +318,7 @@ export default function BudgetManagementPage() {
       </FormDialog>
 
       {/* Edit Dialog */}
-      <FormDialog open={editOpen} title="Edit Budget" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Budget" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Budgeted Amount" type="number" value={editForm.budgeted_amount} onChange={onEditField('budgeted_amount')} />
           <TextField label="Status" select value={editForm.status} onChange={onEditField('status')}>
@@ -333,16 +329,16 @@ export default function BudgetManagementPage() {
 
       {/* New Version Confirm */}
       <ConfirmDialog
-        open={versionOpen}
+        open={versionDialog.isOpen}
         title="Create New Budget Version"
         message={selection.selected ? `Create a new draft version from budget v${selection.selected.version}? The current version will be marked as superseded.` : ''}
         confirmLabel="Create Version"
         loading={newVersionMut.isPending}
         onConfirm={handleNewVersion}
-        onCancel={() => setVersionOpen(false)}
+        onCancel={versionDialog.close}
       />
 
-      <ImportDialog open={importOpen} title="Import Budgets" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import Budgets" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
 

--- a/apps/nap-client/src/pages/Activities/CategoriesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/CategoriesPage.jsx
@@ -13,6 +13,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -88,12 +89,10 @@ export default function CategoriesPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewCategory, setViewCategory] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -102,25 +101,23 @@ export default function CategoriesPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewCategory(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       code: row.code || '',
       name: row.name || '',
       type: row.type || '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Category created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -129,10 +126,9 @@ export default function CategoriesPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Category updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -142,7 +138,7 @@ export default function CategoriesPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -195,14 +191,14 @@ export default function CategoriesPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -229,34 +225,34 @@ export default function CategoriesPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Category Details</span>
-            {viewCategory && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewCategory.name}
+                {viewDialog.data.name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewCategory && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewCategory.code || '\u2014'} />
-                <FieldRow label="Name" value={viewCategory.name} />
-                <FieldRow label="Type" value={cap(viewCategory.type)} />
+                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
+                <FieldRow label="Name" value={viewDialog.data.name} />
+                <FieldRow label="Type" value={cap(viewDialog.data.type)} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewCategory.deactivated_at ? 'archived' : 'active'} />
+                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
                 </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewCategory.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewCategory.updated_at)} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
             </Box>
           )}
@@ -264,7 +260,7 @@ export default function CategoriesPage() {
       </Dialog>
 
       {/* Create Dialog */}
-      <FormDialog open={createOpen} title="Create Category" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Category" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Code" required value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
           <TextField label="Name" required value={createForm.name} onChange={onCreateField('name')} inputProps={{ maxLength: 64 }} />
@@ -275,7 +271,7 @@ export default function CategoriesPage() {
       </FormDialog>
 
       {/* Edit Dialog */}
-      <FormDialog open={editOpen} title="Edit Category" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Category" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Code" required value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
           <TextField label="Name" required value={editForm.name} onChange={onEditField('name')} inputProps={{ maxLength: 64 }} />
@@ -286,11 +282,11 @@ export default function CategoriesPage() {
       </FormDialog>
 
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Categories"
         loading={importMut.isPending}
         onSubmit={handleImport}
-        onCancel={() => setImportOpen(false)}
+        onCancel={importDialog.close}
       />
 
       <ConfirmDialog {...archiveConfirmProps} />

--- a/apps/nap-client/src/pages/Activities/CostTrackingPage.jsx
+++ b/apps/nap-client/src/pages/Activities/CostTrackingPage.jsx
@@ -9,6 +9,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -76,12 +77,10 @@ export default function CostTrackingPage() {
   const { selectedRows, allActive } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewCost, setViewCost] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -90,12 +89,10 @@ export default function CostTrackingPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewCost(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       amount: row.amount || '',
       currency: row.currency || 'USD',
@@ -103,14 +100,14 @@ export default function CostTrackingPage() {
       approval_status: row.approval_status || '',
       incurred_on: row.incurred_on || '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Actual cost created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -119,10 +116,9 @@ export default function CostTrackingPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Actual cost updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -132,7 +128,7 @@ export default function CostTrackingPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -199,14 +195,14 @@ export default function CostTrackingPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Record Actual Cost',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -234,42 +230,42 @@ export default function CostTrackingPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Actual Cost Details</span>
-            {viewCost && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewCost.reference || viewCost.amount}
+                {viewDialog.data.reference || viewDialog.data.amount}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewCost && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="Activity" value={activityMap[viewCost.activity_id] || viewCost.activity_id || '\u2014'} />
-              <FieldRow label="Amount" value={viewCost.amount ?? '\u2014'} />
-              <FieldRow label="Currency" value={viewCost.currency || '\u2014'} />
+              <FieldRow label="Activity" value={activityMap[viewDialog.data.activity_id] || viewDialog.data.activity_id || '\u2014'} />
+              <FieldRow label="Amount" value={viewDialog.data.amount ?? '\u2014'} />
+              <FieldRow label="Currency" value={viewDialog.data.currency || '\u2014'} />
               <FieldRow label="Approval Status">
-                <StatusBadge status={viewCost.approval_status} />
+                <StatusBadge status={viewDialog.data.approval_status} />
               </FieldRow>
-              <FieldRow label="Incurred On" value={viewCost.incurred_on || '\u2014'} />
-              <FieldRow label="Reference" value={viewCost.reference || '\u2014'} />
-              <FieldRow label="Created" value={fmtDate(viewCost.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewCost.updated_at)} />
+              <FieldRow label="Incurred On" value={viewDialog.data.incurred_on || '\u2014'} />
+              <FieldRow label="Reference" value={viewDialog.data.reference || '\u2014'} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Create Dialog ─────────────────────────────────────────── */}
-      <FormDialog open={createOpen} title="Record Actual Cost" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Record Actual Cost" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Activity" required select value={createForm.activity_id} onChange={onCreateField('activity_id')}>
             {activities.map((a) => <MenuItem key={a.id} value={a.id}>{a.code} — {a.name}</MenuItem>)}
@@ -282,7 +278,7 @@ export default function CostTrackingPage() {
       </FormDialog>
 
       {/* ── Edit Dialog ───────────────────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Actual Cost" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Actual Cost" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Amount" type="number" value={editForm.amount} onChange={onEditField('amount')} />
           <TextField label="Currency" value={editForm.currency} onChange={onEditField('currency')} inputProps={{ maxLength: 3 }} />
@@ -294,7 +290,7 @@ export default function CostTrackingPage() {
         </Box>
       </FormDialog>
 
-      <ImportDialog open={importOpen} title="Import Actual Costs" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import Actual Costs" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
 

--- a/apps/nap-client/src/pages/Activities/DeliverablesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/DeliverablesPage.jsx
@@ -12,6 +12,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -93,12 +94,10 @@ export default function DeliverablesPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewDeliverable, setViewDeliverable] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -107,12 +106,10 @@ export default function DeliverablesPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewDeliverable(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       name: row.name || '',
       description: row.description || '',
@@ -120,14 +117,14 @@ export default function DeliverablesPage() {
       start_date: row.start_date || '',
       end_date: row.end_date || '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Deliverable created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -136,10 +133,9 @@ export default function DeliverablesPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Deliverable updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -149,7 +145,7 @@ export default function DeliverablesPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -202,14 +198,14 @@ export default function DeliverablesPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -236,35 +232,35 @@ export default function DeliverablesPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Deliverable Details</span>
-            {viewDeliverable && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewDeliverable.name}
+                {viewDialog.data.name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewDeliverable && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Name" value={viewDeliverable.name} />
+                <FieldRow label="Name" value={viewDialog.data.name} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewDeliverable.status} />
+                  <StatusBadge status={viewDialog.data.status} />
                 </FieldRow>
-                <FieldRow label="Start Date" value={fmtDate(viewDeliverable.start_date)} />
-                <FieldRow label="End Date" value={fmtDate(viewDeliverable.end_date)} />
-                <FieldRow label="Description" value={viewDeliverable.description || '\u2014'} />
-                <FieldRow label="Created" value={fmtDate(viewDeliverable.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewDeliverable.updated_at)} />
+                <FieldRow label="Start Date" value={fmtDate(viewDialog.data.start_date)} />
+                <FieldRow label="End Date" value={fmtDate(viewDialog.data.end_date)} />
+                <FieldRow label="Description" value={viewDialog.data.description || '\u2014'} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
             </Box>
           )}
@@ -272,7 +268,7 @@ export default function DeliverablesPage() {
       </Dialog>
 
       {/* Create Dialog */}
-      <FormDialog open={createOpen} title="Create Deliverable" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Deliverable" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Name" required value={createForm.name} onChange={onCreateField('name')} inputProps={{ maxLength: 128 }} />
           <TextField label="Status" select value={createForm.status} onChange={onCreateField('status')}>
@@ -285,7 +281,7 @@ export default function DeliverablesPage() {
       </FormDialog>
 
       {/* Edit Dialog */}
-      <FormDialog open={editOpen} title="Edit Deliverable" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Deliverable" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="Name" required value={editForm.name} onChange={onEditField('name')} inputProps={{ maxLength: 128 }} />
           <TextField label="Status" select value={editForm.status} onChange={onEditField('status')}>
@@ -298,11 +294,11 @@ export default function DeliverablesPage() {
       </FormDialog>
 
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Deliverables"
         loading={importMut.isPending}
         onSubmit={handleImport}
-        onCancel={() => setImportOpen(false)}
+        onCancel={importDialog.close}
       />
 
       <ConfirmDialog {...archiveConfirmProps} />

--- a/apps/nap-client/src/pages/BOM/CatalogPage.jsx
+++ b/apps/nap-client/src/pages/BOM/CatalogPage.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -89,12 +90,10 @@ export default function CatalogPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewSku, setViewSku] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -105,26 +104,24 @@ export default function CatalogPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewSku(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       catalog_sku: row.catalog_sku || '',
       description: row.description || '',
       category: row.category || '',
       sub_category: row.sub_category || '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Catalog SKU created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -133,10 +130,9 @@ export default function CatalogPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Catalog SKU updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -155,7 +151,7 @@ export default function CatalogPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -215,14 +211,14 @@ export default function CatalogPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -249,42 +245,42 @@ export default function CatalogPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Catalog SKU Details</span>
-            {viewSku && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewSku.catalog_sku}
+                {viewDialog.data.catalog_sku}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewSku && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="Catalog SKU" value={viewSku.catalog_sku || '\u2014'} />
-              <FieldRow label="Description" value={viewSku.description || '\u2014'} />
-              <FieldRow label="Category" value={viewSku.category || '\u2014'} />
-              <FieldRow label="Sub-Category" value={viewSku.sub_category || '\u2014'} />
-              <FieldRow label="Embedded" value={viewSku.embedding ? 'Yes' : 'No'} />
+              <FieldRow label="Catalog SKU" value={viewDialog.data.catalog_sku || '\u2014'} />
+              <FieldRow label="Description" value={viewDialog.data.description || '\u2014'} />
+              <FieldRow label="Category" value={viewDialog.data.category || '\u2014'} />
+              <FieldRow label="Sub-Category" value={viewDialog.data.sub_category || '\u2014'} />
+              <FieldRow label="Embedded" value={viewDialog.data.embedding ? 'Yes' : 'No'} />
               <FieldRow label="Status">
-                <StatusBadge status={viewSku.deactivated_at ? 'archived' : 'active'} />
+                <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
               </FieldRow>
-              <FieldRow label="Created" value={fmtDate(viewSku.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewSku.updated_at)} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Create Dialog ─────────────────────────────────────────── */}
-      <FormDialog open={createOpen} title="Create Catalog SKU" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Catalog SKU" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="SKU Code" required value={createForm.catalog_sku} onChange={onCreateField('catalog_sku')} inputProps={{ maxLength: 64 }} />
           <TextField label="Category" value={createForm.category} onChange={onCreateField('category')} select={categories.length > 0} inputProps={{ maxLength: 64 }}>
@@ -296,7 +292,7 @@ export default function CatalogPage() {
       </FormDialog>
 
       {/* ── Edit Dialog ───────────────────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Catalog SKU" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Catalog SKU" submitLabel="Save" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <Box sx={formGridSx}>
           <TextField label="SKU Code" required value={editForm.catalog_sku} onChange={onEditField('catalog_sku')} inputProps={{ maxLength: 64 }} />
           <TextField label="Category" value={editForm.category} onChange={onEditField('category')} select={categories.length > 0} inputProps={{ maxLength: 64 }}>
@@ -307,7 +303,7 @@ export default function CatalogPage() {
         </Box>
       </FormDialog>
 
-      <ImportDialog open={importOpen} title="Import Catalog SKUs" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import Catalog SKUs" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />

--- a/apps/nap-client/src/pages/Core/ClientsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ClientsPage.jsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import { useFormState } from '../../hooks/useFormState.js';
 import { useQueryClient } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
@@ -132,16 +133,13 @@ export default function ClientsPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
   const [importErrors, setImportErrors] = useState(null);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewClient, setViewClient] = useState(null);
+  const viewDialog = useDialogState();
   const [viewSourceId, setViewSourceId] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
-  const [resetPwOpen, setResetPwOpen] = useState(false);
-  const [resetPwTarget, setResetPwTarget] = useState(null);
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
+  const resetPwDialog = useDialogState();
 
   const [editSourceId, setEditSourceId] = useState(null);
   const { data: emailsRes } = useEmails({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
@@ -237,42 +235,40 @@ export default function ClientsPage() {
 
   /* ── Sync query-fetched sub-collections into edit state ────── */
   useEffect(() => {
-    if (editOpen && emailsRes?.rows) {
+    if (editDialog.isOpen && emailsRes?.rows) {
       setEditEmails(emailsRes.rows);
       editInitial.current.emails = emailsRes.rows;
     }
-  }, [editOpen, emailsRes]);
+  }, [editDialog.isOpen, emailsRes]);
 
   useEffect(() => {
-    if (editOpen && phonesRes?.rows) {
+    if (editDialog.isOpen && phonesRes?.rows) {
       setEditPhones(phonesRes.rows);
       editInitial.current.phones = phonesRes.rows;
     }
-  }, [editOpen, phonesRes]);
+  }, [editDialog.isOpen, phonesRes]);
 
   useEffect(() => {
-    if (editOpen && addressesRes?.rows) {
+    if (editDialog.isOpen && addressesRes?.rows) {
       setEditAddresses(addressesRes.rows);
       editInitial.current.addresses = addressesRes.rows;
     }
-  }, [editOpen, addressesRes]);
+  }, [editDialog.isOpen, addressesRes]);
 
   useEffect(() => {
-    if (editOpen && taxIdsRes?.rows) {
+    if (editDialog.isOpen && taxIdsRes?.rows) {
       setEditTaxIds(taxIdsRes.rows);
       editInitial.current.taxIds = taxIdsRes.rows;
     }
-  }, [editOpen, taxIdsRes]);
+  }, [editDialog.isOpen, taxIdsRes]);
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewClient(row);
+    viewDialog.open(row);
     setViewSourceId(row.source_id || null);
-    setViewOpen(true);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     const form = { name: row.name ?? '', code: row.code ?? '', is_active: row.is_active ?? true, is_app_user: row.is_app_user ?? false, roles: row.roles ?? [] };
     setEditForm(form);
     editInitial.current.form = form;
@@ -289,7 +285,7 @@ export default function ClientsPage() {
       editInitial.current.taxIds = [];
     }
 
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   /* ── Dirty-check: disable Save when nothing changed ──────── */
@@ -318,7 +314,7 @@ export default function ClientsPage() {
     try {
       await createMut.mutateAsync(createForm);
       toast('Client created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -330,20 +326,20 @@ export default function ClientsPage() {
       // When toggling is_app_user on, include the selected login email in the
       // client update payload so the backend can provision before email mutations run
       const changes = { ...editForm };
-      if (changes.is_app_user && !editRow.is_app_user) {
+      if (changes.is_app_user && !editDialog.data.is_app_user) {
         const loginEm = editEmails.find((em) => em.is_login && !em._deleted)
           || editEmails.find((em) => em.is_primary && !em._deleted)
           || editEmails.find((em) => !em._deleted);
         if (loginEm) changes.email = loginEm.email;
       }
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes });
 
-      if (editRow.source_id) {
+      if (editDialog.data.source_id) {
         for (const em of editEmails) {
           if (em._deleted && em.id) {
             await archiveEmailMut.mutateAsync({ id: em.id });
           } else if (!em.id && !em._deleted) {
-            await createEmailMut.mutateAsync({ source_id: editRow.source_id, email: em.email, label: em.label, is_primary: em.is_primary });
+            await createEmailMut.mutateAsync({ source_id: editDialog.data.source_id, email: em.email, label: em.label, is_primary: em.is_primary });
           } else if (em.id && !em._deleted) {
             await updateEmailMut.mutateAsync({ filter: { id: em.id }, changes: { email: em.email, label: em.label, is_primary: em.is_primary } });
           }
@@ -352,7 +348,7 @@ export default function ClientsPage() {
           if (p._deleted && p.id) {
             await archivePhoneMut.mutateAsync({ id: p.id });
           } else if (!p.id && !p._deleted) {
-            await createPhoneMut.mutateAsync({ source_id: editRow.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
+            await createPhoneMut.mutateAsync({ source_id: editDialog.data.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
           } else if (p.id && !p._deleted) {
             await updatePhoneMut.mutateAsync({ filter: { id: p.id }, changes: { country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary } });
           }
@@ -362,7 +358,7 @@ export default function ClientsPage() {
             await archiveAddrMut.mutateAsync({ id: a.id });
           } else if (!a.id && !a._deleted) {
             const { _deleted, ...rest } = a;
-            await createAddrMut.mutateAsync({ ...rest, source_id: editRow.source_id });
+            await createAddrMut.mutateAsync({ ...rest, source_id: editDialog.data.source_id });
           } else if (a.id && !a._deleted) {
             const { id, source_id: _sid, created_at: _ca, updated_at: _ua, created_by: _cb, updated_by: _ub, deactivated_at: _da, ...changes } = a;
             await updateAddrMut.mutateAsync({ filter: { id }, changes });
@@ -373,7 +369,7 @@ export default function ClientsPage() {
             await archiveTaxIdMut.mutateAsync({ id: t.id });
           } else if (!t.id && !t._deleted) {
             await createTaxIdMut.mutateAsync({
-              source_id: editRow.source_id, country_code: t.country_code,
+              source_id: editDialog.data.source_id, country_code: t.country_code,
               tax_type: t.tax_type, tax_value: t.tax_value,
             });
           } else if (t.id && !t._deleted) {
@@ -386,12 +382,11 @@ export default function ClientsPage() {
       }
 
       await qc.invalidateQueries({ queryKey: ['clients'] });
-      if (editForm.is_app_user !== editRow.is_app_user) {
+      if (editForm.is_app_user !== editDialog.data.is_app_user) {
         qc.invalidateQueries({ queryKey: ['nap-users'] });
       }
       toast('Client updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
       setEditSourceId(null);
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -403,7 +398,7 @@ export default function ClientsPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       const validationErrors = err.payload?.errors;
       if (validationErrors?.length) {
@@ -469,7 +464,7 @@ export default function ClientsPage() {
       primary.push({
         label: 'Import',
         variant: 'outlined',
-        onClick: () => setImportOpen(true),
+        onClick: () => importDialog.open(),
       });
     }
 
@@ -477,7 +472,7 @@ export default function ClientsPage() {
       label: 'Create Client',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -510,36 +505,36 @@ export default function ClientsPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => { setViewOpen(false); setViewSourceId(null); }} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={() => { viewDialog.close(); setViewSourceId(null); }} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Client Details</span>
-            {viewClient && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewClient.name}
+                {viewDialog.data.name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => { setViewOpen(false); setViewSourceId(null); }}>
+            <Button size="small" color="inherit" onClick={() => { viewDialog.close(); setViewSourceId(null); }}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewClient && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewClient.code || '\u2014'} />
-                <FieldRow label="Name" value={viewClient.name} />
-                <FieldRow label="Active" value={viewClient.is_active ? 'Yes' : 'No'} />
-                <FieldRow label="App User" value={viewClient.is_app_user ? 'Yes' : 'No'} />
-                <FieldRow label="Roles" value={viewClient.roles?.length ? viewClient.roles.join(', ') : '\u2014'} />
+                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
+                <FieldRow label="Name" value={viewDialog.data.name} />
+                <FieldRow label="Active" value={viewDialog.data.is_active ? 'Yes' : 'No'} />
+                <FieldRow label="App User" value={viewDialog.data.is_app_user ? 'Yes' : 'No'} />
+                <FieldRow label="Roles" value={viewDialog.data.roles?.length ? viewDialog.data.roles.join(', ') : '\u2014'} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewClient.deactivated_at ? 'archived' : 'active'} />
+                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
                 </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewClient.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewClient.updated_at)} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
 
               <EmailsSection emails={viewEmails} />
@@ -551,7 +546,7 @@ export default function ClientsPage() {
         </DialogContent>
       </Dialog>
 
-      <FormDialog open={createOpen} title="Create Client" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Client" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Client Name" required value={createForm.name} onChange={onCreateField('name')} />
         <TextField label="Code" value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
         <FormControlLabel
@@ -583,7 +578,7 @@ export default function ClientsPage() {
       </FormDialog>
 
       {/* ── Edit Client Dialog ─────────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Client" submitLabel="Save Changes" maxWidth="md" loading={updateMut.isPending} submitDisabled={!hasEditChanges} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); setEditSourceId(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Client" submitLabel="Save Changes" maxWidth="md" loading={updateMut.isPending} submitDisabled={!hasEditChanges} onSubmit={handleUpdate} onCancel={() => { editDialog.close(); setEditSourceId(null); }}>
         <Box sx={formGridSx}>
           <TextField label="Client Name" required value={editForm.name} onChange={onEditField('name')} />
           <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
@@ -601,8 +596,8 @@ export default function ClientsPage() {
             control={<Checkbox checked={editForm.is_app_user} onChange={handleAppUserToggle('edit', setEditForm)} size="small" />}
             label="App User (creates login account)"
           />
-          {editForm.is_app_user && editRow?.is_app_user && (
-            <Button size="small" startIcon={<LockResetIcon />} onClick={() => { setResetPwTarget(editRow); setResetPwOpen(true); }}>
+          {editForm.is_app_user && editDialog.data?.is_app_user && (
+            <Button size="small" startIcon={<LockResetIcon />} onClick={() => resetPwDialog.open(editDialog.data)}>
               Reset Password
             </Button>
           )}
@@ -825,24 +820,24 @@ export default function ClientsPage() {
       </FormDialog>
 
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Clients"
         loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
-        onCancel={() => { setImportOpen(false); setImportErrors(null); }}
+        onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
       <ResetPasswordDialog
-        open={resetPwOpen}
-        onClose={() => { setResetPwOpen(false); setResetPwTarget(null); }}
-        onSuccess={() => { setResetPwOpen(false); setResetPwTarget(null); toast('Password reset successfully'); }}
+        open={resetPwDialog.isOpen}
+        onClose={resetPwDialog.close}
+        onSuccess={() => { resetPwDialog.close(); toast('Password reset successfully'); }}
         onReset={(id, password) => resetPwMut.mutateAsync({ id, password })}
-        entityId={resetPwTarget?.id}
-        entityName={resetPwTarget?.name || ''}
+        entityId={resetPwDialog.data?.id}
+        entityName={resetPwDialog.data?.name || ''}
       />
 
       <SetPasswordPopover anchorEl={pwAnchor} onConfirm={handlePwConfirm} onCancel={handlePwCancel} />

--- a/apps/nap-client/src/pages/Core/CompaniesPage.jsx
+++ b/apps/nap-client/src/pages/Core/CompaniesPage.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
@@ -104,13 +105,11 @@ export default function CompaniesPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
   const [importErrors, setImportErrors] = useState(null);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewCompany, setViewCompany] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -161,28 +160,26 @@ export default function CompaniesPage() {
 
   /* ── Sync query → local state ───────────────────────────────── */
   useEffect(() => {
-    if (editOpen && addressesRes?.rows) {
+    if (editDialog.isOpen && addressesRes?.rows) {
       setEditAddresses(addressesRes.rows);
       editInitial.current.addresses = addressesRes.rows;
     }
-  }, [editOpen, addressesRes]);
+  }, [editDialog.isOpen, addressesRes]);
 
   useEffect(() => {
-    if (editOpen && taxIdsRes?.rows) {
+    if (editDialog.isOpen && taxIdsRes?.rows) {
       setEditTaxIds(taxIdsRes.rows);
       editInitial.current.taxIds = taxIdsRes.rows;
     }
-  }, [editOpen, taxIdsRes]);
+  }, [editDialog.isOpen, taxIdsRes]);
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewCompany(row);
     setViewSourceId(row.source_id || null);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({ name: row.name ?? '', code: row.code ?? '', is_active: row.is_active ?? true });
     setEditSourceId(row.source_id || null);
     if (!row.source_id) {
@@ -192,14 +189,14 @@ export default function CompaniesPage() {
       editInitial.current.taxIds = [];
     }
     editInitial.current.form = { name: row.name ?? '', code: row.code ?? '', is_active: row.is_active ?? true };
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Company created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -208,7 +205,7 @@ export default function CompaniesPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
 
       /* ── Save addresses ──────────────────────────────────────── */
       for (const a of editAddresses) {
@@ -216,7 +213,7 @@ export default function CompaniesPage() {
           await archiveAddrMut.mutateAsync({ id: a.id });
         } else if (!a.id && !a._deleted) {
           const { _deleted, ...rest } = a;
-          await createAddrMut.mutateAsync({ ...rest, source_id: editRow.source_id });
+          await createAddrMut.mutateAsync({ ...rest, source_id: editDialog.data.source_id });
         } else if (a.id && !a._deleted) {
           const { id, source_id: _sid, created_at: _ca, updated_at: _ua, created_by: _cb, updated_by: _ub, deactivated_at: _da, ...changes } = a;
           await updateAddrMut.mutateAsync({ filter: { id }, changes });
@@ -229,7 +226,7 @@ export default function CompaniesPage() {
           await archiveTaxIdMut.mutateAsync({ id: t.id });
         } else if (!t.id && !t._deleted) {
           await createTaxIdMut.mutateAsync({
-            source_id: editRow.source_id,
+            source_id: editDialog.data.source_id,
             country_code: t.country_code,
             tax_type: t.tax_type,
             tax_value: t.tax_value,
@@ -243,8 +240,7 @@ export default function CompaniesPage() {
       }
 
       toast('Company updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
       setEditSourceId(null);
       setEditAddresses([]);
       setEditTaxIds([]);
@@ -258,7 +254,7 @@ export default function CompaniesPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       const validationErrors = err.payload?.errors;
       if (validationErrors?.length) {
@@ -328,7 +324,7 @@ export default function CompaniesPage() {
       primary.push({
         label: 'Import',
         variant: 'outlined',
-        onClick: () => setImportOpen(true),
+        onClick: () => importDialog.open(),
       });
     }
 
@@ -336,7 +332,7 @@ export default function CompaniesPage() {
       label: 'Create Company',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -364,38 +360,38 @@ export default function CompaniesPage() {
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
       <Dialog
-        open={viewOpen}
-        onClose={() => { setViewOpen(false); setViewSourceId(null); }}
+        open={viewDialog.isOpen}
+        onClose={() => { viewDialog.close(); setViewSourceId(null); }}
         maxWidth="sm"
         fullWidth
       >
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Company Details</span>
-            {viewCompany && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewCompany.name}
+                {viewDialog.data.name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => { setViewOpen(false); setViewSourceId(null); }}>
+            <Button size="small" color="inherit" onClick={() => { viewDialog.close(); setViewSourceId(null); }}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewCompany && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewCompany.code || '\u2014'} />
-                <FieldRow label="Name" value={viewCompany.name} />
-                <FieldRow label="Active" value={viewCompany.is_active ? 'Yes' : 'No'} />
+                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
+                <FieldRow label="Name" value={viewDialog.data.name} />
+                <FieldRow label="Active" value={viewDialog.data.is_active ? 'Yes' : 'No'} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewCompany.deactivated_at ? 'archived' : 'active'} />
+                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
                 </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewCompany.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewCompany.updated_at)} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
               <AddressesSection addresses={viewAddresses} />
               <TaxIdentifiersSection taxIds={viewTaxIds} />
@@ -405,7 +401,7 @@ export default function CompaniesPage() {
       </Dialog>
 
       {/* ── Create Dialog ─────────────────────────────────────────── */}
-      <FormDialog open={createOpen} title="Create Company" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Company" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Company Name" required value={createForm.name} onChange={onCreateField('name')} />
         <TextField label="Code" value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
         <FormControlLabel
@@ -422,12 +418,12 @@ export default function CompaniesPage() {
 
       {/* ── Edit Dialog ───────────────────────────────────────────── */}
       <FormDialog
-        open={editOpen}
+        open={editDialog.isOpen}
         title="Edit Company"
         submitLabel="Save Changes"
         loading={updateMut.isPending}
         onSubmit={handleUpdate}
-        onCancel={() => { setEditOpen(false); setEditRow(null); setEditSourceId(null); setEditAddresses([]); setEditTaxIds([]); }}
+        onCancel={() => { editDialog.close(); setEditSourceId(null); setEditAddresses([]); setEditTaxIds([]); }}
       >
         <TextField label="Company Name" required value={editForm.name} onChange={onEditField('name')} />
         <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
@@ -446,12 +442,12 @@ export default function CompaniesPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Addresses</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addAddress} disabled={!editRow?.source_id}>Add Address</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={addAddress} disabled={!editDialog.data?.source_id}>Add Address</Button>
         </Box>
-        {!editRow?.source_id && (
+        {!editDialog.data?.source_id && (
           <Typography variant="body2" color="text.secondary">Save company first to manage addresses</Typography>
         )}
-        {visibleAddresses.length === 0 && editRow?.source_id && (
+        {visibleAddresses.length === 0 && editDialog.data?.source_id && (
           <Typography variant="body2" color="text.secondary">No addresses</Typography>
         )}
         {visibleAddresses.map((addr) => {
@@ -487,12 +483,12 @@ export default function CompaniesPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Tax Identifiers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addTaxId} disabled={!editRow?.source_id}>Add Tax ID</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={addTaxId} disabled={!editDialog.data?.source_id}>Add Tax ID</Button>
         </Box>
-        {!editRow?.source_id && (
+        {!editDialog.data?.source_id && (
           <Typography variant="body2" color="text.secondary">Save company first to manage tax identifiers</Typography>
         )}
-        {visibleTaxIds.length === 0 && editRow?.source_id && (
+        {visibleTaxIds.length === 0 && editDialog.data?.source_id && (
           <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
         )}
         {visibleTaxIds.map((taxId) => {
@@ -550,12 +546,12 @@ export default function CompaniesPage() {
       </FormDialog>
 
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Companies"
         loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
-        onCancel={() => { setImportOpen(false); setImportErrors(null); }}
+        onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />
 
       <ConfirmDialog {...archiveConfirmProps} />

--- a/apps/nap-client/src/pages/Core/ContactsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ContactsPage.jsx
@@ -13,6 +13,7 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -124,14 +125,12 @@ export default function ContactsPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
   const [importErrors, setImportErrors] = useState(null);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewContact, setViewContact] = useState(null);
+  const viewDialog = useDialogState();
   const [viewSourceId, setViewSourceId] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const [editSourceId, setEditSourceId] = useState(null);
   const { data: emailsRes } = useEmails({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
@@ -203,42 +202,40 @@ export default function ContactsPage() {
 
   /* ── Sync query-fetched child data into edit state ──────────── */
   useEffect(() => {
-    if (editOpen && emailsRes?.rows) {
+    if (editDialog.isOpen && emailsRes?.rows) {
       setEditEmails(emailsRes.rows);
       editInitial.current.emails = emailsRes.rows;
     }
-  }, [editOpen, emailsRes]);
+  }, [editDialog.isOpen, emailsRes]);
 
   useEffect(() => {
-    if (editOpen && phonesRes?.rows) {
+    if (editDialog.isOpen && phonesRes?.rows) {
       setEditPhones(phonesRes.rows);
       editInitial.current.phones = phonesRes.rows;
     }
-  }, [editOpen, phonesRes]);
+  }, [editDialog.isOpen, phonesRes]);
 
   useEffect(() => {
-    if (editOpen && addressesRes?.rows) {
+    if (editDialog.isOpen && addressesRes?.rows) {
       setEditAddresses(addressesRes.rows);
       editInitial.current.addresses = addressesRes.rows;
     }
-  }, [editOpen, addressesRes]);
+  }, [editDialog.isOpen, addressesRes]);
 
   useEffect(() => {
-    if (editOpen && taxIdsRes?.rows) {
+    if (editDialog.isOpen && taxIdsRes?.rows) {
       setEditTaxIds(taxIdsRes.rows);
       editInitial.current.taxIds = taxIdsRes.rows;
     }
-  }, [editOpen, taxIdsRes]);
+  }, [editDialog.isOpen, taxIdsRes]);
 
   /* ── Row action callbacks ───────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewContact(row);
     setViewSourceId(row.source_id || null);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     const form = {
       name: row.name ?? '',
       code: row.code ?? '',
@@ -259,7 +256,7 @@ export default function ContactsPage() {
       editInitial.current.taxIds = [];
     }
 
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   /* ── Dirty-check: disable Save when nothing changed ─────────── */
@@ -288,7 +285,7 @@ export default function ContactsPage() {
     try {
       await createMut.mutateAsync(createForm);
       toast('Contact created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -297,14 +294,14 @@ export default function ContactsPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
 
-      if (editRow.source_id) {
+      if (editDialog.data.source_id) {
         for (const em of editEmails) {
           if (em._deleted && em.id) {
             await archiveEmailMut.mutateAsync({ id: em.id });
           } else if (!em.id && !em._deleted) {
-            await createEmailMut.mutateAsync({ source_id: editRow.source_id, email: em.email, label: em.label, is_primary: em.is_primary });
+            await createEmailMut.mutateAsync({ source_id: editDialog.data.source_id, email: em.email, label: em.label, is_primary: em.is_primary });
           } else if (em.id && !em._deleted) {
             await updateEmailMut.mutateAsync({ filter: { id: em.id }, changes: { email: em.email, label: em.label, is_primary: em.is_primary } });
           }
@@ -313,7 +310,7 @@ export default function ContactsPage() {
           if (p._deleted && p.id) {
             await archivePhoneMut.mutateAsync({ id: p.id });
           } else if (!p.id && !p._deleted) {
-            await createPhoneMut.mutateAsync({ source_id: editRow.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
+            await createPhoneMut.mutateAsync({ source_id: editDialog.data.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
           } else if (p.id && !p._deleted) {
             await updatePhoneMut.mutateAsync({ filter: { id: p.id }, changes: { country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary } });
           }
@@ -323,7 +320,7 @@ export default function ContactsPage() {
             await archiveAddrMut.mutateAsync({ id: a.id });
           } else if (!a.id && !a._deleted) {
             const { _deleted, is_primary: _ip, ...rest } = a;
-            await createAddrMut.mutateAsync({ ...rest, source_id: editRow.source_id });
+            await createAddrMut.mutateAsync({ ...rest, source_id: editDialog.data.source_id });
           } else if (a.id && !a._deleted) {
             const { id, source_id: _sid, created_at: _ca, updated_at: _ua, created_by: _cb, updated_by: _ub, deactivated_at: _da, is_primary: _ip, ...changes } = a;
             await updateAddrMut.mutateAsync({ filter: { id }, changes });
@@ -334,7 +331,7 @@ export default function ContactsPage() {
             await archiveTaxIdMut.mutateAsync({ id: t.id });
           } else if (!t.id && !t._deleted) {
             await createTaxIdMut.mutateAsync({
-              source_id: editRow.source_id, country_code: t.country_code,
+              source_id: editDialog.data.source_id, country_code: t.country_code,
               tax_type: t.tax_type, tax_value: t.tax_value,
             });
           } else if (t.id && !t._deleted) {
@@ -347,8 +344,7 @@ export default function ContactsPage() {
       }
 
       toast('Contact updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
       setEditSourceId(null);
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -360,7 +356,7 @@ export default function ContactsPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       const validationErrors = err.payload?.errors;
       if (validationErrors?.length) {
@@ -425,7 +421,7 @@ export default function ContactsPage() {
       primary.push({
         label: 'Import',
         variant: 'outlined',
-        onClick: () => setImportOpen(true),
+        onClick: () => importDialog.open(),
       });
     }
 
@@ -433,7 +429,7 @@ export default function ContactsPage() {
       label: 'Create Contact',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -466,34 +462,34 @@ export default function ContactsPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => { setViewOpen(false); setViewSourceId(null); }} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={() => { viewDialog.close(); setViewSourceId(null); }} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Contact Details</span>
-            {viewContact && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewContact.name}
+                {viewDialog.data.name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => { setViewOpen(false); setViewSourceId(null); }}>
+            <Button size="small" color="inherit" onClick={() => { viewDialog.close(); setViewSourceId(null); }}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewContact && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewContact.code || '\u2014'} />
-                <FieldRow label="Name" value={viewContact.name} />
-                <FieldRow label="Active" value={viewContact.is_active ? 'Yes' : 'No'} />
+                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
+                <FieldRow label="Name" value={viewDialog.data.name} />
+                <FieldRow label="Active" value={viewDialog.data.is_active ? 'Yes' : 'No'} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewContact.deactivated_at ? 'archived' : 'active'} />
+                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
                 </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewContact.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewContact.updated_at)} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
 
               <EmailsSection emails={viewEmails} />
@@ -505,7 +501,7 @@ export default function ContactsPage() {
         </DialogContent>
       </Dialog>
 
-      <FormDialog open={createOpen} title="Create Contact" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Contact" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Contact Name" required value={createForm.name} onChange={onCreateField('name')} />
         <TextField label="Code" value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
         <FormControlLabel
@@ -521,7 +517,7 @@ export default function ContactsPage() {
       </FormDialog>
 
       {/* ── Edit Contact Dialog ──────────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Contact" submitLabel="Save Changes" maxWidth="md" loading={updateMut.isPending} submitDisabled={!hasEditChanges} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); setEditSourceId(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Contact" submitLabel="Save Changes" maxWidth="md" loading={updateMut.isPending} submitDisabled={!hasEditChanges} onSubmit={handleUpdate} onCancel={() => { editDialog.close(); setEditSourceId(null); }}>
         <Box sx={formGridSx}>
           <TextField label="Contact Name" required value={editForm.name} onChange={onEditField('name')} />
           <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
@@ -744,12 +740,12 @@ export default function ContactsPage() {
       </FormDialog>
 
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Contacts"
         loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
-        onCancel={() => { setImportOpen(false); setImportErrors(null); }}
+        onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />
 
       <ConfirmDialog {...archiveConfirmProps} />

--- a/apps/nap-client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/nap-client/src/pages/Core/EmployeesPage.jsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import { useFormState } from '../../hooks/useFormState.js';
 import { useQueryClient } from '@tanstack/react-query';
 import Autocomplete from '@mui/material/Autocomplete';
@@ -150,16 +151,13 @@ export default function EmployeesPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
   const [importErrors, setImportErrors] = useState(null);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewEmployee, setViewEmployee] = useState(null);
+  const viewDialog = useDialogState();
   const [viewSourceId, setViewSourceId] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
-  const [resetPwOpen, setResetPwOpen] = useState(false);
-  const [resetPwTarget, setResetPwTarget] = useState(null);
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
+  const resetPwDialog = useDialogState();
 
   const [editSourceId, setEditSourceId] = useState(null);
   const { data: phonesRes } = usePhoneNumbers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
@@ -260,42 +258,40 @@ export default function EmployeesPage() {
 
   /* ── Sync query-fetched phones/addresses/taxIds into edit state */
   useEffect(() => {
-    if (editOpen && phonesRes?.rows) {
+    if (editDialog.isOpen && phonesRes?.rows) {
       setEditPhones(phonesRes.rows);
       editInitial.current.phones = phonesRes.rows;
     }
-  }, [editOpen, phonesRes]);
+  }, [editDialog.isOpen, phonesRes]);
 
   useEffect(() => {
-    if (editOpen && emailsRes?.rows) {
+    if (editDialog.isOpen && emailsRes?.rows) {
       setEditEmails(emailsRes.rows);
       editInitial.current.emails = emailsRes.rows;
     }
-  }, [editOpen, emailsRes]);
+  }, [editDialog.isOpen, emailsRes]);
 
   useEffect(() => {
-    if (editOpen && addressesRes?.rows) {
+    if (editDialog.isOpen && addressesRes?.rows) {
       setEditAddresses(addressesRes.rows);
       editInitial.current.addresses = addressesRes.rows;
     }
-  }, [editOpen, addressesRes]);
+  }, [editDialog.isOpen, addressesRes]);
 
   useEffect(() => {
-    if (editOpen && taxIdsRes?.rows) {
+    if (editDialog.isOpen && taxIdsRes?.rows) {
       setEditTaxIds(taxIdsRes.rows);
       editInitial.current.taxIds = taxIdsRes.rows;
     }
-  }, [editOpen, taxIdsRes]);
+  }, [editDialog.isOpen, taxIdsRes]);
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewEmployee(row);
+    viewDialog.open(row);
     setViewSourceId(row.source_id || null);
-    setViewOpen(true);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     const form = {
       first_name: row.first_name ?? '',
       last_name: row.last_name ?? '',
@@ -322,7 +318,7 @@ export default function EmployeesPage() {
       editInitial.current.taxIds = [];
     }
 
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   /** Per-row kebab actions — Reset Password shown for app users when permitted */
@@ -333,10 +329,7 @@ export default function EmployeesPage() {
         actions.push({
           label: 'Reset Password',
           icon: <LockResetIcon fontSize="small" />,
-          onClick: (r) => {
-            setResetPwTarget(r);
-            setResetPwOpen(true);
-          },
+          onClick: (r) => resetPwDialog.open(r),
         });
       }
       return actions;
@@ -372,7 +365,7 @@ export default function EmployeesPage() {
     try {
       await createMut.mutateAsync(createForm);
       toast('Employee created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -384,18 +377,18 @@ export default function EmployeesPage() {
       // When toggling is_app_user on, include the selected login email in the
       // employee update payload so the backend can provision before email mutations run
       const changes = { ...editForm };
-      if (changes.is_app_user && !editRow.is_app_user) {
+      if (changes.is_app_user && !editDialog.data.is_app_user) {
         const loginEm = editEmails.find((em) => em.is_login && !em._deleted);
         if (loginEm) changes.email = loginEm.email;
       }
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes });
 
-      if (editRow.source_id) {
+      if (editDialog.data.source_id) {
         for (const p of editPhones) {
           if (p._deleted && p.id) {
             await archivePhoneMut.mutateAsync({ id: p.id });
           } else if (!p.id && !p._deleted) {
-            await createPhoneMut.mutateAsync({ source_id: editRow.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
+            await createPhoneMut.mutateAsync({ source_id: editDialog.data.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
           } else if (p.id && !p._deleted) {
             await updatePhoneMut.mutateAsync({ filter: { id: p.id }, changes: { country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary } });
           }
@@ -405,7 +398,7 @@ export default function EmployeesPage() {
             await archiveEmailMut.mutateAsync({ id: em.id });
           } else if (!em.id && !em._deleted) {
             await createEmailMut.mutateAsync({
-              source_id: editRow.source_id, email: em.email, label: em.label,
+              source_id: editDialog.data.source_id, email: em.email, label: em.label,
               is_primary: em.is_primary, is_login: em.is_login,
             });
           } else if (em.id && !em._deleted) {
@@ -420,7 +413,7 @@ export default function EmployeesPage() {
             await archiveAddrMut.mutateAsync({ id: a.id });
           } else if (!a.id && !a._deleted) {
             const { _deleted, ...rest } = a;
-            await createAddrMut.mutateAsync({ ...rest, source_id: editRow.source_id });
+            await createAddrMut.mutateAsync({ ...rest, source_id: editDialog.data.source_id });
           } else if (a.id && !a._deleted) {
             const { id, source_id: _sid, created_at: _ca, updated_at: _ua, created_by: _cb, updated_by: _ub, deactivated_at: _da, ...changes } = a;
             await updateAddrMut.mutateAsync({ filter: { id }, changes });
@@ -431,7 +424,7 @@ export default function EmployeesPage() {
             await archiveTaxIdMut.mutateAsync({ id: t.id });
           } else if (!t.id && !t._deleted) {
             await createTaxIdMut.mutateAsync({
-              source_id: editRow.source_id, country_code: t.country_code,
+              source_id: editDialog.data.source_id, country_code: t.country_code,
               tax_type: t.tax_type, tax_value: t.tax_value,
             });
           } else if (t.id && !t._deleted) {
@@ -443,12 +436,11 @@ export default function EmployeesPage() {
         }
       }
 
-      if (editForm.is_app_user !== editRow.is_app_user) {
+      if (editForm.is_app_user !== editDialog.data.is_app_user) {
         qc.invalidateQueries({ queryKey: ['nap-users'] });
       }
       toast('Employee updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
       setEditSourceId(null);
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -460,7 +452,7 @@ export default function EmployeesPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       const validationErrors = err.payload?.errors;
       if (validationErrors?.length) {
@@ -526,7 +518,7 @@ export default function EmployeesPage() {
       primary.push({
         label: 'Import',
         variant: 'outlined',
-        onClick: () => setImportOpen(true),
+        onClick: () => importDialog.open(),
       });
     }
 
@@ -534,7 +526,7 @@ export default function EmployeesPage() {
       label: 'Create Employee',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -568,40 +560,40 @@ export default function EmployeesPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => { setViewOpen(false); setViewSourceId(null); }} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={() => { viewDialog.close(); setViewSourceId(null); }} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Employee Details</span>
-            {viewEmployee && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewEmployee.first_name} {viewEmployee.last_name}
+                {viewDialog.data.first_name} {viewDialog.data.last_name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => { setViewOpen(false); setViewSourceId(null); }}>
+            <Button size="small" color="inherit" onClick={() => { viewDialog.close(); setViewSourceId(null); }}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewEmployee && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewEmployee.code || '\u2014'} />
-                <FieldRow label="First Name" value={viewEmployee.first_name} />
-                <FieldRow label="Last Name" value={viewEmployee.last_name} />
-                <FieldRow label="Position" value={viewEmployee.position || '\u2014'} />
-                <FieldRow label="Department" value={viewEmployee.department || '\u2014'} />
-                <FieldRow label="App User" value={viewEmployee.is_app_user ? 'Yes' : 'No'} />
-                <FieldRow label="Roles" value={(viewEmployee.roles ?? []).join(', ') || '\u2014'} />
+                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
+                <FieldRow label="First Name" value={viewDialog.data.first_name} />
+                <FieldRow label="Last Name" value={viewDialog.data.last_name} />
+                <FieldRow label="Position" value={viewDialog.data.position || '\u2014'} />
+                <FieldRow label="Department" value={viewDialog.data.department || '\u2014'} />
+                <FieldRow label="App User" value={viewDialog.data.is_app_user ? 'Yes' : 'No'} />
+                <FieldRow label="Roles" value={(viewDialog.data.roles ?? []).join(', ') || '\u2014'} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewEmployee.deactivated_at ? 'archived' : 'active'} />
+                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
                 </FieldRow>
-                <FieldRow label="Primary Contact" value={viewEmployee.is_primary_contact ? 'Yes' : 'No'} />
-                <FieldRow label="Billing Contact" value={viewEmployee.is_billing_contact ? 'Yes' : 'No'} />
-                <FieldRow label="Created" value={fmtDate(viewEmployee.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewEmployee.updated_at)} />
+                <FieldRow label="Primary Contact" value={viewDialog.data.is_primary_contact ? 'Yes' : 'No'} />
+                <FieldRow label="Billing Contact" value={viewDialog.data.is_billing_contact ? 'Yes' : 'No'} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
 
               <PhoneNumbersSection phones={viewPhones} />
@@ -614,7 +606,7 @@ export default function EmployeesPage() {
       </Dialog>
 
       {/* ── Create Employee Dialog ───────────────────────────────── */}
-      <FormDialog open={createOpen} title="Create Employee" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Employee" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="First Name" required value={createForm.first_name} onChange={onCreateField('first_name')} />
         <TextField label="Last Name" required value={createForm.last_name} onChange={onCreateField('last_name')} />
         <TextField label="Code" value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
@@ -636,7 +628,7 @@ export default function EmployeesPage() {
       </FormDialog>
 
       {/* ── Edit Employee Dialog ─────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Employee" submitLabel="Save Changes" maxWidth="md" loading={updateMut.isPending} submitDisabled={!hasEditChanges} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); setEditSourceId(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Employee" submitLabel="Save Changes" maxWidth="md" loading={updateMut.isPending} submitDisabled={!hasEditChanges} onSubmit={handleUpdate} onCancel={() => { editDialog.close(); setEditSourceId(null); }}>
         <Box sx={formGridSx}>
           <TextField label="First Name" required value={editForm.first_name} onChange={onEditField('first_name')} />
           <TextField label="Last Name" required value={editForm.last_name} onChange={onEditField('last_name')} />
@@ -658,7 +650,7 @@ export default function EmployeesPage() {
         </Box>
 
         {editForm.is_app_user && canResetPassword && (
-          <Button variant="outlined" size="small" onClick={() => { setResetPwTarget(editRow); setResetPwOpen(true); }}>
+          <Button variant="outlined" size="small" onClick={() => resetPwDialog.open(editDialog.data)}>
             Reset Password
           </Button>
         )}
@@ -764,7 +756,7 @@ export default function EmployeesPage() {
               />
               {editForm.is_app_user && (
                 <FormControlLabel
-                  control={<Checkbox checked={em.is_login} onChange={(e) => updateEmail(idx, 'is_login', e.target.checked)} size="small" disabled={editRow?.is_app_user} />}
+                  control={<Checkbox checked={em.is_login} onChange={(e) => updateEmail(idx, 'is_login', e.target.checked)} size="small" disabled={editDialog.data?.is_app_user} />}
                   label="Login"
                   sx={{ mr: 0 }}
                 />
@@ -878,24 +870,24 @@ export default function EmployeesPage() {
       </FormDialog>
 
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Employees"
         loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
-        onCancel={() => { setImportOpen(false); setImportErrors(null); }}
+        onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
       <ResetPasswordDialog
-        open={resetPwOpen}
-        onClose={() => { setResetPwOpen(false); setResetPwTarget(null); }}
-        onSuccess={() => { setResetPwOpen(false); setResetPwTarget(null); toast('Password reset successfully'); }}
+        open={resetPwDialog.isOpen}
+        onClose={resetPwDialog.close}
+        onSuccess={() => { resetPwDialog.close(); toast('Password reset successfully'); }}
         onReset={(id, password) => resetPwMut.mutateAsync({ id, password })}
-        entityId={resetPwTarget?.id}
-        entityName={resetPwTarget ? `${resetPwTarget.first_name} ${resetPwTarget.last_name}` : ''}
+        entityId={resetPwDialog.data?.id}
+        entityName={resetPwDialog.data ? `${resetPwDialog.data.first_name} ${resetPwDialog.data.last_name}` : ''}
       />
 
       <SetPasswordPopover anchorEl={pwAnchor} onConfirm={handlePwConfirm} onCancel={handlePwCancel} />

--- a/apps/nap-client/src/pages/Projects/ChangeOrdersPage.jsx
+++ b/apps/nap-client/src/pages/Projects/ChangeOrdersPage.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -82,12 +83,10 @@ export default function ChangeOrdersPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewCO, setViewCO] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -96,26 +95,24 @@ export default function ChangeOrdersPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewCO(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       co_number: row.co_number ?? '',
       title: row.title ?? '',
       reason: row.reason ?? '',
       total_amount: row.total_amount ?? '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Change order created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -124,10 +121,9 @@ export default function ChangeOrdersPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Change order updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -137,7 +133,7 @@ export default function ChangeOrdersPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -191,14 +187,14 @@ export default function ChangeOrdersPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create CO',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -225,40 +221,40 @@ export default function ChangeOrdersPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Change Order Details</span>
-            {viewCO && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewCO.title}
+                {viewDialog.data.title}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewCO && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="CO Number" value={viewCO.co_number || '\u2014'} />
-              <FieldRow label="Title" value={viewCO.title} />
+              <FieldRow label="CO Number" value={viewDialog.data.co_number || '\u2014'} />
+              <FieldRow label="Title" value={viewDialog.data.title} />
               <FieldRow label="Status">
-                <StatusBadge status={STATUS_MAP[viewCO.status] || 'active'} label={viewCO.status} />
+                <StatusBadge status={STATUS_MAP[viewDialog.data.status] || 'active'} label={viewDialog.data.status} />
               </FieldRow>
-              <FieldRow label="Total Amount" value={viewCO.total_amount ?? '\u2014'} />
-              <FieldRow label="Created" value={fmtDate(viewCO.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewCO.updated_at)} />
+              <FieldRow label="Total Amount" value={viewDialog.data.total_amount ?? '\u2014'} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Create Change Order Dialog ────────────────────────────── */}
-      <FormDialog open={createOpen} title="Create Change Order" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Change Order" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Unit ID" required value={createForm.unit_id} onChange={onCreateField('unit_id')} helperText="UUID of the unit" />
         <TextField label="CO Number" required value={createForm.co_number} onChange={onCreateField('co_number')} inputProps={{ maxLength: 16 }} />
         <TextField label="Title" required value={createForm.title} onChange={onCreateField('title')} />
@@ -267,14 +263,14 @@ export default function ChangeOrdersPage() {
       </FormDialog>
 
       {/* ── Edit Change Order Dialog ──────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Change Order" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Change Order" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <TextField label="CO Number" required value={editForm.co_number} onChange={onEditField('co_number')} inputProps={{ maxLength: 16 }} />
         <TextField label="Title" required value={editForm.title} onChange={onEditField('title')} />
         <TextField label="Reason" multiline minRows={2} value={editForm.reason} onChange={onEditField('reason')} />
         <TextField label="Total Amount" type="number" value={editForm.total_amount} onChange={onEditField('total_amount')} />
       </FormDialog>
 
-      <ImportDialog open={importOpen} title="Import Change Orders" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import Change Orders" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />

--- a/apps/nap-client/src/pages/Projects/ProjectsPage.jsx
+++ b/apps/nap-client/src/pages/Projects/ProjectsPage.jsx
@@ -8,6 +8,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -85,12 +86,10 @@ export default function ProjectsPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── Dialog state ───────────────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewProject, setViewProject] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const importDialog = useDialogState();
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -99,12 +98,10 @@ export default function ProjectsPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewProject(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       project_code: row.project_code ?? '',
       name: row.name ?? '',
@@ -112,14 +109,14 @@ export default function ProjectsPage() {
       notes: row.notes ?? '',
       contract_amount: row.contract_amount ?? '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Project created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -128,10 +125,9 @@ export default function ProjectsPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Project updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -141,7 +137,7 @@ export default function ProjectsPage() {
     try {
       const result = await importMut.mutateAsync(formData);
       toast(`Imported ${result.inserted} records`);
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -199,14 +195,14 @@ export default function ProjectsPage() {
       primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
     }
     if (canImport) {
-      primary.push({ label: 'Import', variant: 'outlined', onClick: () => setImportOpen(true) });
+      primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
     }
 
     primary.push({
       label: 'Create Project',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -235,40 +231,40 @@ export default function ProjectsPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Project Details</span>
-            {viewProject && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewProject.name}
+                {viewDialog.data.name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewProject && (
+          {viewDialog.data && (
             <Box sx={detailGridSx}>
-              <FieldRow label="Project Code" value={viewProject.project_code || '\u2014'} />
-              <FieldRow label="Name" value={viewProject.name} />
+              <FieldRow label="Project Code" value={viewDialog.data.project_code || '\u2014'} />
+              <FieldRow label="Name" value={viewDialog.data.name} />
               <FieldRow label="Status">
-                <StatusBadge status={STATUS_MAP[viewProject.status] || 'active'} label={viewProject.status} />
+                <StatusBadge status={STATUS_MAP[viewDialog.data.status] || 'active'} label={viewDialog.data.status} />
               </FieldRow>
-              <FieldRow label="Contract Amount" value={viewProject.contract_amount ?? '\u2014'} />
-              <FieldRow label="Created" value={fmtDate(viewProject.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewProject.updated_at)} />
+              <FieldRow label="Contract Amount" value={viewDialog.data.contract_amount ?? '\u2014'} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </Box>
           )}
         </DialogContent>
       </Dialog>
 
       {/* ── Create Project Dialog ─────────────────────────────────── */}
-      <FormDialog open={createOpen} title="Create Project" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={() => setCreateOpen(false)}>
+      <FormDialog open={createDialog.isOpen} title="Create Project" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Project Code" required value={createForm.project_code} onChange={onCreateField('project_code')} inputProps={{ maxLength: 32 }} />
         <TextField label="Project Name" required value={createForm.name} onChange={onCreateField('name')} />
         <TextField label="Description" multiline minRows={2} value={createForm.description} onChange={onCreateField('description')} />
@@ -277,7 +273,7 @@ export default function ProjectsPage() {
       </FormDialog>
 
       {/* ── Edit Project Dialog ──────────────────────────────────── */}
-      <FormDialog open={editOpen} title="Edit Project" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={() => { setEditOpen(false); setEditRow(null); }}>
+      <FormDialog open={editDialog.isOpen} title="Edit Project" submitLabel="Save Changes" loading={updateMut.isPending} onSubmit={handleUpdate} onCancel={editDialog.close}>
         <TextField label="Project Code" required value={editForm.project_code} onChange={onEditField('project_code')} inputProps={{ maxLength: 32 }} />
         <TextField label="Project Name" required value={editForm.name} onChange={onEditField('name')} />
         <TextField label="Description" multiline minRows={2} value={editForm.description} onChange={onEditField('description')} />
@@ -285,7 +281,7 @@ export default function ProjectsPage() {
         <TextField label="Notes" multiline minRows={2} value={editForm.notes} onChange={onEditField('notes')} />
       </FormDialog>
 
-      <ImportDialog open={importOpen} title="Import Projects" loading={importMut.isPending} onSubmit={handleImport} onCancel={() => setImportOpen(false)} />
+      <ImportDialog open={importDialog.isOpen} title="Import Projects" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />

--- a/apps/nap-client/src/pages/Settings/PaymentTermsPage.jsx
+++ b/apps/nap-client/src/pages/Settings/PaymentTermsPage.jsx
@@ -9,6 +9,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
@@ -93,7 +94,7 @@ export default function PaymentTermsPage() {
   });
 
   /* ── Import / Export ──────────────────────────────────── */
-  const [importOpen, setImportOpen] = useState(false);
+  const importDialog = useDialogState();
   const [importErrors, setImportErrors] = useState(null);
 
   const handleImport = useCallback(async (formData) => {
@@ -103,7 +104,7 @@ export default function PaymentTermsPage() {
         setImportErrors(result.errors);
         return;
       }
-      setImportOpen(false);
+      importDialog.close();
       setImportErrors(null);
       toast(`Imported ${(result?.inserted ?? 0) + (result?.updated ?? 0)} payment term(s)`);
     } catch (err) {
@@ -126,13 +127,13 @@ export default function PaymentTermsPage() {
   }, [exportMut.mutateAsync, toast]);
 
   /* ── Create dialog ─────────────────────────────────────── */
-  const [createOpen, setCreateOpen] = useState(false);
+  const createDialog = useDialogState();
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
 
   const handleCreate = useCallback(async () => {
     try {
       await createMut.mutateAsync({ ...createForm, term: Number(createForm.term) });
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
       toast('Payment term created');
     } catch (err) {
@@ -141,34 +142,30 @@ export default function PaymentTermsPage() {
   }, [createForm, createMut, toast]);
 
   /* ── View dialog ───────────────────────────────────────── */
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewRow, setViewRow] = useState(null);
+  const viewDialog = useDialogState();
 
   /* ── Edit dialog ───────────────────────────────────────── */
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const editDialog = useDialogState();
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
 
   const openEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({ label: row.label, term: row.term, units: row.units, is_active: row.is_active });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   const handleUpdate = useCallback(async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: { ...editForm, term: Number(editForm.term) } });
-      setEditOpen(false);
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: { ...editForm, term: Number(editForm.term) } });
+      editDialog.close();
       toast('Payment term updated');
     } catch (err) {
       toast(errMsg(err) || 'Update failed', 'error');
     }
-  }, [editRow, editForm, updateMut, toast]);
+  }, [editDialog.data, editForm, updateMut, toast]);
 
   /* ── Row action callbacks ───────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewRow(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
 
@@ -207,13 +204,13 @@ export default function PaymentTermsPage() {
       variant: 'outlined',
       color: 'primary',
       disabled: importMut.isPending,
-      onClick: () => { setImportErrors(null); setImportOpen(true); },
+      onClick: () => { setImportErrors(null); importDialog.open(); },
     });
     primary.push({
       label: 'Create Payment Term',
       variant: 'contained',
       color: 'primary',
-      onClick: () => { resetCreateForm(); setCreateOpen(true); },
+      onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
     return {
@@ -242,12 +239,12 @@ export default function PaymentTermsPage() {
 
       {/* ── Create Dialog ─────────────────────────────── */}
       <FormDialog
-        open={createOpen}
+        open={createDialog.isOpen}
         title="New Payment Term"
         submitLabel="Create"
         loading={createMut.isPending}
         onSubmit={handleCreate}
-        onCancel={() => { setCreateOpen(false); resetCreateForm(); }}
+        onCancel={() => { createDialog.close(); resetCreateForm(); }}
       >
         <Box sx={formGridSx}>
           <TextField
@@ -277,12 +274,12 @@ export default function PaymentTermsPage() {
 
       {/* ── Edit Dialog ───────────────────────────────── */}
       <FormDialog
-        open={editOpen}
+        open={editDialog.isOpen}
         title="Edit Payment Term"
         submitLabel="Save"
         loading={updateMut.isPending}
         onSubmit={handleUpdate}
-        onCancel={() => setEditOpen(false)}
+        onCancel={editDialog.close}
       >
         <Box sx={formGridSx}>
           <TextField
@@ -320,22 +317,22 @@ export default function PaymentTermsPage() {
       </FormDialog>
 
       {/* ── View Dialog ───────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Typography variant="h6">Payment Term Details</Typography>
           <Box sx={dialogActionBoxSx}>
-            <StatusBadge status={viewRow?.deactivated_at ? 'archived' : viewRow?.is_active ? 'active' : 'suspended'} />
+            <StatusBadge status={viewDialog.data?.deactivated_at ? 'archived' : viewDialog.data?.is_active ? 'active' : 'suspended'} />
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewRow && (
+          {viewDialog.data && (
             <>
-              <FieldRow label="Label" value={viewRow.label} />
-              <FieldRow label="Term" value={viewRow.term} />
-              <FieldRow label="Units" value={viewRow.units} />
-              <FieldRow label="Active" value={viewRow.is_active ? 'Yes' : 'No'} />
-              <FieldRow label="Created" value={fmtDate(viewRow.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(viewRow.updated_at)} />
+              <FieldRow label="Label" value={viewDialog.data.label} />
+              <FieldRow label="Term" value={viewDialog.data.term} />
+              <FieldRow label="Units" value={viewDialog.data.units} />
+              <FieldRow label="Active" value={viewDialog.data.is_active ? 'Yes' : 'No'} />
+              <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
             </>
           )}
         </DialogContent>
@@ -343,12 +340,12 @@ export default function PaymentTermsPage() {
 
       {/* ── Import Dialog ──────────────────────────────── */}
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Payment Terms"
         loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
-        onCancel={() => { setImportOpen(false); setImportErrors(null); }}
+        onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />
 
       {/* ── Confirm Dialogs ───────────────────────────── */}

--- a/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
@@ -16,6 +16,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -98,11 +99,9 @@ export default function ManageRolesPage() {
   const [actionsContainer, setActionsContainer] = useState(null);
 
   /* ── dialog state ──────────────────────────────────────────── */
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewRole, setViewRole] = useState(null);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const viewDialog = useDialogState();
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
 
   /* ── form state ────────────────────────────────────────────── */
   const { form: createForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
@@ -113,18 +112,16 @@ export default function ManageRolesPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewRole(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       name: row.name ?? '',
       description: row.description ?? '',
       scope: row.scope ?? 'all_projects',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   /** Conditional row actions — immutable roles cannot be edited */
@@ -138,7 +135,7 @@ export default function ManageRolesPage() {
     try {
       await createMut.mutateAsync(createForm);
       toast('Role created');
-      setCreateOpen(false);
+      createDialog.close();
       resetCreateForm();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -147,10 +144,9 @@ export default function ManageRolesPage() {
 
   const handleUpdate = async () => {
     try {
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
       toast('Role updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -168,7 +164,7 @@ export default function ManageRolesPage() {
           color: 'primary',
           onClick: () => {
             resetCreateForm();
-            setCreateOpen(true);
+            createDialog.open();
           },
         },
       ],
@@ -243,35 +239,35 @@ export default function ManageRolesPage() {
       )}
 
       {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Role Details</span>
-            {viewRole && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewRole.name}
+                {viewDialog.data.name}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewRole && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewRole.code} />
-                <FieldRow label="Name" value={viewRole.name} />
+                <FieldRow label="Code" value={viewDialog.data.code} />
+                <FieldRow label="Name" value={viewDialog.data.name} />
                 <FieldRow label="Scope">
-                  <StatusBadge status={viewRole.scope} />
+                  <StatusBadge status={viewDialog.data.scope} />
                 </FieldRow>
-                <FieldRow label="System" value={viewRole.is_system ? 'Yes' : 'No'} />
-                <FieldRow label="Immutable" value={viewRole.is_immutable ? 'Yes' : 'No'} />
-                <FieldRow label="Created" value={fmtDate(viewRole.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewRole.updated_at)} />
+                <FieldRow label="System" value={viewDialog.data.is_system ? 'Yes' : 'No'} />
+                <FieldRow label="Immutable" value={viewDialog.data.is_immutable ? 'Yes' : 'No'} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
             </Box>
           )}
@@ -280,12 +276,12 @@ export default function ManageRolesPage() {
 
       {/* ── Create Dialog ──────────────────────────────────────── */}
       <FormDialog
-        open={createOpen}
+        open={createDialog.isOpen}
         title="Create Role"
         submitLabel="Create"
         loading={createMut.isPending}
         onSubmit={handleCreate}
-        onCancel={() => setCreateOpen(false)}
+        onCancel={createDialog.close}
       >
         <TextField label="Code" required value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 64 }} />
         <TextField label="Name" required value={createForm.name} onChange={onCreateField('name')} inputProps={{ maxLength: 128 }} />
@@ -301,14 +297,14 @@ export default function ManageRolesPage() {
 
       {/* ── Edit Dialog ────────────────────────────────────────── */}
       <FormDialog
-        open={editOpen}
+        open={editDialog.isOpen}
         title="Edit Role"
         submitLabel="Save Changes"
         loading={updateMut.isPending}
         onSubmit={handleUpdate}
-        onCancel={() => { setEditOpen(false); setEditRow(null); }}
+        onCancel={editDialog.close}
       >
-        {editRow && <TextField label="Code" value={editRow.code} disabled />}
+        {editDialog.data && <TextField label="Code" value={editDialog.data.code} disabled />}
         <TextField label="Name" required value={editForm.name} onChange={onEditField('name')} inputProps={{ maxLength: 128 }} />
         <TextField label="Description" value={editForm.description} onChange={onEditField('description')} inputProps={{ maxLength: 255 }} />
         <TextField label="Scope" select value={editForm.scope} onChange={onEditField('scope')}>

--- a/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
@@ -16,6 +16,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -143,11 +144,10 @@ export default function ManageTenantsPage() {
   const { data: tenantRes, isLoading } = useTenants();
   const allRows = tenantRes?.rows ?? [];
 
-  const [detailOpen, setDetailOpen] = useState(false);
-  const [detailTenantId, setDetailTenantId] = useState(null);
-  const detailTenant = allRows.find((r) => r.id === detailTenantId) ?? null;
-  const { data: contactsData } = useTenantContacts(detailTenantId);
-  const { data: companyData } = useTenantCompany(detailTenantId);
+  const detailDialog = useDialogState();
+  const detailTenant = allRows.find((r) => r.id === detailDialog.data) ?? null;
+  const { data: contactsData } = useTenantContacts(detailDialog.data);
+  const { data: companyData } = useTenantCompany(detailDialog.data);
 
   /* ── view filter (Active / All / Archived) ───────────────── */
   const [viewFilter, setViewFilter] = useState('active');
@@ -169,12 +169,11 @@ export default function ManageTenantsPage() {
   const { selectedRows, allActive, allArchived } = selection;
 
   /* ── dialog state ────────────────────────────────────────── */
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const createDialog = useDialogState();
+  const editDialog = useDialogState();
+  const importDialog = useDialogState();
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [restoreOpen, setRestoreOpen] = useState(false);
-  const [importOpen, setImportOpen] = useState(false);
   const [importErrors, setImportErrors] = useState(null);
 
   /* ── form state ──────────────────────────────────────────── */
@@ -187,12 +186,10 @@ export default function ManageTenantsPage() {
   const handleView = useCallback((row) => {
     qc.invalidateQueries({ queryKey: [...TENANTS_KEY, row.id, 'contacts'] });
     qc.invalidateQueries({ queryKey: [...TENANTS_KEY, row.id, 'company'] });
-    setDetailTenantId(row.id);
-    setDetailOpen(true);
+    detailDialog.open(row.id);
   }, [qc]);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       company: row.company ?? '',
       status: row.status ?? 'active',
@@ -201,19 +198,18 @@ export default function ManageTenantsPage() {
       max_users: row.max_users ?? 5,
       notes: row.notes ?? '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   /* ── CRUD handlers ───────────────────────────────────────── */
   const handleUpdate = async () => {
     try {
       await updateMut.mutateAsync({
-        filter: { id: editRow.id },
+        filter: { id: editDialog.data.id },
         changes: { ...editForm, max_users: Number(editForm.max_users) || 5 },
       });
       toast('Tenant updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -264,7 +260,7 @@ export default function ManageTenantsPage() {
       if (result.inserted) parts.push(`${result.inserted} created`);
       if (result.updated) parts.push(`${result.updated} updated`);
       toast(parts.join(', ') || 'Import complete');
-      setImportOpen(false);
+      importDialog.close();
     } catch (err) {
       const validationErrors = err.payload?.errors;
       if (validationErrors?.length) {
@@ -303,7 +299,7 @@ export default function ManageTenantsPage() {
     primary.push({
       label: 'Import',
       variant: 'outlined',
-      onClick: () => setImportOpen(true),
+      onClick: () => importDialog.open(),
     });
 
     if (viewFilter === 'active' || viewFilter === 'all') {
@@ -329,7 +325,7 @@ export default function ManageTenantsPage() {
       label: 'Create Tenant',
       variant: 'contained',
       color: 'primary',
-      onClick: () => setCreateOpen(true),
+      onClick: () => createDialog.open(),
     });
 
     return {
@@ -357,7 +353,7 @@ export default function ManageTenantsPage() {
       />
 
       {/* ── View Details ───────────────────────────────────── */}
-      <Dialog open={detailOpen} onClose={() => setDetailOpen(false)} maxWidth="md" fullWidth>
+      <Dialog open={detailDialog.isOpen} onClose={detailDialog.close} maxWidth="md" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>Tenant Details</span>
@@ -368,7 +364,7 @@ export default function ManageTenantsPage() {
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setDetailOpen(false)}>
+            <Button size="small" color="inherit" onClick={detailDialog.close}>
               Close
             </Button>
           </Box>
@@ -476,26 +472,26 @@ export default function ManageTenantsPage() {
       </Dialog>
 
       {/* ── Create Wizard ──────────────────────────────────── */}
-      <CreateTenantWizard open={createOpen} onClose={() => setCreateOpen(false)} onSuccess={toast} />
+      <CreateTenantWizard open={createDialog.isOpen} onClose={createDialog.close} onSuccess={toast} />
 
       {/* ── Edit Dialog ────────────────────────────────────── */}
       <FormDialog
-        open={editOpen}
+        open={editDialog.isOpen}
         title="Edit Tenant"
         submitLabel="Save Changes"
         loading={updateMut.isPending}
         onSubmit={handleUpdate}
-        onCancel={() => { setEditOpen(false); setEditRow(null); }}
+        onCancel={editDialog.close}
       >
-        {editRow && (
+        {editDialog.data && (
           <>
             <TextField
               label="Tenant Code"
-              value={editRow.tenant_code}
+              value={editDialog.data.tenant_code}
               disabled
               helperText="Cannot be changed after creation"
             />
-            <TextField label="Schema Name" value={editRow.schema_name ?? ''} disabled />
+            <TextField label="Schema Name" value={editDialog.data.schema_name ?? ''} disabled />
           </>
         )}
         <TextField
@@ -572,12 +568,12 @@ export default function ManageTenantsPage() {
 
       {/* ── Import Dialog ──────────────────────────────────── */}
       <ImportDialog
-        open={importOpen}
+        open={importDialog.isOpen}
         title="Import Tenants"
         loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
-        onCancel={() => { setImportOpen(false); setImportErrors(null); }}
+        onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />
 
       {/* ── Snackbar ───────────────────────────────────────── */}

--- a/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
@@ -15,6 +15,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -111,10 +112,8 @@ export default function ManageUsersPage() {
   const { selectedRows } = selection;
 
   /* ── dialog state ────────────────────────────────────────── */
-  const [viewOpen, setViewOpen] = useState(false);
-  const [viewUser, setViewUser] = useState(null);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editRow, setEditRow] = useState(null);
+  const viewDialog = useDialogState();
+  const editDialog = useDialogState();
 
   /* ── form state ──────────────────────────────────────────── */
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
@@ -124,18 +123,16 @@ export default function ManageUsersPage() {
 
   /* ── Row action callbacks ──────────────────────────────────── */
   const handleView = useCallback((row) => {
-    setViewUser(row);
-    setViewOpen(true);
+    viewDialog.open(row);
   }, []);
 
   const handleEdit = useCallback((row) => {
-    setEditRow(row);
     setEditForm({
       email: row.email ?? '',
       status: row.status ?? 'active',
       password: '',
     });
-    setEditOpen(true);
+    editDialog.open(row);
   }, []);
 
   /* ── CRUD handlers ───────────────────────────────────────── */
@@ -146,10 +143,9 @@ export default function ManageUsersPage() {
         ...fields,
         ...(password ? { password } : {}),
       };
-      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes });
+      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes });
       toast('User updated');
-      setEditOpen(false);
-      setEditRow(null);
+      editDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -182,33 +178,33 @@ export default function ManageUsersPage() {
       />
 
       {/* ── View Details Dialog ──────────────────────────────── */}
-      <Dialog open={viewOpen} onClose={() => setViewOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={viewDialog.isOpen} onClose={viewDialog.close} maxWidth="sm" fullWidth>
         <DialogTitle sx={dialogHeaderSx}>
           <Box>
             <span>User Details</span>
-            {viewUser && (
+            {viewDialog.data && (
               <Typography variant="body2" color="text.secondary">
-                {viewUser.email}
+                {viewDialog.data.email}
               </Typography>
             )}
           </Box>
           <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => setViewOpen(false)}>
+            <Button size="small" color="inherit" onClick={viewDialog.close}>
               Close
             </Button>
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {viewUser && (
+          {viewDialog.data && (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Box sx={detailGridSx}>
-                <FieldRow label="Email" value={viewUser.email} />
-                <FieldRow label="Entity Type" value={capSnake(viewUser.entity_type) || '\u2014'} />
+                <FieldRow label="Email" value={viewDialog.data.email} />
+                <FieldRow label="Entity Type" value={capSnake(viewDialog.data.entity_type) || '\u2014'} />
                 <FieldRow label="Status">
-                  <StatusBadge status={viewUser.status} />
+                  <StatusBadge status={viewDialog.data.status} />
                 </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewUser.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewUser.updated_at)} />
+                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
               </Box>
             </Box>
           )}
@@ -217,15 +213,15 @@ export default function ManageUsersPage() {
 
       {/* ── Edit Dialog ────────────────────────────────────── */}
       <FormDialog
-        open={editOpen}
+        open={editDialog.isOpen}
         title="Edit User"
         submitLabel="Save Changes"
         loading={updateMut.isPending}
         submitDisabled={!!editForm.password && !PW_RULES.every((r) => r.test(editForm.password))}
         onSubmit={handleUpdate}
-        onCancel={() => { setEditOpen(false); setEditRow(null); }}
+        onCancel={editDialog.close}
       >
-        {editRow && <TextField label="Email" value={editRow.email} disabled />}
+        {editDialog.data && <TextField label="Email" value={editDialog.data.email} disabled />}
         <TextField label="Status" select value={editForm.status} onChange={onEditField('status')}>
           {STATUS_OPTS.map((s) => (
             <MenuItem key={s} value={s}>


### PR DESCRIPTION
## Summary
- Add `useDialogState()` hook encapsulating `isOpen` / `data` / `open(data?)` / `close()`
- Replace duplicated `[open, setOpen] + [row, setRow]` pairs across 23 page components
- Net reduction of ~63 lines of boilerplate with identical runtime behaviour

## Test plan
- [x] Verify create/edit/view dialogs open and close correctly on all CRUD pages
- [x] Verify edit dialogs populate with the correct row data
- [ ] Verify import dialogs and reset-password dialogs still function