### PR TITLE
refactor: extract useCollectionState hook and saveCollection util

### DIFF
--- a/apps/nap-client/src/hooks/useCollectionState.js
+++ b/apps/nap-client/src/hooks/useCollectionState.js
@@ -1,0 +1,52 @@
+/**
+ * @file Sub-collection state hook — add / update / remove with soft-delete
+ * @module nap-client/hooks/useCollectionState
+ *
+ * Replaces the per-entity `updateEmail`, `addEmail`, `removeEmail`
+ * (and phone / address / taxId equivalents) boilerplate.
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+
+/**
+ * @param {object[]} initial  Initial items (usually [])
+ * @param {object}   opts
+ * @param {object}   opts.blank          Blank item shape for add()
+ * @param {string}   [opts.autoPrimary]  Field name auto-set on first item (e.g. 'is_primary')
+ * @param {string[]} [opts.exclusive]    Fields with radio-button behaviour (e.g. ['is_primary'])
+ */
+export function useCollectionState(initial, { blank, autoPrimary, exclusive = [] } = {}) {
+  const [items, setItems] = useState(initial);
+
+  const visibleItems = useMemo(() => items.filter((it) => !it._deleted), [items]);
+
+  const update = useCallback((idx, field, value) => {
+    setItems((prev) => prev.map((it, i) => {
+      if (i !== idx) {
+        if (exclusive.includes(field) && value) return { ...it, [field]: false };
+        return it;
+      }
+      return { ...it, [field]: value };
+    }));
+  }, [exclusive]);
+
+  const add = useCallback(() => {
+    setItems((prev) => {
+      const item = { ...blank };
+      if (autoPrimary && !prev.filter((it) => !it._deleted).length) {
+        item[autoPrimary] = true;
+      }
+      return [...prev, item];
+    });
+  }, [blank, autoPrimary]);
+
+  const remove = useCallback((idx) => {
+    setItems((prev) => prev.map((it, i) => (i === idx ? { ...it, _deleted: true } : it)));
+  }, []);
+
+  const reset = useCallback((next) => setItems(next ?? initial), [initial]);
+
+  return { items, visibleItems, setItems, update, add, remove, reset };
+}

--- a/apps/nap-client/src/pages/Core/ClientsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ClientsPage.jsx
@@ -11,6 +11,8 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useDialogState } from '../../hooks/useDialogState.js';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useCollectionState } from '../../hooks/useCollectionState.js';
+import { saveCollection } from '../../utils/saveCollection.js';
 import { useQueryClient } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -159,10 +161,10 @@ export default function ClientsPage() {
 
   const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
-  const [editEmails, setEditEmails] = useState([]);
-  const [editPhones, setEditPhones] = useState([]);
-  const [editAddresses, setEditAddresses] = useState([]);
-  const [editTaxIds, setEditTaxIds] = useState([]);
+  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
+  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
   const editInitial = useRef({ form: null, emails: null, phones: null, addresses: null, taxIds: null });
 
   const { toast, snackProps } = useToast();
@@ -193,71 +195,31 @@ export default function ClientsPage() {
     setPwTarget(null);
   };
 
-  /* ── Email edit helpers ──────────────────────────────────────── */
-  const updateEmail = (idx, field, value) =>
-    setEditEmails((prev) => prev.map((e, i) => {
-      if (i !== idx) {
-        if (field === 'is_primary' && value) return { ...e, is_primary: false };
-        return e;
-      }
-      return { ...e, [field]: value };
-    }));
-  const addEmail = () => setEditEmails((prev) => [...prev, { ...BLANK_EMAIL, is_primary: !prev.filter((e) => !e._deleted).length }]);
-  const removeEmail = (idx) =>
-    setEditEmails((prev) => prev.map((e, i) => (i === idx ? { ...e, _deleted: true } : e)));
-
-  /* ── Phone edit helpers ─────────────────────────────────────── */
-  const updatePhone = (idx, field, value) =>
-    setEditPhones((prev) => prev.map((p, i) => {
-      if (i !== idx) {
-        if (field === 'is_primary' && value) return { ...p, is_primary: false };
-        return p;
-      }
-      return { ...p, [field]: value };
-    }));
-  const addPhone = () => setEditPhones((prev) => [...prev, { ...BLANK_PHONE, is_primary: !prev.filter((p) => !p._deleted).length }]);
-  const removePhone = (idx) =>
-    setEditPhones((prev) => prev.map((p, i) => (i === idx ? { ...p, _deleted: true } : p)));
-
-  /* ── Address edit helpers ───────────────────────────────────── */
-  const updateAddress = (idx, field, value) =>
-    setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, [field]: value } : a)));
-  const addAddress = () => setEditAddresses((prev) => [...prev, { ...BLANK_ADDRESS }]);
-  const removeAddress = (idx) =>
-    setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, _deleted: true } : a)));
-
-  /* ── Tax ID edit helpers ──────────────────────────────────── */
-  const updateTaxId = (idx, field, value) =>
-    setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, [field]: value } : t)));
-  const addTaxId = () => setEditTaxIds((prev) => [...prev, { ...BLANK_TAX_ID }]);
-  const removeTaxId = (idx) =>
-    setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, _deleted: true } : t)));
-
   /* ── Sync query-fetched sub-collections into edit state ────── */
   useEffect(() => {
     if (editDialog.isOpen && emailsRes?.rows) {
-      setEditEmails(emailsRes.rows);
+      emails.reset(emailsRes.rows);
       editInitial.current.emails = emailsRes.rows;
     }
   }, [editDialog.isOpen, emailsRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && phonesRes?.rows) {
-      setEditPhones(phonesRes.rows);
+      phones.reset(phonesRes.rows);
       editInitial.current.phones = phonesRes.rows;
     }
   }, [editDialog.isOpen, phonesRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && addressesRes?.rows) {
-      setEditAddresses(addressesRes.rows);
+      addresses.reset(addressesRes.rows);
       editInitial.current.addresses = addressesRes.rows;
     }
   }, [editDialog.isOpen, addressesRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && taxIdsRes?.rows) {
-      setEditTaxIds(taxIdsRes.rows);
+      taxIds.reset(taxIdsRes.rows);
       editInitial.current.taxIds = taxIdsRes.rows;
     }
   }, [editDialog.isOpen, taxIdsRes]);
@@ -275,10 +237,10 @@ export default function ClientsPage() {
 
     setEditSourceId(row.source_id || null);
     if (!row.source_id) {
-      setEditEmails([]);
-      setEditPhones([]);
-      setEditAddresses([]);
-      setEditTaxIds([]);
+      emails.reset([]);
+      phones.reset([]);
+      addresses.reset([]);
+      taxIds.reset([]);
       editInitial.current.emails = [];
       editInitial.current.phones = [];
       editInitial.current.addresses = [];
@@ -303,12 +265,12 @@ export default function ClientsPage() {
         return !orig || fields.some((f) => c[f] !== orig[f]);
       });
     };
-    if (collectionChanged(editEmails, init.emails, ['email', 'label', 'is_primary'])) return true;
-    if (collectionChanged(editPhones, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
-    if (collectionChanged(editAddresses, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
-    if (collectionChanged(editTaxIds, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
+    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary'])) return true;
+    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
+    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
+    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
     return false;
-  }, [editForm, editEmails, editPhones, editAddresses, editTaxIds]);
+  }, [editForm, emails.items, phones.items, addresses.items, taxIds.items]);
 
   const handleCreate = async () => {
     try {
@@ -327,58 +289,31 @@ export default function ClientsPage() {
       // client update payload so the backend can provision before email mutations run
       const changes = { ...editForm };
       if (changes.is_app_user && !editDialog.data.is_app_user) {
-        const loginEm = editEmails.find((em) => em.is_login && !em._deleted)
-          || editEmails.find((em) => em.is_primary && !em._deleted)
-          || editEmails.find((em) => !em._deleted);
+        const loginEm = emails.items.find((em) => em.is_login && !em._deleted)
+          || emails.items.find((em) => em.is_primary && !em._deleted)
+          || emails.items.find((em) => !em._deleted);
         if (loginEm) changes.email = loginEm.email;
       }
       await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes });
 
-      if (editDialog.data.source_id) {
-        for (const em of editEmails) {
-          if (em._deleted && em.id) {
-            await archiveEmailMut.mutateAsync({ id: em.id });
-          } else if (!em.id && !em._deleted) {
-            await createEmailMut.mutateAsync({ source_id: editDialog.data.source_id, email: em.email, label: em.label, is_primary: em.is_primary });
-          } else if (em.id && !em._deleted) {
-            await updateEmailMut.mutateAsync({ filter: { id: em.id }, changes: { email: em.email, label: em.label, is_primary: em.is_primary } });
-          }
-        }
-        for (const p of editPhones) {
-          if (p._deleted && p.id) {
-            await archivePhoneMut.mutateAsync({ id: p.id });
-          } else if (!p.id && !p._deleted) {
-            await createPhoneMut.mutateAsync({ source_id: editDialog.data.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
-          } else if (p.id && !p._deleted) {
-            await updatePhoneMut.mutateAsync({ filter: { id: p.id }, changes: { country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary } });
-          }
-        }
-        for (const a of editAddresses) {
-          if (a._deleted && a.id) {
-            await archiveAddrMut.mutateAsync({ id: a.id });
-          } else if (!a.id && !a._deleted) {
-            const { _deleted, ...rest } = a;
-            await createAddrMut.mutateAsync({ ...rest, source_id: editDialog.data.source_id });
-          } else if (a.id && !a._deleted) {
-            const { id, source_id: _sid, created_at: _ca, updated_at: _ua, created_by: _cb, updated_by: _ub, deactivated_at: _da, ...changes } = a;
-            await updateAddrMut.mutateAsync({ filter: { id }, changes });
-          }
-        }
-        for (const t of editTaxIds) {
-          if (t._deleted && t.id) {
-            await archiveTaxIdMut.mutateAsync({ id: t.id });
-          } else if (!t.id && !t._deleted) {
-            await createTaxIdMut.mutateAsync({
-              source_id: editDialog.data.source_id, country_code: t.country_code,
-              tax_type: t.tax_type, tax_value: t.tax_value,
-            });
-          } else if (t.id && !t._deleted) {
-            await updateTaxIdMut.mutateAsync({
-              filter: { id: t.id },
-              changes: { country_code: t.country_code, tax_type: t.tax_type, tax_value: t.tax_value },
-            });
-          }
-        }
+      const sid = editDialog.data.source_id;
+      if (sid) {
+        await saveCollection(emails.items, {
+          sourceId: sid, fields: ['email', 'label', 'is_primary'],
+          createMut: createEmailMut.mutateAsync, updateMut: updateEmailMut.mutateAsync, archiveMut: archiveEmailMut.mutateAsync,
+        });
+        await saveCollection(phones.items, {
+          sourceId: sid, fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
+          createMut: createPhoneMut.mutateAsync, updateMut: updatePhoneMut.mutateAsync, archiveMut: archivePhoneMut.mutateAsync,
+        });
+        await saveCollection(addresses.items, {
+          sourceId: sid, fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+          createMut: createAddrMut.mutateAsync, updateMut: updateAddrMut.mutateAsync, archiveMut: archiveAddrMut.mutateAsync,
+        });
+        await saveCollection(taxIds.items, {
+          sourceId: sid, fields: ['country_code', 'tax_type', 'tax_value'],
+          createMut: createTaxIdMut.mutateAsync, updateMut: updateTaxIdMut.mutateAsync, archiveMut: archiveTaxIdMut.mutateAsync,
+        });
       }
 
       await qc.invalidateQueries({ queryKey: ['clients'] });
@@ -486,12 +421,6 @@ export default function ClientsPage() {
     };
   }, [viewFilter, selectedRows.length, allActive, allArchived, selection.clearSelection, setArchiveOpen, setRestoreOpen, canImport, canExport, exportMut.isPending, handleExport]);
   useModuleToolbarRegistration(toolbar);
-
-  /* ── Visible (non-deleted) sub-collections for the form ──── */
-  const visibleEmails = editEmails.filter((e) => !e._deleted);
-  const visiblePhones = editPhones.filter((p) => !p._deleted);
-  const visibleAddresses = editAddresses.filter((a) => !a._deleted);
-  const visibleTaxIds = editTaxIds.filter((t) => !t._deleted);
 
   return (
     <Box sx={pageContainerSx}>
@@ -617,20 +546,20 @@ export default function ClientsPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Emails</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addEmail}>Add Email</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
         </Box>
-        {visibleEmails.length === 0 && (
+        {emails.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No emails</Typography>
         )}
-        {visibleEmails.map((em) => {
-          const idx = editEmails.indexOf(em);
+        {emails.visibleItems.map((em) => {
+          const idx = emails.items.indexOf(em);
           return (
             <Box key={em.id || idx} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
               <TextField
                 label="Email"
                 type="email"
                 value={em.email}
-                onChange={(e) => updateEmail(idx, 'email', e.target.value)}
+                onChange={(e) => emails.update(idx, 'email', e.target.value)}
                 size="small"
                 sx={{ flex: 1, minWidth: 200 }}
               />
@@ -638,7 +567,7 @@ export default function ClientsPage() {
                 select
                 label="Label"
                 value={em.label}
-                onChange={(e) => updateEmail(idx, 'label', e.target.value)}
+                onChange={(e) => emails.update(idx, 'label', e.target.value)}
                 sx={{ minWidth: 120 }}
                 size="small"
               >
@@ -647,11 +576,11 @@ export default function ClientsPage() {
                 ))}
               </TextField>
               <FormControlLabel
-                control={<Checkbox checked={em.is_primary} onChange={(e) => updateEmail(idx, 'is_primary', e.target.checked)} size="small" />}
+                control={<Checkbox checked={em.is_primary} onChange={(e) => emails.update(idx, 'is_primary', e.target.checked)} size="small" />}
                 label="Primary"
                 sx={{ mr: 0 }}
               />
-              <IconButton size="small" onClick={() => removeEmail(idx)} color="error">
+              <IconButton size="small" onClick={() => emails.remove(idx)} color="error">
                 <DeleteOutlineIcon fontSize="small" />
               </IconButton>
             </Box>
@@ -662,13 +591,13 @@ export default function ClientsPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Phone Numbers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addPhone}>Add Phone</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
         </Box>
-        {visiblePhones.length === 0 && (
+        {phones.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
         )}
-        {visiblePhones.map((phone) => {
-          const idx = editPhones.indexOf(phone);
+        {phones.visibleItems.map((phone) => {
+          const idx = phones.items.indexOf(phone);
           const countryCode = phone.country_code?.trim() || 'US';
           const country = COUNTRIES.find((c) => c.code === countryCode);
           return (
@@ -677,7 +606,7 @@ export default function ClientsPage() {
                 select
                 label="Type"
                 value={phone.phone_type}
-                onChange={(e) => updatePhone(idx, 'phone_type', e.target.value)}
+                onChange={(e) => phones.update(idx, 'phone_type', e.target.value)}
                 sx={{ minWidth: 120 }}
                 size="small"
               >
@@ -689,7 +618,7 @@ export default function ClientsPage() {
                 select
                 label="Country"
                 value={countryCode}
-                onChange={(e) => updatePhone(idx, 'country_code', e.target.value)}
+                onChange={(e) => phones.update(idx, 'country_code', e.target.value)}
                 SelectProps={{ renderValue: (val) => COUNTRIES.find((c) => c.code === val)?.dial_code || val }}
                 sx={{ minWidth: 80 }}
                 size="small"
@@ -701,17 +630,17 @@ export default function ClientsPage() {
               <PatternTextField
                 label="Number"
                 value={phone.phone_number}
-                onChange={(raw) => updatePhone(idx, 'phone_number', raw)}
+                onChange={(raw) => phones.update(idx, 'phone_number', raw)}
                 pattern={country?.placeholder}
                 size="small"
                 sx={{ flex: 1, minWidth: 160 }}
               />
               <FormControlLabel
-                control={<Checkbox checked={phone.is_primary} onChange={(e) => updatePhone(idx, 'is_primary', e.target.checked)} size="small" />}
+                control={<Checkbox checked={phone.is_primary} onChange={(e) => phones.update(idx, 'is_primary', e.target.checked)} size="small" />}
                 label="Primary"
                 sx={{ mr: 0 }}
               />
-              <IconButton size="small" onClick={() => removePhone(idx)} color="error">
+              <IconButton size="small" onClick={() => phones.remove(idx)} color="error">
                 <DeleteOutlineIcon fontSize="small" />
               </IconButton>
             </Box>
@@ -722,35 +651,35 @@ export default function ClientsPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Addresses</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addAddress}>Add Address</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
         </Box>
-        {visibleAddresses.length === 0 && (
+        {addresses.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No addresses</Typography>
         )}
-        {visibleAddresses.map((addr) => {
-          const idx = editAddresses.indexOf(addr);
+        {addresses.visibleItems.map((addr) => {
+          const idx = addresses.items.indexOf(addr);
           return (
             <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                 <TextField
                   label="Label"
                   value={addr.label}
-                  onChange={(e) => updateAddress(idx, 'label', e.target.value)}
+                  onChange={(e) => addresses.update(idx, 'label', e.target.value)}
                   size="small"
                   sx={{ width: 200 }}
                 />
-                <IconButton size="small" onClick={() => removeAddress(idx)} color="error">
+                <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
                   <DeleteOutlineIcon fontSize="small" />
                 </IconButton>
               </Box>
               <Box sx={formGridSx}>
-                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => updateAddress(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => updateAddress(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => updateAddress(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="City" value={addr.city} onChange={(e) => updateAddress(idx, 'city', e.target.value)} size="small" />
-                <TextField label="State / Province" value={addr.state_province} onChange={(e) => updateAddress(idx, 'state_province', e.target.value)} size="small" />
-                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => updateAddress(idx, 'postal_code', e.target.value)} size="small" />
-                <TextField label="Country Code" value={addr.country_code} onChange={(e) => updateAddress(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
+                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
+                <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
+                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
+                <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
               </Box>
             </Box>
           );
@@ -760,13 +689,13 @@ export default function ClientsPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Tax Identifiers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addTaxId}>Add Tax ID</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
         </Box>
-        {visibleTaxIds.length === 0 && (
+        {taxIds.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
         )}
-        {visibleTaxIds.map((taxId) => {
-          const idx = editTaxIds.indexOf(taxId);
+        {taxIds.visibleItems.map((taxId) => {
+          const idx = taxIds.items.indexOf(taxId);
           const countryCode = taxId.country_code?.trim() || '';
           const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
           return (
@@ -777,9 +706,9 @@ export default function ClientsPage() {
                   label="Country"
                   value={countryCode}
                   onChange={(e) => {
-                    updateTaxId(idx, 'country_code', e.target.value);
+                    taxIds.update(idx, 'country_code', e.target.value);
                     const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                    updateTaxId(idx, 'tax_type', newTypes[0]?.code || 'TIN');
+                    taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
                   }}
                   SelectProps={{ renderValue: (val) => val }}
                   size="small"
@@ -793,7 +722,7 @@ export default function ClientsPage() {
                   select
                   label="Type"
                   value={taxId.tax_type}
-                  onChange={(e) => updateTaxId(idx, 'tax_type', e.target.value)}
+                  onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
                   SelectProps={{ renderValue: (val) => val }}
                   size="small"
                   sx={{ minWidth: 80 }}
@@ -805,12 +734,12 @@ export default function ClientsPage() {
                 <PatternTextField
                   label="Tax ID Value"
                   value={taxId.tax_value}
-                  onChange={(raw) => updateTaxId(idx, 'tax_value', raw)}
+                  onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
                   pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
                   size="small"
                   sx={{ flex: 1, minWidth: 160 }}
                 />
-                <IconButton size="small" onClick={() => removeTaxId(idx)} color="error">
+                <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
                   <DeleteOutlineIcon fontSize="small" />
                 </IconButton>
               </Box>

--- a/apps/nap-client/src/pages/Core/CompaniesPage.jsx
+++ b/apps/nap-client/src/pages/Core/CompaniesPage.jsx
@@ -8,6 +8,8 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useFormState } from '../../hooks/useFormState.js';
 import { useDialogState } from '../../hooks/useDialogState.js';
+import { useCollectionState } from '../../hooks/useCollectionState.js';
+import { saveCollection } from '../../utils/saveCollection.js';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
@@ -125,8 +127,8 @@ export default function CompaniesPage() {
     { enabled: !!editSourceId },
   );
 
-  const [editAddresses, setEditAddresses] = useState([]);
-  const [editTaxIds, setEditTaxIds] = useState([]);
+  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
+  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
   const editInitial = useRef({ form: null, addresses: null, taxIds: null });
 
   /* ── View: source-linked collections ────────────────────────── */
@@ -145,30 +147,17 @@ export default function CompaniesPage() {
   const { toast, snackProps } = useToast();
 
 
-  /* ── Address / TaxId helpers ────────────────────────────────── */
-  const updateAddress = (idx, field, value) =>
-    setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, [field]: value } : a)));
-  const addAddress = () => setEditAddresses((prev) => [...prev, { ...BLANK_ADDRESS }]);
-  const removeAddress = (idx) =>
-    setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, _deleted: true } : a)));
-
-  const updateTaxId = (idx, field, value) =>
-    setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, [field]: value } : t)));
-  const addTaxId = () => setEditTaxIds((prev) => [...prev, { ...BLANK_TAX_ID }]);
-  const removeTaxId = (idx) =>
-    setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, _deleted: true } : t)));
-
   /* ── Sync query → local state ───────────────────────────────── */
   useEffect(() => {
     if (editDialog.isOpen && addressesRes?.rows) {
-      setEditAddresses(addressesRes.rows);
+      addresses.reset(addressesRes.rows);
       editInitial.current.addresses = addressesRes.rows;
     }
   }, [editDialog.isOpen, addressesRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && taxIdsRes?.rows) {
-      setEditTaxIds(taxIdsRes.rows);
+      taxIds.reset(taxIdsRes.rows);
       editInitial.current.taxIds = taxIdsRes.rows;
     }
   }, [editDialog.isOpen, taxIdsRes]);
@@ -183,8 +172,8 @@ export default function CompaniesPage() {
     setEditForm({ name: row.name ?? '', code: row.code ?? '', is_active: row.is_active ?? true });
     setEditSourceId(row.source_id || null);
     if (!row.source_id) {
-      setEditAddresses([]);
-      setEditTaxIds([]);
+      addresses.reset([]);
+      taxIds.reset([]);
       editInitial.current.addresses = [];
       editInitial.current.taxIds = [];
     }
@@ -208,42 +197,28 @@ export default function CompaniesPage() {
       await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
 
       /* ── Save addresses ──────────────────────────────────────── */
-      for (const a of editAddresses) {
-        if (a._deleted && a.id) {
-          await archiveAddrMut.mutateAsync({ id: a.id });
-        } else if (!a.id && !a._deleted) {
-          const { _deleted, ...rest } = a;
-          await createAddrMut.mutateAsync({ ...rest, source_id: editDialog.data.source_id });
-        } else if (a.id && !a._deleted) {
-          const { id, source_id: _sid, created_at: _ca, updated_at: _ua, created_by: _cb, updated_by: _ub, deactivated_at: _da, ...changes } = a;
-          await updateAddrMut.mutateAsync({ filter: { id }, changes });
-        }
-      }
+      await saveCollection(addresses.items, {
+        sourceId: editDialog.data.source_id,
+        fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+        createMut: createAddrMut.mutateAsync,
+        updateMut: updateAddrMut.mutateAsync,
+        archiveMut: archiveAddrMut.mutateAsync,
+      });
 
       /* ── Save tax identifiers ────────────────────────────────── */
-      for (const t of editTaxIds) {
-        if (t._deleted && t.id) {
-          await archiveTaxIdMut.mutateAsync({ id: t.id });
-        } else if (!t.id && !t._deleted) {
-          await createTaxIdMut.mutateAsync({
-            source_id: editDialog.data.source_id,
-            country_code: t.country_code,
-            tax_type: t.tax_type,
-            tax_value: t.tax_value,
-          });
-        } else if (t.id && !t._deleted) {
-          await updateTaxIdMut.mutateAsync({
-            filter: { id: t.id },
-            changes: { country_code: t.country_code, tax_type: t.tax_type, tax_value: t.tax_value },
-          });
-        }
-      }
+      await saveCollection(taxIds.items, {
+        sourceId: editDialog.data.source_id,
+        fields: ['country_code', 'tax_type', 'tax_value'],
+        createMut: createTaxIdMut.mutateAsync,
+        updateMut: updateTaxIdMut.mutateAsync,
+        archiveMut: archiveTaxIdMut.mutateAsync,
+      });
 
       toast('Company updated');
       editDialog.close();
       setEditSourceId(null);
-      setEditAddresses([]);
-      setEditTaxIds([]);
+      addresses.reset([]);
+      taxIds.reset([]);
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -284,10 +259,6 @@ export default function CompaniesPage() {
     errMsg,
     getLabel: (r) => r.name,
   });
-
-  /* ── Visible (non-deleted) collections for rendering ────────── */
-  const visibleAddresses = editAddresses.filter((a) => !a._deleted);
-  const visibleTaxIds = editTaxIds.filter((t) => !t._deleted);
 
   /* ── ModuleBar: tabs + Create + Archive/Restore ────────────── */
   const toolbar = useMemo(() => {
@@ -423,7 +394,7 @@ export default function CompaniesPage() {
         submitLabel="Save Changes"
         loading={updateMut.isPending}
         onSubmit={handleUpdate}
-        onCancel={() => { editDialog.close(); setEditSourceId(null); setEditAddresses([]); setEditTaxIds([]); }}
+        onCancel={() => { editDialog.close(); setEditSourceId(null); addresses.reset([]); taxIds.reset([]); }}
       >
         <TextField label="Company Name" required value={editForm.name} onChange={onEditField('name')} />
         <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
@@ -442,38 +413,38 @@ export default function CompaniesPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Addresses</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addAddress} disabled={!editDialog.data?.source_id}>Add Address</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={addresses.add} disabled={!editDialog.data?.source_id}>Add Address</Button>
         </Box>
         {!editDialog.data?.source_id && (
           <Typography variant="body2" color="text.secondary">Save company first to manage addresses</Typography>
         )}
-        {visibleAddresses.length === 0 && editDialog.data?.source_id && (
+        {addresses.visibleItems.length === 0 && editDialog.data?.source_id && (
           <Typography variant="body2" color="text.secondary">No addresses</Typography>
         )}
-        {visibleAddresses.map((addr) => {
-          const idx = editAddresses.indexOf(addr);
+        {addresses.visibleItems.map((addr) => {
+          const idx = addresses.items.indexOf(addr);
           return (
             <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                 <TextField
                   label="Label"
                   value={addr.label}
-                  onChange={(e) => updateAddress(idx, 'label', e.target.value)}
+                  onChange={(e) => addresses.update(idx, 'label', e.target.value)}
                   size="small"
                   sx={{ width: 200 }}
                 />
-                <IconButton size="small" onClick={() => removeAddress(idx)} color="error">
+                <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
                   <DeleteOutlineIcon fontSize="small" />
                 </IconButton>
               </Box>
               <Box sx={formGridSx}>
-                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => updateAddress(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => updateAddress(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => updateAddress(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="City" value={addr.city} onChange={(e) => updateAddress(idx, 'city', e.target.value)} size="small" />
-                <TextField label="State / Province" value={addr.state_province} onChange={(e) => updateAddress(idx, 'state_province', e.target.value)} size="small" />
-                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => updateAddress(idx, 'postal_code', e.target.value)} size="small" />
-                <TextField label="Country Code" value={addr.country_code} onChange={(e) => updateAddress(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
+                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
+                <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
+                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
+                <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
               </Box>
             </Box>
           );
@@ -483,16 +454,16 @@ export default function CompaniesPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Tax Identifiers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addTaxId} disabled={!editDialog.data?.source_id}>Add Tax ID</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add} disabled={!editDialog.data?.source_id}>Add Tax ID</Button>
         </Box>
         {!editDialog.data?.source_id && (
           <Typography variant="body2" color="text.secondary">Save company first to manage tax identifiers</Typography>
         )}
-        {visibleTaxIds.length === 0 && editDialog.data?.source_id && (
+        {taxIds.visibleItems.length === 0 && editDialog.data?.source_id && (
           <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
         )}
-        {visibleTaxIds.map((taxId) => {
-          const idx = editTaxIds.indexOf(taxId);
+        {taxIds.visibleItems.map((taxId) => {
+          const idx = taxIds.items.indexOf(taxId);
           const countryCode = taxId.country_code?.trim() || '';
           const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
           return (
@@ -503,9 +474,9 @@ export default function CompaniesPage() {
                   label="Country"
                   value={countryCode}
                   onChange={(e) => {
-                    updateTaxId(idx, 'country_code', e.target.value);
+                    taxIds.update(idx, 'country_code', e.target.value);
                     const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                    updateTaxId(idx, 'tax_type', newTypes[0]?.code || 'TIN');
+                    taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
                   }}
                   SelectProps={{ renderValue: (val) => val }}
                   size="small"
@@ -519,7 +490,7 @@ export default function CompaniesPage() {
                   select
                   label="Type"
                   value={taxId.tax_type}
-                  onChange={(e) => updateTaxId(idx, 'tax_type', e.target.value)}
+                  onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
                   SelectProps={{ renderValue: (val) => val }}
                   size="small"
                   sx={{ minWidth: 80 }}
@@ -531,12 +502,12 @@ export default function CompaniesPage() {
                 <PatternTextField
                   label="Tax ID Value"
                   value={taxId.tax_value}
-                  onChange={(raw) => updateTaxId(idx, 'tax_value', raw)}
+                  onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
                   pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
                   size="small"
                   sx={{ flex: 1, minWidth: 160 }}
                 />
-                <IconButton size="small" onClick={() => removeTaxId(idx)} color="error">
+                <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
                   <DeleteOutlineIcon fontSize="small" />
                 </IconButton>
               </Box>

--- a/apps/nap-client/src/pages/Core/ContactsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ContactsPage.jsx
@@ -65,6 +65,8 @@ import { cap, fmtDate, errMsg } from '../../utils/format.js';
 import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
 import { contactApi } from '../../services/contactApi.js';
 import { pageContainerSx, formGridSx, formGroupCardSx, formFullSpanSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
+import { useCollectionState } from '../../hooks/useCollectionState.js';
+import { saveCollection } from '../../utils/saveCollection.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 
@@ -150,81 +152,41 @@ export default function ContactsPage() {
 
   const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
-  const [editEmails, setEditEmails] = useState([]);
-  const [editPhones, setEditPhones] = useState([]);
-  const [editAddresses, setEditAddresses] = useState([]);
-  const [editTaxIds, setEditTaxIds] = useState([]);
+  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
+  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
   const editInitial = useRef({ form: null, emails: null, phones: null, addresses: null, taxIds: null });
 
   const { toast, snackProps } = useToast();
 
 
 
-  /* ── Email edit helpers ──────────────────────────────────────── */
-  const updateEmail = (idx, field, value) =>
-    setEditEmails((prev) => prev.map((e, i) => {
-      if (i !== idx) {
-        if (field === 'is_primary' && value) return { ...e, is_primary: false };
-        return e;
-      }
-      return { ...e, [field]: value };
-    }));
-  const addEmail = () => setEditEmails((prev) => [...prev, { ...BLANK_EMAIL, is_primary: !prev.filter((e) => !e._deleted).length }]);
-  const removeEmail = (idx) =>
-    setEditEmails((prev) => prev.map((e, i) => (i === idx ? { ...e, _deleted: true } : e)));
-
-  /* ── Phone edit helpers ──────────────────────────────────────── */
-  const updatePhone = (idx, field, value) =>
-    setEditPhones((prev) => prev.map((p, i) => {
-      if (i !== idx) {
-        if (field === 'is_primary' && value) return { ...p, is_primary: false };
-        return p;
-      }
-      return { ...p, [field]: value };
-    }));
-  const addPhone = () => setEditPhones((prev) => [...prev, { ...BLANK_PHONE, is_primary: !prev.filter((p) => !p._deleted).length }]);
-  const removePhone = (idx) =>
-    setEditPhones((prev) => prev.map((p, i) => (i === idx ? { ...p, _deleted: true } : p)));
-
-  /* ── Address edit helpers ────────────────────────────────────── */
-  const updateAddress = (idx, field, value) =>
-    setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, [field]: value } : a)));
-  const addAddress = () => setEditAddresses((prev) => [...prev, { ...BLANK_ADDRESS }]);
-  const removeAddress = (idx) =>
-    setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, _deleted: true } : a)));
-
-  /* ── Tax ID edit helpers ─────────────────────────────────────── */
-  const updateTaxId = (idx, field, value) =>
-    setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, [field]: value } : t)));
-  const addTaxId = () => setEditTaxIds((prev) => [...prev, { ...BLANK_TAX_ID }]);
-  const removeTaxId = (idx) =>
-    setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, _deleted: true } : t)));
-
   /* ── Sync query-fetched child data into edit state ──────────── */
   useEffect(() => {
     if (editDialog.isOpen && emailsRes?.rows) {
-      setEditEmails(emailsRes.rows);
+      emails.reset(emailsRes.rows);
       editInitial.current.emails = emailsRes.rows;
     }
   }, [editDialog.isOpen, emailsRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && phonesRes?.rows) {
-      setEditPhones(phonesRes.rows);
+      phones.reset(phonesRes.rows);
       editInitial.current.phones = phonesRes.rows;
     }
   }, [editDialog.isOpen, phonesRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && addressesRes?.rows) {
-      setEditAddresses(addressesRes.rows);
+      addresses.reset(addressesRes.rows);
       editInitial.current.addresses = addressesRes.rows;
     }
   }, [editDialog.isOpen, addressesRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && taxIdsRes?.rows) {
-      setEditTaxIds(taxIdsRes.rows);
+      taxIds.reset(taxIdsRes.rows);
       editInitial.current.taxIds = taxIdsRes.rows;
     }
   }, [editDialog.isOpen, taxIdsRes]);
@@ -246,10 +208,10 @@ export default function ContactsPage() {
 
     setEditSourceId(row.source_id || null);
     if (!row.source_id) {
-      setEditEmails([]);
-      setEditPhones([]);
-      setEditAddresses([]);
-      setEditTaxIds([]);
+      emails.reset([]);
+      phones.reset([]);
+      addresses.reset([]);
+      taxIds.reset([]);
       editInitial.current.emails = [];
       editInitial.current.phones = [];
       editInitial.current.addresses = [];
@@ -274,12 +236,12 @@ export default function ContactsPage() {
         return !orig || fields.some((f) => c[f] !== orig[f]);
       });
     };
-    if (collectionChanged(editEmails, init.emails, ['email', 'label', 'is_primary'])) return true;
-    if (collectionChanged(editPhones, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
-    if (collectionChanged(editAddresses, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
-    if (collectionChanged(editTaxIds, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
+    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary'])) return true;
+    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
+    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
+    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
     return false;
-  }, [editForm, editEmails, editPhones, editAddresses, editTaxIds]);
+  }, [editForm, emails.items, phones.items, addresses.items, taxIds.items]);
 
   const handleCreate = async () => {
     try {
@@ -297,50 +259,23 @@ export default function ContactsPage() {
       await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
 
       if (editDialog.data.source_id) {
-        for (const em of editEmails) {
-          if (em._deleted && em.id) {
-            await archiveEmailMut.mutateAsync({ id: em.id });
-          } else if (!em.id && !em._deleted) {
-            await createEmailMut.mutateAsync({ source_id: editDialog.data.source_id, email: em.email, label: em.label, is_primary: em.is_primary });
-          } else if (em.id && !em._deleted) {
-            await updateEmailMut.mutateAsync({ filter: { id: em.id }, changes: { email: em.email, label: em.label, is_primary: em.is_primary } });
-          }
-        }
-        for (const p of editPhones) {
-          if (p._deleted && p.id) {
-            await archivePhoneMut.mutateAsync({ id: p.id });
-          } else if (!p.id && !p._deleted) {
-            await createPhoneMut.mutateAsync({ source_id: editDialog.data.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
-          } else if (p.id && !p._deleted) {
-            await updatePhoneMut.mutateAsync({ filter: { id: p.id }, changes: { country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary } });
-          }
-        }
-        for (const a of editAddresses) {
-          if (a._deleted && a.id) {
-            await archiveAddrMut.mutateAsync({ id: a.id });
-          } else if (!a.id && !a._deleted) {
-            const { _deleted, is_primary: _ip, ...rest } = a;
-            await createAddrMut.mutateAsync({ ...rest, source_id: editDialog.data.source_id });
-          } else if (a.id && !a._deleted) {
-            const { id, source_id: _sid, created_at: _ca, updated_at: _ua, created_by: _cb, updated_by: _ub, deactivated_at: _da, is_primary: _ip, ...changes } = a;
-            await updateAddrMut.mutateAsync({ filter: { id }, changes });
-          }
-        }
-        for (const t of editTaxIds) {
-          if (t._deleted && t.id) {
-            await archiveTaxIdMut.mutateAsync({ id: t.id });
-          } else if (!t.id && !t._deleted) {
-            await createTaxIdMut.mutateAsync({
-              source_id: editDialog.data.source_id, country_code: t.country_code,
-              tax_type: t.tax_type, tax_value: t.tax_value,
-            });
-          } else if (t.id && !t._deleted) {
-            await updateTaxIdMut.mutateAsync({
-              filter: { id: t.id },
-              changes: { country_code: t.country_code, tax_type: t.tax_type, tax_value: t.tax_value },
-            });
-          }
-        }
+        const sid = editDialog.data.source_id;
+        await saveCollection(emails.items, {
+          sourceId: sid, fields: ['email', 'label', 'is_primary'],
+          createMut: createEmailMut.mutateAsync, updateMut: updateEmailMut.mutateAsync, archiveMut: archiveEmailMut.mutateAsync,
+        });
+        await saveCollection(phones.items, {
+          sourceId: sid, fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
+          createMut: createPhoneMut.mutateAsync, updateMut: updatePhoneMut.mutateAsync, archiveMut: archivePhoneMut.mutateAsync,
+        });
+        await saveCollection(addresses.items, {
+          sourceId: sid, fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+          createMut: createAddrMut.mutateAsync, updateMut: updateAddrMut.mutateAsync, archiveMut: archiveAddrMut.mutateAsync,
+        });
+        await saveCollection(taxIds.items, {
+          sourceId: sid, fields: ['country_code', 'tax_type', 'tax_value'],
+          createMut: createTaxIdMut.mutateAsync, updateMut: updateTaxIdMut.mutateAsync, archiveMut: archiveTaxIdMut.mutateAsync,
+        });
       }
 
       toast('Contact updated');
@@ -444,12 +379,6 @@ export default function ContactsPage() {
   }, [viewFilter, selectedRows.length, allActive, allArchived, selection.clearSelection, setArchiveOpen, setRestoreOpen, canImport, canExport, exportMut.isPending, handleExport]);
   useModuleToolbarRegistration(toolbar);
 
-  /* ── Visible (non-deleted) sub-collections for the form ─────── */
-  const visibleEmails = editEmails.filter((e) => !e._deleted);
-  const visiblePhones = editPhones.filter((p) => !p._deleted);
-  const visibleAddresses = editAddresses.filter((a) => !a._deleted);
-  const visibleTaxIds = editTaxIds.filter((t) => !t._deleted);
-
   return (
     <Box sx={pageContainerSx}>
       <DataTable
@@ -537,20 +466,20 @@ export default function ContactsPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Emails</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addEmail}>Add Email</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
         </Box>
-        {visibleEmails.length === 0 && (
+        {emails.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No emails</Typography>
         )}
-        {visibleEmails.map((em) => {
-          const idx = editEmails.indexOf(em);
+        {emails.visibleItems.map((em) => {
+          const idx = emails.items.indexOf(em);
           return (
             <Box key={em.id || idx} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
               <TextField
                 label="Email"
                 type="email"
                 value={em.email}
-                onChange={(e) => updateEmail(idx, 'email', e.target.value)}
+                onChange={(e) => emails.update(idx, 'email', e.target.value)}
                 size="small"
                 sx={{ flex: 1, minWidth: 200 }}
               />
@@ -558,7 +487,7 @@ export default function ContactsPage() {
                 select
                 label="Label"
                 value={em.label}
-                onChange={(e) => updateEmail(idx, 'label', e.target.value)}
+                onChange={(e) => emails.update(idx, 'label', e.target.value)}
                 sx={{ minWidth: 120 }}
                 size="small"
               >
@@ -567,11 +496,11 @@ export default function ContactsPage() {
                 ))}
               </TextField>
               <FormControlLabel
-                control={<Checkbox checked={em.is_primary} onChange={(e) => updateEmail(idx, 'is_primary', e.target.checked)} size="small" />}
+                control={<Checkbox checked={em.is_primary} onChange={(e) => emails.update(idx, 'is_primary', e.target.checked)} size="small" />}
                 label="Primary"
                 sx={{ mr: 0 }}
               />
-              <IconButton size="small" onClick={() => removeEmail(idx)} color="error">
+              <IconButton size="small" onClick={() => emails.remove(idx)} color="error">
                 <DeleteOutlineIcon fontSize="small" />
               </IconButton>
             </Box>
@@ -582,13 +511,13 @@ export default function ContactsPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Phone Numbers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addPhone}>Add Phone</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
         </Box>
-        {visiblePhones.length === 0 && (
+        {phones.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
         )}
-        {visiblePhones.map((phone) => {
-          const idx = editPhones.indexOf(phone);
+        {phones.visibleItems.map((phone) => {
+          const idx = phones.items.indexOf(phone);
           const countryCode = phone.country_code?.trim() || 'US';
           const country = COUNTRIES.find((c) => c.code === countryCode);
           return (
@@ -597,7 +526,7 @@ export default function ContactsPage() {
                 select
                 label="Type"
                 value={phone.phone_type}
-                onChange={(e) => updatePhone(idx, 'phone_type', e.target.value)}
+                onChange={(e) => phones.update(idx, 'phone_type', e.target.value)}
                 sx={{ minWidth: 120 }}
                 size="small"
               >
@@ -609,7 +538,7 @@ export default function ContactsPage() {
                 select
                 label="Country"
                 value={countryCode}
-                onChange={(e) => updatePhone(idx, 'country_code', e.target.value)}
+                onChange={(e) => phones.update(idx, 'country_code', e.target.value)}
                 SelectProps={{ renderValue: (val) => COUNTRIES.find((c) => c.code === val)?.dial_code || val }}
                 sx={{ minWidth: 80 }}
                 size="small"
@@ -621,17 +550,17 @@ export default function ContactsPage() {
               <PatternTextField
                 label="Number"
                 value={phone.phone_number}
-                onChange={(raw) => updatePhone(idx, 'phone_number', raw)}
+                onChange={(raw) => phones.update(idx, 'phone_number', raw)}
                 pattern={country?.placeholder}
                 size="small"
                 sx={{ flex: 1, minWidth: 160 }}
               />
               <FormControlLabel
-                control={<Checkbox checked={phone.is_primary} onChange={(e) => updatePhone(idx, 'is_primary', e.target.checked)} size="small" />}
+                control={<Checkbox checked={phone.is_primary} onChange={(e) => phones.update(idx, 'is_primary', e.target.checked)} size="small" />}
                 label="Primary"
                 sx={{ mr: 0 }}
               />
-              <IconButton size="small" onClick={() => removePhone(idx)} color="error">
+              <IconButton size="small" onClick={() => phones.remove(idx)} color="error">
                 <DeleteOutlineIcon fontSize="small" />
               </IconButton>
             </Box>
@@ -642,35 +571,35 @@ export default function ContactsPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Addresses</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addAddress}>Add Address</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
         </Box>
-        {visibleAddresses.length === 0 && (
+        {addresses.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No addresses</Typography>
         )}
-        {visibleAddresses.map((addr) => {
-          const idx = editAddresses.indexOf(addr);
+        {addresses.visibleItems.map((addr) => {
+          const idx = addresses.items.indexOf(addr);
           return (
             <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                 <TextField
                   label="Label"
                   value={addr.label}
-                  onChange={(e) => updateAddress(idx, 'label', e.target.value)}
+                  onChange={(e) => addresses.update(idx, 'label', e.target.value)}
                   size="small"
                   sx={{ width: 200 }}
                 />
-                <IconButton size="small" onClick={() => removeAddress(idx)} color="error">
+                <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
                   <DeleteOutlineIcon fontSize="small" />
                 </IconButton>
               </Box>
               <Box sx={formGridSx}>
-                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => updateAddress(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => updateAddress(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => updateAddress(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="City" value={addr.city} onChange={(e) => updateAddress(idx, 'city', e.target.value)} size="small" />
-                <TextField label="State / Province" value={addr.state_province} onChange={(e) => updateAddress(idx, 'state_province', e.target.value)} size="small" />
-                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => updateAddress(idx, 'postal_code', e.target.value)} size="small" />
-                <TextField label="Country Code" value={addr.country_code} onChange={(e) => updateAddress(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
+                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
+                <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
+                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
+                <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
               </Box>
             </Box>
           );
@@ -680,13 +609,13 @@ export default function ContactsPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Tax Identifiers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addTaxId}>Add Tax ID</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
         </Box>
-        {visibleTaxIds.length === 0 && (
+        {taxIds.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
         )}
-        {visibleTaxIds.map((taxId) => {
-          const idx = editTaxIds.indexOf(taxId);
+        {taxIds.visibleItems.map((taxId) => {
+          const idx = taxIds.items.indexOf(taxId);
           const countryCode = taxId.country_code?.trim() || '';
           const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
           return (
@@ -697,9 +626,9 @@ export default function ContactsPage() {
                   label="Country"
                   value={countryCode}
                   onChange={(e) => {
-                    updateTaxId(idx, 'country_code', e.target.value);
+                    taxIds.update(idx, 'country_code', e.target.value);
                     const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                    updateTaxId(idx, 'tax_type', newTypes[0]?.code || 'TIN');
+                    taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
                   }}
                   SelectProps={{ renderValue: (val) => val }}
                   size="small"
@@ -713,7 +642,7 @@ export default function ContactsPage() {
                   select
                   label="Type"
                   value={taxId.tax_type}
-                  onChange={(e) => updateTaxId(idx, 'tax_type', e.target.value)}
+                  onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
                   SelectProps={{ renderValue: (val) => val }}
                   size="small"
                   sx={{ minWidth: 80 }}
@@ -725,12 +654,12 @@ export default function ContactsPage() {
                 <PatternTextField
                   label="Tax ID Value"
                   value={taxId.tax_value}
-                  onChange={(raw) => updateTaxId(idx, 'tax_value', raw)}
+                  onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
                   pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
                   size="small"
                   sx={{ flex: 1, minWidth: 160 }}
                 />
-                <IconButton size="small" onClick={() => removeTaxId(idx)} color="error">
+                <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
                   <DeleteOutlineIcon fontSize="small" />
                 </IconButton>
               </Box>

--- a/apps/nap-client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/nap-client/src/pages/Core/EmployeesPage.jsx
@@ -11,6 +11,8 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useDialogState } from '../../hooks/useDialogState.js';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useCollectionState } from '../../hooks/useCollectionState.js';
+import { saveCollection } from '../../utils/saveCollection.js';
 import { useQueryClient } from '@tanstack/react-query';
 import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
@@ -177,10 +179,10 @@ export default function EmployeesPage() {
 
   const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
-  const [editPhones, setEditPhones] = useState([]);
-  const [editEmails, setEditEmails] = useState([]);
-  const [editAddresses, setEditAddresses] = useState([]);
-  const [editTaxIds, setEditTaxIds] = useState([]);
+  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary', 'is_login'] });
+  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
+  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
   const editInitial = useRef({ form: null, phones: null, emails: null, addresses: null, taxIds: null });
 
   const { toast, snackProps } = useToast();
@@ -214,73 +216,31 @@ export default function EmployeesPage() {
     setPwTarget(null);
   };
 
-  /* ── Phone edit helpers ─────────────────────────────────────── */
-  const updatePhone = (idx, field, value) =>
-    setEditPhones((prev) => prev.map((p, i) => {
-      if (i !== idx) {
-        if (field === 'is_primary' && value) return { ...p, is_primary: false };
-        return p;
-      }
-      return { ...p, [field]: value };
-    }));
-  const addPhone = () => setEditPhones((prev) => [...prev, { ...BLANK_PHONE, is_primary: !prev.filter((p) => !p._deleted).length }]);
-  const removePhone = (idx) =>
-    setEditPhones((prev) => prev.map((p, i) => (i === idx ? { ...p, _deleted: true } : p)));
-
-  /* ── Email edit helpers ──────────────────────────────────────── */
-  const updateEmail = (idx, field, value) =>
-    setEditEmails((prev) => prev.map((e, i) => {
-      if (i !== idx) {
-        // Radio behavior: when setting is_login or is_primary on one row, clear it on all others
-        if (field === 'is_login' && value) return { ...e, is_login: false };
-        if (field === 'is_primary' && value) return { ...e, is_primary: false };
-        return e;
-      }
-      return { ...e, [field]: value };
-    }));
-  const addEmail = () => setEditEmails((prev) => [...prev, { ...BLANK_EMAIL, is_primary: !prev.filter((e) => !e._deleted).length }]);
-  const removeEmail = (idx) =>
-    setEditEmails((prev) => prev.map((e, i) => (i === idx ? { ...e, _deleted: true } : e)));
-
-  /* ── Address edit helpers ───────────────────────────────────── */
-  const updateAddress = (idx, field, value) =>
-    setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, [field]: value } : a)));
-  const addAddress = () => setEditAddresses((prev) => [...prev, { ...BLANK_ADDRESS }]);
-  const removeAddress = (idx) =>
-    setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, _deleted: true } : a)));
-
-  /* ── Tax ID edit helpers ──────────────────────────────────── */
-  const updateTaxId = (idx, field, value) =>
-    setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, [field]: value } : t)));
-  const addTaxId = () => setEditTaxIds((prev) => [...prev, { ...BLANK_TAX_ID }]);
-  const removeTaxId = (idx) =>
-    setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, _deleted: true } : t)));
-
   /* ── Sync query-fetched phones/addresses/taxIds into edit state */
   useEffect(() => {
     if (editDialog.isOpen && phonesRes?.rows) {
-      setEditPhones(phonesRes.rows);
+      phones.reset(phonesRes.rows);
       editInitial.current.phones = phonesRes.rows;
     }
   }, [editDialog.isOpen, phonesRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && emailsRes?.rows) {
-      setEditEmails(emailsRes.rows);
+      emails.reset(emailsRes.rows);
       editInitial.current.emails = emailsRes.rows;
     }
   }, [editDialog.isOpen, emailsRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && addressesRes?.rows) {
-      setEditAddresses(addressesRes.rows);
+      addresses.reset(addressesRes.rows);
       editInitial.current.addresses = addressesRes.rows;
     }
   }, [editDialog.isOpen, addressesRes]);
 
   useEffect(() => {
     if (editDialog.isOpen && taxIdsRes?.rows) {
-      setEditTaxIds(taxIdsRes.rows);
+      taxIds.reset(taxIdsRes.rows);
       editInitial.current.taxIds = taxIdsRes.rows;
     }
   }, [editDialog.isOpen, taxIdsRes]);
@@ -308,10 +268,10 @@ export default function EmployeesPage() {
 
     setEditSourceId(row.source_id || null);
     if (!row.source_id) {
-      setEditPhones([]);
-      setEditEmails([]);
-      setEditAddresses([]);
-      setEditTaxIds([]);
+      phones.reset([]);
+      emails.reset([]);
+      addresses.reset([]);
+      taxIds.reset([]);
       editInitial.current.phones = [];
       editInitial.current.emails = [];
       editInitial.current.addresses = [];
@@ -354,12 +314,12 @@ export default function EmployeesPage() {
         return !orig || fields.some((f) => c[f] !== orig[f]);
       });
     };
-    if (collectionChanged(editPhones, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
-    if (collectionChanged(editEmails, init.emails, ['email', 'label', 'is_primary', 'is_login'])) return true;
-    if (collectionChanged(editAddresses, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
-    if (collectionChanged(editTaxIds, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
+    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
+    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary', 'is_login'])) return true;
+    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
+    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
     return false;
-  }, [editForm, editPhones, editEmails, editAddresses, editTaxIds]);
+  }, [editForm, phones.items, emails.items, addresses.items, taxIds.items]);
 
   const handleCreate = async () => {
     try {
@@ -378,62 +338,33 @@ export default function EmployeesPage() {
       // employee update payload so the backend can provision before email mutations run
       const changes = { ...editForm };
       if (changes.is_app_user && !editDialog.data.is_app_user) {
-        const loginEm = editEmails.find((em) => em.is_login && !em._deleted);
+        const loginEm = emails.items.find((em) => em.is_login && !em._deleted);
         if (loginEm) changes.email = loginEm.email;
       }
       await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes });
 
       if (editDialog.data.source_id) {
-        for (const p of editPhones) {
-          if (p._deleted && p.id) {
-            await archivePhoneMut.mutateAsync({ id: p.id });
-          } else if (!p.id && !p._deleted) {
-            await createPhoneMut.mutateAsync({ source_id: editDialog.data.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
-          } else if (p.id && !p._deleted) {
-            await updatePhoneMut.mutateAsync({ filter: { id: p.id }, changes: { country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary } });
-          }
-        }
-        for (const em of editEmails) {
-          if (em._deleted && em.id) {
-            await archiveEmailMut.mutateAsync({ id: em.id });
-          } else if (!em.id && !em._deleted) {
-            await createEmailMut.mutateAsync({
-              source_id: editDialog.data.source_id, email: em.email, label: em.label,
-              is_primary: em.is_primary, is_login: em.is_login,
-            });
-          } else if (em.id && !em._deleted) {
-            await updateEmailMut.mutateAsync({
-              filter: { id: em.id },
-              changes: { email: em.email, label: em.label, is_primary: em.is_primary, is_login: em.is_login },
-            });
-          }
-        }
-        for (const a of editAddresses) {
-          if (a._deleted && a.id) {
-            await archiveAddrMut.mutateAsync({ id: a.id });
-          } else if (!a.id && !a._deleted) {
-            const { _deleted, ...rest } = a;
-            await createAddrMut.mutateAsync({ ...rest, source_id: editDialog.data.source_id });
-          } else if (a.id && !a._deleted) {
-            const { id, source_id: _sid, created_at: _ca, updated_at: _ua, created_by: _cb, updated_by: _ub, deactivated_at: _da, ...changes } = a;
-            await updateAddrMut.mutateAsync({ filter: { id }, changes });
-          }
-        }
-        for (const t of editTaxIds) {
-          if (t._deleted && t.id) {
-            await archiveTaxIdMut.mutateAsync({ id: t.id });
-          } else if (!t.id && !t._deleted) {
-            await createTaxIdMut.mutateAsync({
-              source_id: editDialog.data.source_id, country_code: t.country_code,
-              tax_type: t.tax_type, tax_value: t.tax_value,
-            });
-          } else if (t.id && !t._deleted) {
-            await updateTaxIdMut.mutateAsync({
-              filter: { id: t.id },
-              changes: { country_code: t.country_code, tax_type: t.tax_type, tax_value: t.tax_value },
-            });
-          }
-        }
+        const sid = editDialog.data.source_id;
+        await saveCollection(phones.items, {
+          sourceId: sid,
+          fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
+          createMut: createPhoneMut.mutateAsync, updateMut: updatePhoneMut.mutateAsync, archiveMut: archivePhoneMut.mutateAsync,
+        });
+        await saveCollection(emails.items, {
+          sourceId: sid,
+          fields: ['email', 'label', 'is_primary', 'is_login'],
+          createMut: createEmailMut.mutateAsync, updateMut: updateEmailMut.mutateAsync, archiveMut: archiveEmailMut.mutateAsync,
+        });
+        await saveCollection(addresses.items, {
+          sourceId: sid,
+          fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+          createMut: createAddrMut.mutateAsync, updateMut: updateAddrMut.mutateAsync, archiveMut: archiveAddrMut.mutateAsync,
+        });
+        await saveCollection(taxIds.items, {
+          sourceId: sid,
+          fields: ['country_code', 'tax_type', 'tax_value'],
+          createMut: createTaxIdMut.mutateAsync, updateMut: updateTaxIdMut.mutateAsync, archiveMut: archiveTaxIdMut.mutateAsync,
+        });
       }
 
       if (editForm.is_app_user !== editDialog.data.is_app_user) {
@@ -540,12 +471,6 @@ export default function EmployeesPage() {
     };
   }, [viewFilter, selectedRows.length, allActive, allArchived, selection.clearSelection, setArchiveOpen, setRestoreOpen, canImport, canExport, exportMut.isPending, handleExport]);
   useModuleToolbarRegistration(toolbar);
-
-  /* ── Visible (non-deleted) sub-collections for the form ──── */
-  const visiblePhones = editPhones.filter((p) => !p._deleted);
-  const visibleEmails = editEmails.filter((e) => !e._deleted);
-  const visibleAddresses = editAddresses.filter((a) => !a._deleted);
-  const visibleTaxIds = editTaxIds.filter((t) => !t._deleted);
 
   return (
     <Box sx={pageContainerSx}>
@@ -659,13 +584,13 @@ export default function EmployeesPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Phone Numbers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addPhone}>Add Phone</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
         </Box>
-        {visiblePhones.length === 0 && (
+        {phones.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
         )}
-        {visiblePhones.map((phone) => {
-          const idx = editPhones.indexOf(phone);
+        {phones.visibleItems.map((phone) => {
+          const idx = phones.items.indexOf(phone);
           const countryCode = phone.country_code?.trim() || 'US';
           const country = COUNTRIES.find((c) => c.code === countryCode);
           return (
@@ -674,7 +599,7 @@ export default function EmployeesPage() {
                 select
                 label="Type"
                 value={phone.phone_type}
-                onChange={(e) => updatePhone(idx, 'phone_type', e.target.value)}
+                onChange={(e) => phones.update(idx, 'phone_type', e.target.value)}
                 sx={{ minWidth: 120 }}
                 size="small"
               >
@@ -686,7 +611,7 @@ export default function EmployeesPage() {
                 select
                 label="Country"
                 value={countryCode}
-                onChange={(e) => updatePhone(idx, 'country_code', e.target.value)}
+                onChange={(e) => phones.update(idx, 'country_code', e.target.value)}
                 SelectProps={{ renderValue: (val) => COUNTRIES.find((c) => c.code === val)?.dial_code || val }}
                 sx={{ minWidth: 80 }}
                 size="small"
@@ -698,17 +623,17 @@ export default function EmployeesPage() {
               <PatternTextField
                 label="Number"
                 value={phone.phone_number}
-                onChange={(raw) => updatePhone(idx, 'phone_number', raw)}
+                onChange={(raw) => phones.update(idx, 'phone_number', raw)}
                 pattern={country?.placeholder}
                 size="small"
                 sx={{ flex: 1, minWidth: 160 }}
               />
               <FormControlLabel
-                control={<Checkbox checked={phone.is_primary} onChange={(e) => updatePhone(idx, 'is_primary', e.target.checked)} size="small" />}
+                control={<Checkbox checked={phone.is_primary} onChange={(e) => phones.update(idx, 'is_primary', e.target.checked)} size="small" />}
                 label="Primary"
                 sx={{ mr: 0 }}
               />
-              <IconButton size="small" onClick={() => removePhone(idx)} color="error">
+              <IconButton size="small" onClick={() => phones.remove(idx)} color="error">
                 <DeleteOutlineIcon fontSize="small" />
               </IconButton>
             </Box>
@@ -719,13 +644,13 @@ export default function EmployeesPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Emails</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addEmail}>Add Email</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
         </Box>
-        {visibleEmails.length === 0 && (
+        {emails.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No emails</Typography>
         )}
-        {visibleEmails.map((em) => {
-          const idx = editEmails.indexOf(em);
+        {emails.visibleItems.map((em) => {
+          const idx = emails.items.indexOf(em);
           const isLoginEmail = em.is_login && editForm.is_app_user;
           return (
             <Box key={em.id || idx} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
@@ -733,7 +658,7 @@ export default function EmployeesPage() {
                 label="Email"
                 type="email"
                 value={em.email}
-                onChange={(e) => updateEmail(idx, 'email', e.target.value)}
+                onChange={(e) => emails.update(idx, 'email', e.target.value)}
                 size="small"
                 sx={{ flex: 1, minWidth: 200 }}
               />
@@ -741,7 +666,7 @@ export default function EmployeesPage() {
                 select
                 label="Label"
                 value={em.label}
-                onChange={(e) => updateEmail(idx, 'label', e.target.value)}
+                onChange={(e) => emails.update(idx, 'label', e.target.value)}
                 sx={{ minWidth: 120 }}
                 size="small"
               >
@@ -750,18 +675,18 @@ export default function EmployeesPage() {
                 ))}
               </TextField>
               <FormControlLabel
-                control={<Checkbox checked={em.is_primary} onChange={(e) => updateEmail(idx, 'is_primary', e.target.checked)} size="small" />}
+                control={<Checkbox checked={em.is_primary} onChange={(e) => emails.update(idx, 'is_primary', e.target.checked)} size="small" />}
                 label="Primary"
                 sx={{ mr: 0 }}
               />
               {editForm.is_app_user && (
                 <FormControlLabel
-                  control={<Checkbox checked={em.is_login} onChange={(e) => updateEmail(idx, 'is_login', e.target.checked)} size="small" disabled={editDialog.data?.is_app_user} />}
+                  control={<Checkbox checked={em.is_login} onChange={(e) => emails.update(idx, 'is_login', e.target.checked)} size="small" disabled={editDialog.data?.is_app_user} />}
                   label="Login"
                   sx={{ mr: 0 }}
                 />
               )}
-              <IconButton size="small" onClick={() => removeEmail(idx)} color="error" disabled={isLoginEmail}>
+              <IconButton size="small" onClick={() => emails.remove(idx)} color="error" disabled={isLoginEmail}>
                 <DeleteOutlineIcon fontSize="small" />
               </IconButton>
             </Box>
@@ -772,35 +697,35 @@ export default function EmployeesPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Addresses</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addAddress}>Add Address</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
         </Box>
-        {visibleAddresses.length === 0 && (
+        {addresses.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No addresses</Typography>
         )}
-        {visibleAddresses.map((addr) => {
-          const idx = editAddresses.indexOf(addr);
+        {addresses.visibleItems.map((addr) => {
+          const idx = addresses.items.indexOf(addr);
           return (
             <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                 <TextField
                   label="Label"
                   value={addr.label}
-                  onChange={(e) => updateAddress(idx, 'label', e.target.value)}
+                  onChange={(e) => addresses.update(idx, 'label', e.target.value)}
                   size="small"
                   sx={{ width: 200 }}
                 />
-                <IconButton size="small" onClick={() => removeAddress(idx)} color="error">
+                <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
                   <DeleteOutlineIcon fontSize="small" />
                 </IconButton>
               </Box>
               <Box sx={formGridSx}>
-                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => updateAddress(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => updateAddress(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => updateAddress(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="City" value={addr.city} onChange={(e) => updateAddress(idx, 'city', e.target.value)} size="small" />
-                <TextField label="State / Province" value={addr.state_province} onChange={(e) => updateAddress(idx, 'state_province', e.target.value)} size="small" />
-                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => updateAddress(idx, 'postal_code', e.target.value)} size="small" />
-                <TextField label="Country Code" value={addr.country_code} onChange={(e) => updateAddress(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
+                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
+                <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
+                <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
+                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
+                <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
               </Box>
             </Box>
           );
@@ -810,13 +735,13 @@ export default function EmployeesPage() {
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="subtitle2">Tax Identifiers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addTaxId}>Add Tax ID</Button>
+          <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
         </Box>
-        {visibleTaxIds.length === 0 && (
+        {taxIds.visibleItems.length === 0 && (
           <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
         )}
-        {visibleTaxIds.map((taxId) => {
-          const idx = editTaxIds.indexOf(taxId);
+        {taxIds.visibleItems.map((taxId) => {
+          const idx = taxIds.items.indexOf(taxId);
           const countryCode = taxId.country_code?.trim() || '';
           const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
           return (
@@ -827,9 +752,9 @@ export default function EmployeesPage() {
                   label="Country"
                   value={countryCode}
                   onChange={(e) => {
-                    updateTaxId(idx, 'country_code', e.target.value);
+                    taxIds.update(idx, 'country_code', e.target.value);
                     const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                    updateTaxId(idx, 'tax_type', newTypes[0]?.code || 'TIN');
+                    taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
                   }}
                   SelectProps={{ renderValue: (val) => val }}
                   size="small"
@@ -843,7 +768,7 @@ export default function EmployeesPage() {
                   select
                   label="Type"
                   value={taxId.tax_type}
-                  onChange={(e) => updateTaxId(idx, 'tax_type', e.target.value)}
+                  onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
                   SelectProps={{ renderValue: (val) => val }}
                   size="small"
                   sx={{ minWidth: 80 }}
@@ -855,12 +780,12 @@ export default function EmployeesPage() {
                 <PatternTextField
                   label="Tax ID Value"
                   value={taxId.tax_value}
-                  onChange={(raw) => updateTaxId(idx, 'tax_value', raw)}
+                  onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
                   pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
                   size="small"
                   sx={{ flex: 1, minWidth: 160 }}
                 />
-                <IconButton size="small" onClick={() => removeTaxId(idx)} color="error">
+                <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
                   <DeleteOutlineIcon fontSize="small" />
                 </IconButton>
               </Box>

--- a/apps/nap-client/src/pages/Core/VendorsPage.jsx
+++ b/apps/nap-client/src/pages/Core/VendorsPage.jsx
@@ -71,6 +71,8 @@ import { TAX_TYPES, COUNTRIES, resolveLevel } from '@nap/shared';
 import { useToast } from '../../hooks/useToast.js';
 import { cap, fmtDate, fmtPhone, errMsg } from '../../utils/format.js';
 import { useFormState } from '../../hooks/useFormState.js';
+import { useCollectionState } from '../../hooks/useCollectionState.js';
+import { saveCollection } from '../../utils/saveCollection.js';
 import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
 import { vendorApi } from '../../services/vendorApi.js';
 import { emailApi } from '../../services/emailApi.js';
@@ -245,53 +247,14 @@ export default function VendorsPage() {
 
   const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
-  const [editEmails, setEditEmails] = useState([]);
-  const [editPhones, setEditPhones] = useState([]);
-  const [editAddresses, setEditAddresses] = useState([]);
-  const [editTaxIds, setEditTaxIds] = useState([]);
+  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
+  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
   const [editContacts, setEditContacts] = useState([]);
   const editInitial = useRef({ form: null, emails: null, phones: null, addresses: null, taxIds: null });
 
   const { toast, snackProps } = useToast();
-
-
-  /* ── Email edit helpers ─────────────────────────────────────── */
-  const updateEmail = (idx, field, value) =>
-    setEditEmails((prev) => prev.map((e, i) => {
-      if (i !== idx) {
-        if (field === 'is_primary' && value) return { ...e, is_primary: false };
-        return e;
-      }
-      return { ...e, [field]: value };
-    }));
-  const addEmail = () => setEditEmails((prev) => [...prev, { ...BLANK_EMAIL, is_primary: !prev.filter((e) => !e._deleted).length }]);
-  const removeEmail = (idx) =>
-    setEditEmails((prev) => prev.map((e, i) => (i === idx ? { ...e, _deleted: true } : e)));
-
-  /* ── Phone edit helpers ─────────────────────────────────────── */
-  const updatePhone = (idx, field, value) =>
-    setEditPhones((prev) => prev.map((p, i) => {
-      if (i !== idx) {
-        if (field === 'is_primary' && value) return { ...p, is_primary: false };
-        return p;
-      }
-      return { ...p, [field]: value };
-    }));
-  const addPhone = () => setEditPhones((prev) => [...prev, { ...BLANK_PHONE, is_primary: !prev.filter((p) => !p._deleted).length }]);
-  const removePhone = (idx) =>
-    setEditPhones((prev) => prev.map((p, i) => (i === idx ? { ...p, _deleted: true } : p)));
-
-  /* ── Address edit helpers ───────────────────────────────────── */
-  const updateAddress = (idx, field, value) => setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, [field]: value } : a)));
-  const addAddress = () => setEditAddresses((prev) => [...prev, { ...BLANK_ADDRESS }]);
-  const removeAddress = (idx) =>
-    setEditAddresses((prev) => prev.map((a, i) => (i === idx ? { ...a, _deleted: true } : a)));
-
-  /* ── Tax ID edit helpers ──────────────────────────────────── */
-  const updateTaxId = (idx, field, value) => setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, [field]: value } : t)));
-  const addTaxId = () => setEditTaxIds((prev) => [...prev, { ...BLANK_TAX_ID }]);
-  const removeTaxId = (idx) =>
-    setEditTaxIds((prev) => prev.map((t, i) => (i === idx ? { ...t, _deleted: true } : t)));
 
   /* ── Contact DataTable columns ──────────────────────────────── */
   const contactColumns = useMemo(() => [
@@ -362,28 +325,28 @@ export default function VendorsPage() {
   /* ── Sync query-fetched sub-collections into edit state ────── */
   useEffect(() => {
     if (editOpen && emailsRes?.rows) {
-      setEditEmails(emailsRes.rows);
+      emails.reset(emailsRes.rows);
       editInitial.current.emails = emailsRes.rows;
     }
   }, [editOpen, emailsRes]);
 
   useEffect(() => {
     if (editOpen && phonesRes?.rows) {
-      setEditPhones(phonesRes.rows);
+      phones.reset(phonesRes.rows);
       editInitial.current.phones = phonesRes.rows;
     }
   }, [editOpen, phonesRes]);
 
   useEffect(() => {
     if (editOpen && addressesRes?.rows) {
-      setEditAddresses(addressesRes.rows);
+      addresses.reset(addressesRes.rows);
       editInitial.current.addresses = addressesRes.rows;
     }
   }, [editOpen, addressesRes]);
 
   useEffect(() => {
     if (editOpen && taxIdsRes?.rows) {
-      setEditTaxIds(taxIdsRes.rows);
+      taxIds.reset(taxIdsRes.rows);
       editInitial.current.taxIds = taxIdsRes.rows;
     }
   }, [editOpen, taxIdsRes]);
@@ -501,10 +464,10 @@ export default function VendorsPage() {
     setEditSourceId(row.source_id || null);
     setEditVendorId(row.id || null);
     if (!row.source_id) {
-      setEditEmails([]);
-      setEditPhones([]);
-      setEditAddresses([]);
-      setEditTaxIds([]);
+      emails.reset([]);
+      phones.reset([]);
+      addresses.reset([]);
+      taxIds.reset([]);
       editInitial.current.emails = [];
       editInitial.current.phones = [];
       editInitial.current.addresses = [];
@@ -552,12 +515,12 @@ export default function VendorsPage() {
         return !orig || fields.some((f) => c[f] !== orig[f]);
       });
     };
-    if (collectionChanged(editEmails, init.emails, ['email', 'label', 'is_primary'])) return true;
-    if (collectionChanged(editPhones, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
-    if (collectionChanged(editAddresses, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
-    if (collectionChanged(editTaxIds, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
+    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary'])) return true;
+    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
+    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
+    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
     return false;
-  }, [editForm, editEmails, editPhones, editAddresses, editTaxIds]);
+  }, [editForm, emails.items, phones.items, addresses.items, taxIds.items]);
 
   const handleCreate = async () => {
     try {
@@ -579,50 +542,23 @@ export default function VendorsPage() {
       await updateMut.mutateAsync({ filter: { id: editRow.id }, changes });
 
       if (editRow.source_id) {
-        for (const em of editEmails) {
-          if (em._deleted && em.id) {
-            await archiveEmailMut.mutateAsync({ id: em.id });
-          } else if (!em.id && !em._deleted) {
-            await createEmailMut.mutateAsync({ source_id: editRow.source_id, email: em.email, label: em.label, is_primary: em.is_primary });
-          } else if (em.id && !em._deleted) {
-            await updateEmailMut.mutateAsync({ filter: { id: em.id }, changes: { email: em.email, label: em.label, is_primary: em.is_primary } });
-          }
-        }
-        for (const p of editPhones) {
-          if (p._deleted && p.id) {
-            await archivePhoneMut.mutateAsync({ id: p.id });
-          } else if (!p.id && !p._deleted) {
-            await createPhoneMut.mutateAsync({ source_id: editRow.source_id, country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary });
-          } else if (p.id && !p._deleted) {
-            await updatePhoneMut.mutateAsync({ filter: { id: p.id }, changes: { country_code: p.country_code, phone_type: p.phone_type, phone_number: p.phone_number, is_primary: p.is_primary } });
-          }
-        }
-        for (const a of editAddresses) {
-          if (a._deleted && a.id) {
-            await archiveAddrMut.mutateAsync({ id: a.id });
-          } else if (!a.id && !a._deleted) {
-            const { _deleted, ...rest } = a;
-            await createAddrMut.mutateAsync({ ...rest, source_id: editRow.source_id });
-          } else if (a.id && !a._deleted) {
-            const { id, source_id: _sid, created_at: _ca, updated_at: _ua, created_by: _cb, updated_by: _ub, deactivated_at: _da, ...addrChanges } = a;
-            await updateAddrMut.mutateAsync({ filter: { id }, changes: addrChanges });
-          }
-        }
-        for (const t of editTaxIds) {
-          if (t._deleted && t.id) {
-            await archiveTaxIdMut.mutateAsync({ id: t.id });
-          } else if (!t.id && !t._deleted) {
-            await createTaxIdMut.mutateAsync({
-              source_id: editRow.source_id, country_code: t.country_code,
-              tax_type: t.tax_type, tax_value: t.tax_value,
-            });
-          } else if (t.id && !t._deleted) {
-            await updateTaxIdMut.mutateAsync({
-              filter: { id: t.id },
-              changes: { country_code: t.country_code, tax_type: t.tax_type, tax_value: t.tax_value },
-            });
-          }
-        }
+        const sid = editRow.source_id;
+        await saveCollection(emails.items, {
+          sourceId: sid, fields: ['email', 'label', 'is_primary'],
+          createMut: createEmailMut.mutateAsync, updateMut: updateEmailMut.mutateAsync, archiveMut: archiveEmailMut.mutateAsync,
+        });
+        await saveCollection(phones.items, {
+          sourceId: sid, fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
+          createMut: createPhoneMut.mutateAsync, updateMut: updatePhoneMut.mutateAsync, archiveMut: archivePhoneMut.mutateAsync,
+        });
+        await saveCollection(addresses.items, {
+          sourceId: sid, fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+          createMut: createAddrMut.mutateAsync, updateMut: updateAddrMut.mutateAsync, archiveMut: archiveAddrMut.mutateAsync,
+        });
+        await saveCollection(taxIds.items, {
+          sourceId: sid, fields: ['country_code', 'tax_type', 'tax_value'],
+          createMut: createTaxIdMut.mutateAsync, updateMut: updateTaxIdMut.mutateAsync, archiveMut: archiveTaxIdMut.mutateAsync,
+        });
       }
 
       toast('Vendor updated');
@@ -850,12 +786,6 @@ export default function VendorsPage() {
     };
   }, [viewFilter, selectedRows.length, allActive, allArchived, selection.clearSelection, setArchiveOpen, setRestoreOpen, canImport, canExport, exportMut.isPending, handleExport]);
   useModuleToolbarRegistration(toolbar);
-
-  /* ── Visible (non-deleted) sub-collections for the form ──── */
-  const visibleEmails = editEmails.filter((e) => !e._deleted);
-  const visiblePhones = editPhones.filter((p) => !p._deleted);
-  const visibleAddresses = editAddresses.filter((a) => !a._deleted);
-  const visibleTaxIds = editTaxIds.filter((t) => !t._deleted);
 
   /* ── Inline email row renderer (edit mode) ──────────────────── */
   const renderEmailRow = (em, emailIdx, onUpdate, onRemove) => (
@@ -1173,18 +1103,18 @@ export default function VendorsPage() {
                 <Divider />
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                   <Typography variant="subtitle2">Emails</Typography>
-                  <Button size="small" startIcon={<AddIcon />} onClick={addEmail}>Add Email</Button>
+                  <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
                 </Box>
-                {visibleEmails.length === 0 && (
+                {emails.visibleItems.length === 0 && (
                   <Typography variant="body2" color="text.secondary">No emails</Typography>
                 )}
-                {visibleEmails.map((em) => {
-                  const idx = editEmails.indexOf(em);
+                {emails.visibleItems.map((em) => {
+                  const idx = emails.items.indexOf(em);
                   return renderEmailRow(
                     em,
                     idx,
-                    (i, f, v) => updateEmail(i, f, v),
-                    (i) => removeEmail(i),
+                    emails.update,
+                    emails.remove,
                   );
                 })}
 
@@ -1192,18 +1122,18 @@ export default function VendorsPage() {
                 <Divider />
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                   <Typography variant="subtitle2">Phone Numbers</Typography>
-                  <Button size="small" startIcon={<AddIcon />} onClick={addPhone}>Add Phone</Button>
+                  <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
                 </Box>
-                {visiblePhones.length === 0 && (
+                {phones.visibleItems.length === 0 && (
                   <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
                 )}
-                {visiblePhones.map((phone) => {
-                  const idx = editPhones.indexOf(phone);
+                {phones.visibleItems.map((phone) => {
+                  const idx = phones.items.indexOf(phone);
                   return renderPhoneRow(
                     phone,
                     idx,
-                    (i, f, v) => updatePhone(i, f, v),
-                    (i) => removePhone(i),
+                    phones.update,
+                    phones.remove,
                   );
                 })}
 
@@ -1211,35 +1141,35 @@ export default function VendorsPage() {
                 <Divider />
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                   <Typography variant="subtitle2">Addresses</Typography>
-                  <Button size="small" startIcon={<AddIcon />} onClick={addAddress}>Add Address</Button>
+                  <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
                 </Box>
-                {visibleAddresses.length === 0 && (
+                {addresses.visibleItems.length === 0 && (
                   <Typography variant="body2" color="text.secondary">No addresses</Typography>
                 )}
-                {visibleAddresses.map((addr) => {
-                  const idx = editAddresses.indexOf(addr);
+                {addresses.visibleItems.map((addr) => {
+                  const idx = addresses.items.indexOf(addr);
                   return (
                     <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
                       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                         <TextField
                           label="Label"
                           value={addr.label}
-                          onChange={(e) => updateAddress(idx, 'label', e.target.value)}
+                          onChange={(e) => addresses.update(idx, 'label', e.target.value)}
                           size="small"
                           sx={{ width: 200 }}
                         />
-                        <IconButton size="small" onClick={() => removeAddress(idx)} color="error">
+                        <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
                           <DeleteOutlineIcon fontSize="small" />
                         </IconButton>
                       </Box>
                       <Box sx={formGridSx}>
-                        <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => updateAddress(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                        <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => updateAddress(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                        <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => updateAddress(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                        <TextField label="City" value={addr.city} onChange={(e) => updateAddress(idx, 'city', e.target.value)} size="small" />
-                        <TextField label="State / Province" value={addr.state_province} onChange={(e) => updateAddress(idx, 'state_province', e.target.value)} size="small" />
-                        <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => updateAddress(idx, 'postal_code', e.target.value)} size="small" />
-                        <TextField label="Country Code" value={addr.country_code} onChange={(e) => updateAddress(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
+                        <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
+                        <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
+                        <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
+                        <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
+                        <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
+                        <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
+                        <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
                       </Box>
                     </Box>
                   );
@@ -1249,13 +1179,13 @@ export default function VendorsPage() {
                 <Divider />
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                   <Typography variant="subtitle2">Tax Identifiers</Typography>
-                  <Button size="small" startIcon={<AddIcon />} onClick={addTaxId}>Add Tax ID</Button>
+                  <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
                 </Box>
-                {visibleTaxIds.length === 0 && (
+                {taxIds.visibleItems.length === 0 && (
                   <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
                 )}
-                {visibleTaxIds.map((taxId) => {
-                  const idx = editTaxIds.indexOf(taxId);
+                {taxIds.visibleItems.map((taxId) => {
+                  const idx = taxIds.items.indexOf(taxId);
                   const countryCode = taxId.country_code?.trim() || '';
                   const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
                   return (
@@ -1266,9 +1196,9 @@ export default function VendorsPage() {
                           label="Country"
                           value={countryCode}
                           onChange={(e) => {
-                            updateTaxId(idx, 'country_code', e.target.value);
+                            taxIds.update(idx, 'country_code', e.target.value);
                             const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                            updateTaxId(idx, 'tax_type', newTypes[0]?.code || 'TIN');
+                            taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
                           }}
                           SelectProps={{ renderValue: (val) => val }}
                           size="small"
@@ -1282,7 +1212,7 @@ export default function VendorsPage() {
                           select
                           label="Type"
                           value={taxId.tax_type}
-                          onChange={(e) => updateTaxId(idx, 'tax_type', e.target.value)}
+                          onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
                           SelectProps={{ renderValue: (val) => val }}
                           size="small"
                           sx={{ minWidth: 80 }}
@@ -1294,12 +1224,12 @@ export default function VendorsPage() {
                         <PatternTextField
                           label="Tax ID Value"
                           value={taxId.tax_value}
-                          onChange={(raw) => updateTaxId(idx, 'tax_value', raw)}
+                          onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
                           pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
                           size="small"
                           sx={{ flex: 1, minWidth: 160 }}
                         />
-                        <IconButton size="small" onClick={() => removeTaxId(idx)} color="error">
+                        <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
                           <DeleteOutlineIcon fontSize="small" />
                         </IconButton>
                       </Box>

--- a/apps/nap-client/src/utils/saveCollection.js
+++ b/apps/nap-client/src/utils/saveCollection.js
@@ -1,0 +1,37 @@
+/**
+ * @file Persist sub-collection changes — create / update / archive loop
+ * @module nap-client/utils/saveCollection
+ *
+ * Replaces the per-entity for-loops that diff sub-collection items
+ * against the API (the `_deleted` + `id` presence pattern).
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+/**
+ * Persist an array of sub-collection items that may have been added,
+ * modified, or soft-deleted (`_deleted: true`).
+ *
+ * @param {object[]} items  The full items array (including _deleted)
+ * @param {object}   opts
+ * @param {string}   opts.sourceId    Parent source_id for new items
+ * @param {string[]} opts.fields      Field names to include in create/update payloads
+ * @param {Function} opts.createMut   mutateAsync for creating
+ * @param {Function} opts.updateMut   mutateAsync for updating
+ * @param {Function} opts.archiveMut  mutateAsync for archiving
+ */
+export async function saveCollection(items, { sourceId, fields, createMut, updateMut, archiveMut }) {
+  for (const item of items) {
+    if (item._deleted && item.id) {
+      await archiveMut({ id: item.id });
+    } else if (!item.id && !item._deleted) {
+      const payload = { source_id: sourceId };
+      for (const f of fields) payload[f] = item[f];
+      await createMut(payload);
+    } else if (item.id && !item._deleted) {
+      const changes = {};
+      for (const f of fields) changes[f] = item[f];
+      await updateMut({ filter: { id: item.id }, changes });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `useCollectionState()` hook for sub-collection state management (add/update/remove with soft-delete, exclusive-field radio behaviour, auto-primary)
- Add `saveCollection()` utility to persist sub-collection diffs via create/update/archive mutations
- Remove ~316 lines of duplicated sub-collection boilerplate from the 5 Core entity pages (Clients, Contacts, Companies, Employees, Vendors)

## Test plan
- [ ] Verify adding/editing/removing emails, phones, addresses, and tax IDs in all Core entity edit dialogs
- [ ] Verify is_primary radio behaviour (only one primary at a time)
- [ ] Verify auto-primary on first item added to an empty collection
- [ ] Verify soft-deleted items are archived and new items are created on save