### PR TITLE
refactor: decompose Core entity pages into dialog subcomponents

### DIFF
--- a/apps/nap-client/src/components/shared/EmailRow.jsx
+++ b/apps/nap-client/src/components/shared/EmailRow.jsx
@@ -1,6 +1,6 @@
 /**
- * @file Inline editable email row — shared between vendor and contact edit forms
- * @module nap-client/pages/Core/vendors/EmailRow
+ * @file Inline editable email row — reusable across all entity edit forms
+ * @module nap-client/components/shared/EmailRow
  *
  * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
  */
@@ -13,10 +13,11 @@ import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
-import { cap } from '../../../utils/format.js';
-import { EMAIL_LABELS } from '../../../utils/formConstants.js';
+import { cap } from '../../utils/format.js';
+import { EMAIL_LABELS } from '../../utils/formConstants.js';
 
-export default function EmailRow({ item, index, onUpdate, onRemove }) {
+export default function EmailRow({ item, index, onUpdate, onRemove, showLogin, loginDisabled }) {
+  const isLoginEmail = showLogin && item.is_login;
   return (
     <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
       <TextField
@@ -44,7 +45,14 @@ export default function EmailRow({ item, index, onUpdate, onRemove }) {
         label="Primary"
         sx={{ mr: 0 }}
       />
-      <IconButton size="small" onClick={() => onRemove(index)} color="error">
+      {showLogin && (
+        <FormControlLabel
+          control={<Checkbox checked={item.is_login} onChange={(e) => onUpdate(index, 'is_login', e.target.checked)} size="small" disabled={loginDisabled} />}
+          label="Login"
+          sx={{ mr: 0 }}
+        />
+      )}
+      <IconButton size="small" onClick={() => onRemove(index)} color="error" disabled={isLoginEmail}>
         <DeleteOutlineIcon fontSize="small" />
       </IconButton>
     </Box>

--- a/apps/nap-client/src/components/shared/PhoneRow.jsx
+++ b/apps/nap-client/src/components/shared/PhoneRow.jsx
@@ -1,6 +1,6 @@
 /**
- * @file Inline editable phone row — shared between vendor and contact edit forms
- * @module nap-client/pages/Core/vendors/PhoneRow
+ * @file Inline editable phone row — reusable across all entity edit forms
+ * @module nap-client/components/shared/PhoneRow
  *
  * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
  */
@@ -13,9 +13,9 @@ import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
-import PatternTextField from '../../../components/shared/PatternTextField.jsx';
-import { cap } from '../../../utils/format.js';
-import { PHONE_TYPES } from '../../../utils/formConstants.js';
+import PatternTextField from './PatternTextField.jsx';
+import { cap } from '../../utils/format.js';
+import { PHONE_TYPES } from '../../utils/formConstants.js';
 import { COUNTRIES } from '@nap/shared';
 
 export default function PhoneRow({ item, index, onUpdate, onRemove }) {

--- a/apps/nap-client/src/pages/Core/ClientsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ClientsPage.jsx
@@ -26,7 +26,7 @@ import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
 import { useAuth } from '../../contexts/AuthContext.jsx';
 import {
-  useClients, useCreateClient, useArchiveClient, useRestoreClient, useResetClientPassword,
+  useClients, useCreateClient, useUpdateClient, useArchiveClient, useRestoreClient, useResetClientPassword,
 } from '../../hooks/useClients.js';
 import {
   useCreateEmail, useUpdateEmail, useArchiveEmail,
@@ -45,7 +45,6 @@ import { usePhoneNumbers } from '../../hooks/usePhoneNumbers.js';
 import { useAddresses } from '../../hooks/useAddresses.js';
 import { useTaxIdentifiers } from '../../hooks/useTaxIdentifiers.js';
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
-import { useUpdateClient } from '../../hooks/useClients.js';
 import { useRoles } from '../../hooks/useRoles.js';
 import { resolveLevel } from '@nap/shared';
 import { useToast } from '../../hooks/useToast.js';
@@ -115,7 +114,7 @@ export default function ClientsPage() {
   const updateTaxIdMut = useUpdateTaxIdentifier();
   const archiveTaxIdMut = useArchiveTaxIdentifier();
 
-  /* ── Selection ───────────────────────────────────────────────��� */
+  /* ── Selection ─────────────────────────────────────────────── */
   const selection = useListSelection(rows);
   const { selectedRows, allActive, allArchived } = selection;
 

--- a/apps/nap-client/src/pages/Core/ClientsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ClientsPage.jsx
@@ -1,81 +1,66 @@
 /**
- * @file Clients CRUD page — DataTable + create/edit/view/archive/restore
+ * @file Clients CRUD page — coordinator component
  * @module nap-client/pages/Core/ClientsPage
- *
- * Migrated to standardised list-view selection system:
- *   useListSelection + DataTable + RowActionsMenu
  *
  * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
  */
 
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useState, useMemo, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useDialogState } from '../../hooks/useDialogState.js';
 import { useFormState } from '../../hooks/useFormState.js';
-import { useCollectionState } from '../../hooks/useCollectionState.js';
-import { saveCollection } from '../../utils/saveCollection.js';
-import { useQueryClient } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import Divider from '@mui/material/Divider';
-import IconButton from '@mui/material/IconButton';
-import MenuItem from '@mui/material/MenuItem';
-import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
-import { useToast } from '../../hooks/useToast.js';
-import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
 import Autocomplete from '@mui/material/Autocomplete';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import AddIcon from '@mui/icons-material/Add';
-import LockResetIcon from '@mui/icons-material/LockReset';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import TextField from '@mui/material/TextField';
 
 import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import ResetPasswordDialog from '../../components/shared/ResetPasswordDialog.jsx';
 import SetPasswordPopover from '../../components/shared/SetPasswordPopover.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
-import FieldRow from '../../components/shared/FieldRow.jsx';
 import FormDialog from '../../components/shared/FormDialog.jsx';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
-import PatternTextField from '../../components/shared/PatternTextField.jsx';
-import EmailsSection from '../../components/shared/EmailsSection.jsx';
-import PhoneNumbersSection from '../../components/shared/PhoneNumbersSection.jsx';
-import AddressesSection from '../../components/shared/AddressesSection.jsx';
-import TaxIdentifiersSection from '../../components/shared/TaxIdentifiersSection.jsx';
+import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
 import { useAuth } from '../../contexts/AuthContext.jsx';
 import {
-  useClients, useCreateClient, useUpdateClient, useArchiveClient, useRestoreClient, useResetClientPassword,
+  useClients, useCreateClient, useArchiveClient, useRestoreClient, useResetClientPassword,
 } from '../../hooks/useClients.js';
 import {
-  useEmails, useCreateEmail, useUpdateEmail, useArchiveEmail,
+  useCreateEmail, useUpdateEmail, useArchiveEmail,
 } from '../../hooks/useEmails.js';
 import {
-  usePhoneNumbers, useCreatePhoneNumber, useUpdatePhoneNumber, useArchivePhoneNumber,
+  useCreatePhoneNumber, useUpdatePhoneNumber, useArchivePhoneNumber,
 } from '../../hooks/usePhoneNumbers.js';
 import {
-  useAddresses, useCreateAddress, useUpdateAddress, useArchiveAddress,
+  useCreateAddress, useUpdateAddress, useArchiveAddress,
 } from '../../hooks/useAddresses.js';
 import {
-  useTaxIdentifiers, useCreateTaxIdentifier, useUpdateTaxIdentifier, useArchiveTaxIdentifier,
+  useCreateTaxIdentifier, useUpdateTaxIdentifier, useArchiveTaxIdentifier,
 } from '../../hooks/useTaxIdentifiers.js';
+import { useEmails } from '../../hooks/useEmails.js';
+import { usePhoneNumbers } from '../../hooks/usePhoneNumbers.js';
+import { useAddresses } from '../../hooks/useAddresses.js';
+import { useTaxIdentifiers } from '../../hooks/useTaxIdentifiers.js';
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
+import { useUpdateClient } from '../../hooks/useClients.js';
 import { useRoles } from '../../hooks/useRoles.js';
-import { TAX_TYPES, COUNTRIES, resolveLevel } from '@nap/shared';
-import { cap, fmtDate, errMsg } from '../../utils/format.js';
-import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
+import { resolveLevel } from '@nap/shared';
+import { useToast } from '../../hooks/useToast.js';
+import { errMsg } from '../../utils/format.js';
 import { clientApi } from '../../services/clientApi.js';
-import { pageContainerSx, formGridSx, formGroupCardSx, formFullSpanSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
+import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 
+import ClientViewDialog from './clients/ClientViewDialog.jsx';
+import ClientEditDialog from './clients/ClientEditDialog.jsx';
+import { useClientEditCollections } from './clients/useClientEditCollections.jsx';
+
 const BLANK_CREATE = { name: '', code: '', is_active: true, is_app_user: false, roles: [] };
 const BLANK_EDIT = { name: '', code: '', is_active: true, is_app_user: false, roles: [] };
-
 
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
@@ -130,7 +115,7 @@ export default function ClientsPage() {
   const updateTaxIdMut = useUpdateTaxIdentifier();
   const archiveTaxIdMut = useArchiveTaxIdentifier();
 
-  /* ── Selection (new system) ─────────────────────────────────── */
+  /* ── Selection ───────────────────────────────────────────────��� */
   const selection = useListSelection(rows);
   const { selectedRows, allActive, allArchived } = selection;
 
@@ -138,139 +123,75 @@ export default function ClientsPage() {
   const importDialog = useDialogState();
   const [importErrors, setImportErrors] = useState(null);
   const viewDialog = useDialogState();
-  const [viewSourceId, setViewSourceId] = useState(null);
   const createDialog = useDialogState();
   const editDialog = useDialogState();
   const resetPwDialog = useDialogState();
 
-  const [editSourceId, setEditSourceId] = useState(null);
-  const { data: emailsRes } = useEmails({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
-  const { data: phonesRes } = usePhoneNumbers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
-  const { data: addressesRes } = useAddresses({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
-  const { data: taxIdsRes } = useTaxIdentifiers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
+  const { toast, snackProps } = useToast();
 
   // View dialog child data
+  const viewSourceId = viewDialog.data?.source_id;
   const { data: viewEmailsRes } = useEmails({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
   const { data: viewPhonesRes } = usePhoneNumbers({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
   const { data: viewAddressesRes } = useAddresses({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
   const { data: viewTaxIdsRes } = useTaxIdentifiers({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
-  const viewEmails = viewEmailsRes?.rows ?? [];
-  const viewPhones = viewPhonesRes?.rows ?? [];
-  const viewAddresses = viewAddressesRes?.rows ?? [];
-  const viewTaxIds = viewTaxIdsRes?.rows ?? [];
 
-  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
-  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
-  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
-  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
-  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
-  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
-  const editInitial = useRef({ form: null, emails: null, phones: null, addresses: null, taxIds: null });
+  const {
+    emails, phones, addresses, taxIds,
+    hasEditChanges, handleUpdate,
+    openEditSession, closeEditSession,
+  } = useClientEditCollections({
+    editOpen: editDialog.isOpen,
+    editRow: editDialog.data,
+    editForm,
+    updateMut,
+    toast,
+    qc,
+    emailMuts: { create: createEmailMut, update: updateEmailMut, archive: archiveEmailMut },
+    phoneMuts: { create: createPhoneMut, update: updatePhoneMut, archive: archivePhoneMut },
+    addressMuts: { create: createAddrMut, update: updateAddrMut, archive: archiveAddrMut },
+    taxIdMuts: { create: createTaxIdMut, update: updateTaxIdMut, archive: archiveTaxIdMut },
+  });
 
-  const { toast, snackProps } = useToast();
-
-
-  /* ── App-user password popover state ────────────────────────── */
+  /* ── App-user password popover ─────────────────────────────── */
   const [pwAnchor, setPwAnchor] = useState(null);
-  const [pwTarget, setPwTarget] = useState(null); // 'create' | 'edit'
+  const [pwTarget, setPwTarget] = useState(null);
 
-  const handleAppUserToggle = (target, setForm) => (e) => {
+  const handleAppUserToggle = useCallback((target, setForm) => (e) => {
     if (e.target.checked) {
       setPwTarget(target);
       setPwAnchor(e.currentTarget);
     } else {
       setForm((p) => ({ ...p, is_app_user: false, password: '' }));
     }
-  };
+  }, []);
 
-  const handlePwConfirm = (password) => {
+  const handlePwConfirm = useCallback((password) => {
     const setForm = pwTarget === 'create' ? setCreateForm : setEditForm;
     setForm((p) => ({ ...p, is_app_user: true, password }));
     setPwAnchor(null);
     setPwTarget(null);
-  };
+  }, [pwTarget, setCreateForm, setEditForm]);
 
-  const handlePwCancel = () => {
+  const handlePwCancel = useCallback(() => {
     setPwAnchor(null);
     setPwTarget(null);
-  };
-
-  /* ── Sync query-fetched sub-collections into edit state ────── */
-  useEffect(() => {
-    if (editDialog.isOpen && emailsRes?.rows) {
-      emails.reset(emailsRes.rows);
-      editInitial.current.emails = emailsRes.rows;
-    }
-  }, [editDialog.isOpen, emailsRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && phonesRes?.rows) {
-      phones.reset(phonesRes.rows);
-      editInitial.current.phones = phonesRes.rows;
-    }
-  }, [editDialog.isOpen, phonesRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && addressesRes?.rows) {
-      addresses.reset(addressesRes.rows);
-      editInitial.current.addresses = addressesRes.rows;
-    }
-  }, [editDialog.isOpen, addressesRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && taxIdsRes?.rows) {
-      taxIds.reset(taxIdsRes.rows);
-      editInitial.current.taxIds = taxIdsRes.rows;
-    }
-  }, [editDialog.isOpen, taxIdsRes]);
+  }, []);
 
   /* ── Row action callbacks ──────────────────────────────────── */
-  const handleView = useCallback((row) => {
-    viewDialog.open(row);
-    setViewSourceId(row.source_id || null);
-  }, []);
+  const handleView = useCallback((row) => viewDialog.open(row), [viewDialog.open]);
 
   const handleEdit = useCallback((row) => {
-    const form = { name: row.name ?? '', code: row.code ?? '', is_active: row.is_active ?? true, is_app_user: row.is_app_user ?? false, roles: row.roles ?? [] };
-    setEditForm(form);
-    editInitial.current.form = form;
-
-    setEditSourceId(row.source_id || null);
-    if (!row.source_id) {
-      emails.reset([]);
-      phones.reset([]);
-      addresses.reset([]);
-      taxIds.reset([]);
-      editInitial.current.emails = [];
-      editInitial.current.phones = [];
-      editInitial.current.addresses = [];
-      editInitial.current.taxIds = [];
-    }
-
+    openEditSession(row, setEditForm);
     editDialog.open(row);
-  }, []);
+  }, [openEditSession, editDialog.open]);
 
-  /* ── Dirty-check: disable Save when nothing changed ──────── */
-  const hasEditChanges = useMemo(() => {
-    const init = editInitial.current;
-    if (!init.form) return false;
-    if (JSON.stringify(editForm) !== JSON.stringify(init.form)) return true;
-    const collectionChanged = (current, initial, fields) => {
-      if (!initial) return false;
-      if (current.some((c) => c._deleted)) return true;
-      if (current.some((c) => !c.id && !c._deleted)) return true;
-      const initMap = new Map(initial.map((r) => [r.id, r]));
-      return current.filter((c) => c.id && !c._deleted).some((c) => {
-        const orig = initMap.get(c.id);
-        return !orig || fields.some((f) => c[f] !== orig[f]);
-      });
-    };
-    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary'])) return true;
-    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
-    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
-    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
-    return false;
-  }, [editForm, emails.items, phones.items, addresses.items, taxIds.items]);
+  const handleEditClose = useCallback(() => {
+    editDialog.close();
+    closeEditSession();
+  }, [editDialog.close, closeEditSession]);
 
   const handleCreate = async () => {
     try {
@@ -278,51 +199,6 @@ export default function ClientsPage() {
       toast('Client created');
       createDialog.close();
       resetCreateForm();
-    } catch (err) {
-      toast(errMsg(err), 'error');
-    }
-  };
-
-  const handleUpdate = async () => {
-    try {
-      // When toggling is_app_user on, include the selected login email in the
-      // client update payload so the backend can provision before email mutations run
-      const changes = { ...editForm };
-      if (changes.is_app_user && !editDialog.data.is_app_user) {
-        const loginEm = emails.items.find((em) => em.is_login && !em._deleted)
-          || emails.items.find((em) => em.is_primary && !em._deleted)
-          || emails.items.find((em) => !em._deleted);
-        if (loginEm) changes.email = loginEm.email;
-      }
-      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes });
-
-      const sid = editDialog.data.source_id;
-      if (sid) {
-        await saveCollection(emails.items, {
-          sourceId: sid, fields: ['email', 'label', 'is_primary'],
-          createMut: createEmailMut.mutateAsync, updateMut: updateEmailMut.mutateAsync, archiveMut: archiveEmailMut.mutateAsync,
-        });
-        await saveCollection(phones.items, {
-          sourceId: sid, fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
-          createMut: createPhoneMut.mutateAsync, updateMut: updatePhoneMut.mutateAsync, archiveMut: archivePhoneMut.mutateAsync,
-        });
-        await saveCollection(addresses.items, {
-          sourceId: sid, fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
-          createMut: createAddrMut.mutateAsync, updateMut: updateAddrMut.mutateAsync, archiveMut: archiveAddrMut.mutateAsync,
-        });
-        await saveCollection(taxIds.items, {
-          sourceId: sid, fields: ['country_code', 'tax_type', 'tax_value'],
-          createMut: createTaxIdMut.mutateAsync, updateMut: updateTaxIdMut.mutateAsync, archiveMut: archiveTaxIdMut.mutateAsync,
-        });
-      }
-
-      await qc.invalidateQueries({ queryKey: ['clients'] });
-      if (editForm.is_app_user !== editDialog.data.is_app_user) {
-        qc.invalidateQueries({ queryKey: ['nap-users'] });
-      }
-      toast('Client updated');
-      editDialog.close();
-      setEditSourceId(null);
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -364,15 +240,14 @@ export default function ClientsPage() {
     getLabel: (r) => r.name,
   });
 
-  /* ── ModuleBar: tabs + Create + Archive/Restore ────────────── */
+  /* ── ModuleBar ─────────────────────────────────────────────── */
   const toolbar = useMemo(() => {
     const primary = [];
 
     if (viewFilter === 'active' || viewFilter === 'all') {
       primary.push({
         label: selectedRows.length > 1 ? `Archive (${selectedRows.length})` : 'Archive',
-        variant: 'outlined',
-        color: 'error',
+        variant: 'outlined', color: 'error',
         disabled: selectedRows.length === 0 || !allActive,
         onClick: () => setArchiveOpen(true),
       });
@@ -380,33 +255,17 @@ export default function ClientsPage() {
     if (viewFilter === 'archived' || viewFilter === 'all') {
       primary.push({
         label: selectedRows.length > 1 ? `Restore (${selectedRows.length})` : 'Restore',
-        variant: 'outlined',
-        color: 'success',
+        variant: 'outlined', color: 'success',
         disabled: selectedRows.length === 0 || !allArchived,
         onClick: () => setRestoreOpen(true),
       });
     }
 
-    if (canExport) {
-      primary.push({
-        label: 'Export',
-        variant: 'outlined',
-        disabled: exportMut.isPending,
-        onClick: handleExport,
-      });
-    }
-    if (canImport) {
-      primary.push({
-        label: 'Import',
-        variant: 'outlined',
-        onClick: () => importDialog.open(),
-      });
-    }
+    if (canExport) primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
+    if (canImport) primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
 
     primary.push({
-      label: 'Create Client',
-      variant: 'contained',
-      color: 'primary',
+      label: 'Create Client', variant: 'contained', color: 'primary',
       onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
@@ -424,68 +283,23 @@ export default function ClientsPage() {
 
   return (
     <Box sx={pageContainerSx}>
-      <DataTable
-        rows={rows}
-        columns={columns}
-        loading={isLoading}
-        selection={selection}
-        onView={handleView}
-        onEdit={handleEdit}
+      <DataTable rows={rows} columns={columns} loading={isLoading} selection={selection} onView={handleView} onEdit={handleEdit} />
+
+      <ClientViewDialog
+        open={viewDialog.isOpen}
+        onClose={viewDialog.close}
+        client={viewDialog.data}
+        viewEmails={viewEmailsRes?.rows ?? []}
+        viewPhones={viewPhonesRes?.rows ?? []}
+        viewAddresses={viewAddressesRes?.rows ?? []}
+        viewTaxIds={viewTaxIdsRes?.rows ?? []}
       />
-
-      {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewDialog.isOpen} onClose={() => { viewDialog.close(); setViewSourceId(null); }} maxWidth="sm" fullWidth>
-        <DialogTitle sx={dialogHeaderSx}>
-          <Box>
-            <span>Client Details</span>
-            {viewDialog.data && (
-              <Typography variant="body2" color="text.secondary">
-                {viewDialog.data.name}
-              </Typography>
-            )}
-          </Box>
-          <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => { viewDialog.close(); setViewSourceId(null); }}>
-              Close
-            </Button>
-          </Box>
-        </DialogTitle>
-        <DialogContent dividers>
-          {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
-                <FieldRow label="Name" value={viewDialog.data.name} />
-                <FieldRow label="Active" value={viewDialog.data.is_active ? 'Yes' : 'No'} />
-                <FieldRow label="App User" value={viewDialog.data.is_app_user ? 'Yes' : 'No'} />
-                <FieldRow label="Roles" value={viewDialog.data.roles?.length ? viewDialog.data.roles.join(', ') : '\u2014'} />
-                <FieldRow label="Status">
-                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
-                </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
-              </Box>
-
-              <EmailsSection emails={viewEmails} />
-              <PhoneNumbersSection phones={viewPhones} />
-              <AddressesSection addresses={viewAddresses} />
-              <TaxIdentifiersSection taxIds={viewTaxIds} />
-            </Box>
-          )}
-        </DialogContent>
-      </Dialog>
 
       <FormDialog open={createDialog.isOpen} title="Create Client" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Client Name" required value={createForm.name} onChange={onCreateField('name')} />
         <TextField label="Code" value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
         <FormControlLabel
-          control={
-            <Checkbox
-              checked={createForm.is_active}
-              onChange={(e) => setCreateForm((p) => ({ ...p, is_active: e.target.checked }))}
-              size="small"
-            />
-          }
+          control={<Checkbox checked={createForm.is_active} onChange={(e) => setCreateForm((p) => ({ ...p, is_active: e.target.checked }))} size="small" />}
           label="Active"
         />
         <FormControlLabel
@@ -496,9 +310,7 @@ export default function ClientsPage() {
           <TextField label="Email" required value={createForm.email || ''} onChange={onCreateField('email')} />
         )}
         <Autocomplete
-          multiple
-          options={roleOptions}
-          getOptionLabel={(opt) => opt.name}
+          multiple options={roleOptions} getOptionLabel={(opt) => opt.name}
           isOptionEqualToValue={(opt, val) => opt.code === val.code}
           value={roleOptions.filter((r) => createForm.roles.includes(r.code))}
           onChange={(_, v) => setCreateForm((p) => ({ ...p, roles: v.map((r) => r.code) }))}
@@ -506,252 +318,27 @@ export default function ClientsPage() {
         />
       </FormDialog>
 
-      {/* ── Edit Client Dialog ─────────────────────────────────── */}
-      <FormDialog open={editDialog.isOpen} title="Edit Client" submitLabel="Save Changes" maxWidth="md" loading={updateMut.isPending} submitDisabled={!hasEditChanges} onSubmit={handleUpdate} onCancel={() => { editDialog.close(); setEditSourceId(null); }}>
-        <Box sx={formGridSx}>
-          <TextField label="Client Name" required value={editForm.name} onChange={onEditField('name')} />
-          <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={editForm.is_active}
-                onChange={(e) => setEditForm((p) => ({ ...p, is_active: e.target.checked }))}
-                size="small"
-              />
-            }
-            label="Active"
-          />
-          <FormControlLabel
-            control={<Checkbox checked={editForm.is_app_user} onChange={handleAppUserToggle('edit', setEditForm)} size="small" />}
-            label="App User (creates login account)"
-          />
-          {editForm.is_app_user && editDialog.data?.is_app_user && (
-            <Button size="small" startIcon={<LockResetIcon />} onClick={() => resetPwDialog.open(editDialog.data)}>
-              Reset Password
-            </Button>
-          )}
-          <Autocomplete
-            multiple
-            options={roleOptions}
-            getOptionLabel={(opt) => opt.name}
-            isOptionEqualToValue={(opt, val) => opt.code === val.code}
-            value={roleOptions.filter((r) => editForm.roles.includes(r.code))}
-            onChange={(_, v) => setEditForm((p) => ({ ...p, roles: v.map((r) => r.code) }))}
-            renderInput={(params) => <TextField {...params} label="Roles" />}
-            sx={formFullSpanSx}
-          />
-        </Box>
-
-        {/* ── Emails ────────────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Emails</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
-        </Box>
-        {emails.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No emails</Typography>
-        )}
-        {emails.visibleItems.map((em) => {
-          const idx = emails.items.indexOf(em);
-          return (
-            <Box key={em.id || idx} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-              <TextField
-                label="Email"
-                type="email"
-                value={em.email}
-                onChange={(e) => emails.update(idx, 'email', e.target.value)}
-                size="small"
-                sx={{ flex: 1, minWidth: 200 }}
-              />
-              <TextField
-                select
-                label="Label"
-                value={em.label}
-                onChange={(e) => emails.update(idx, 'label', e.target.value)}
-                sx={{ minWidth: 120 }}
-                size="small"
-              >
-                {EMAIL_LABELS.map((l) => (
-                  <MenuItem key={l} value={l}>{cap(l)}</MenuItem>
-                ))}
-              </TextField>
-              <FormControlLabel
-                control={<Checkbox checked={em.is_primary} onChange={(e) => emails.update(idx, 'is_primary', e.target.checked)} size="small" />}
-                label="Primary"
-                sx={{ mr: 0 }}
-              />
-              <IconButton size="small" onClick={() => emails.remove(idx)} color="error">
-                <DeleteOutlineIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          );
-        })}
-
-        {/* ── Phone Numbers ──────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Phone Numbers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
-        </Box>
-        {phones.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
-        )}
-        {phones.visibleItems.map((phone) => {
-          const idx = phones.items.indexOf(phone);
-          const countryCode = phone.country_code?.trim() || 'US';
-          const country = COUNTRIES.find((c) => c.code === countryCode);
-          return (
-            <Box key={phone.id || idx} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-              <TextField
-                select
-                label="Type"
-                value={phone.phone_type}
-                onChange={(e) => phones.update(idx, 'phone_type', e.target.value)}
-                sx={{ minWidth: 120 }}
-                size="small"
-              >
-                {PHONE_TYPES.map((t) => (
-                  <MenuItem key={t} value={t}>{cap(t)}</MenuItem>
-                ))}
-              </TextField>
-              <TextField
-                select
-                label="Country"
-                value={countryCode}
-                onChange={(e) => phones.update(idx, 'country_code', e.target.value)}
-                SelectProps={{ renderValue: (val) => COUNTRIES.find((c) => c.code === val)?.dial_code || val }}
-                sx={{ minWidth: 80 }}
-                size="small"
-              >
-                {COUNTRIES.map((c) => (
-                  <MenuItem key={c.code} value={c.code}>{c.dial_code} {c.code} - {c.name}</MenuItem>
-                ))}
-              </TextField>
-              <PatternTextField
-                label="Number"
-                value={phone.phone_number}
-                onChange={(raw) => phones.update(idx, 'phone_number', raw)}
-                pattern={country?.placeholder}
-                size="small"
-                sx={{ flex: 1, minWidth: 160 }}
-              />
-              <FormControlLabel
-                control={<Checkbox checked={phone.is_primary} onChange={(e) => phones.update(idx, 'is_primary', e.target.checked)} size="small" />}
-                label="Primary"
-                sx={{ mr: 0 }}
-              />
-              <IconButton size="small" onClick={() => phones.remove(idx)} color="error">
-                <DeleteOutlineIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          );
-        })}
-
-        {/* ── Addresses ──────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Addresses</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
-        </Box>
-        {addresses.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No addresses</Typography>
-        )}
-        {addresses.visibleItems.map((addr) => {
-          const idx = addresses.items.indexOf(addr);
-          return (
-            <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                <TextField
-                  label="Label"
-                  value={addr.label}
-                  onChange={(e) => addresses.update(idx, 'label', e.target.value)}
-                  size="small"
-                  sx={{ width: 200 }}
-                />
-                <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Box>
-              <Box sx={formGridSx}>
-                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
-                <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
-                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
-                <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
-              </Box>
-            </Box>
-          );
-        })}
-
-        {/* ── Tax Identifiers ──────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Tax Identifiers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
-        </Box>
-        {taxIds.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
-        )}
-        {taxIds.visibleItems.map((taxId) => {
-          const idx = taxIds.items.indexOf(taxId);
-          const countryCode = taxId.country_code?.trim() || '';
-          const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
-          return (
-            <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-                <TextField
-                  select
-                  label="Country"
-                  value={countryCode}
-                  onChange={(e) => {
-                    taxIds.update(idx, 'country_code', e.target.value);
-                    const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                    taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
-                  }}
-                  SelectProps={{ renderValue: (val) => val }}
-                  size="small"
-                  sx={{ minWidth: 80 }}
-                >
-                  {COUNTRIES.map((c) => (
-                    <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
-                  ))}
-                </TextField>
-                <TextField
-                  select
-                  label="Type"
-                  value={taxId.tax_type}
-                  onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
-                  SelectProps={{ renderValue: (val) => val }}
-                  size="small"
-                  sx={{ minWidth: 80 }}
-                >
-                  {taxTypes.map((t) => (
-                    <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
-                  ))}
-                </TextField>
-                <PatternTextField
-                  label="Tax ID Value"
-                  value={taxId.tax_value}
-                  onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
-                  pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
-                  size="small"
-                  sx={{ flex: 1, minWidth: 160 }}
-                />
-                <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            </Box>
-          );
-        })}
-      </FormDialog>
+      <ClientEditDialog
+        open={editDialog.isOpen}
+        onClose={handleEditClose}
+        editForm={editForm}
+        onEditField={onEditField}
+        setEditForm={setEditForm}
+        editRow={editDialog.data}
+        emails={emails}
+        phones={phones}
+        addresses={addresses}
+        taxIds={taxIds}
+        roleOptions={roleOptions}
+        hasEditChanges={hasEditChanges}
+        onSubmit={async () => { if (await handleUpdate()) handleEditClose(); }}
+        loading={updateMut.isPending}
+        onResetPassword={() => resetPwDialog.open(editDialog.data)}
+        onAppUserToggle={handleAppUserToggle('edit', setEditForm)}
+      />
 
       <ImportDialog
-        open={importDialog.isOpen}
-        title="Import Clients"
-        loading={importMut.isPending}
+        open={importDialog.isOpen} title="Import Clients" loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
@@ -770,7 +357,6 @@ export default function ClientsPage() {
       />
 
       <SetPasswordPopover anchorEl={pwAnchor} onConfirm={handlePwConfirm} onCancel={handlePwCancel} />
-
       <ToastSnackbar {...snackProps} />
     </Box>
   );

--- a/apps/nap-client/src/pages/Core/CompaniesPage.jsx
+++ b/apps/nap-client/src/pages/Core/CompaniesPage.jsx
@@ -1,65 +1,49 @@
 /**
- * @file Companies CRUD page — DataTable + create/edit/view/archive/restore
+ * @file Companies CRUD page — coordinator component
  * @module nap-client/pages/Core/CompaniesPage
  *
  * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
  */
 
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { useFormState } from '../../hooks/useFormState.js';
+import { useState, useMemo, useCallback } from 'react';
 import { useDialogState } from '../../hooks/useDialogState.js';
-import { useCollectionState } from '../../hooks/useCollectionState.js';
-import { saveCollection } from '../../utils/saveCollection.js';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import Divider from '@mui/material/Divider';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import IconButton from '@mui/material/IconButton';
-import MenuItem from '@mui/material/MenuItem';
-import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
-import { useToast } from '../../hooks/useToast.js';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import AddIcon from '@mui/icons-material/Add';
 
 import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
-import FieldRow from '../../components/shared/FieldRow.jsx';
 import FormDialog from '../../components/shared/FormDialog.jsx';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
-import PatternTextField from '../../components/shared/PatternTextField.jsx';
-import AddressesSection from '../../components/shared/AddressesSection.jsx';
-import TaxIdentifiersSection from '../../components/shared/TaxIdentifiersSection.jsx';
+import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
 import { useAuth } from '../../contexts/AuthContext.jsx';
 import {
   useCompanies, useCreateCompany, useUpdateCompany, useArchiveCompany, useRestoreCompany,
 } from '../../hooks/useCompanies.js';
-import {
-  useAddresses, useCreateAddress, useUpdateAddress, useArchiveAddress,
-} from '../../hooks/useAddresses.js';
-import {
-  useTaxIdentifiers, useCreateTaxIdentifier, useUpdateTaxIdentifier, useArchiveTaxIdentifier,
-} from '../../hooks/useTaxIdentifiers.js';
+import { useCreateAddress, useUpdateAddress, useArchiveAddress } from '../../hooks/useAddresses.js';
+import { useCreateTaxIdentifier, useUpdateTaxIdentifier, useArchiveTaxIdentifier } from '../../hooks/useTaxIdentifiers.js';
+import { useAddresses } from '../../hooks/useAddresses.js';
+import { useTaxIdentifiers } from '../../hooks/useTaxIdentifiers.js';
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
-import { TAX_TYPES, COUNTRIES, resolveLevel } from '@nap/shared';
-import { fmtDate, errMsg } from '../../utils/format.js';
-import { BLANK_ADDRESS, BLANK_TAX_ID } from '../../utils/formConstants.js';
+import { resolveLevel } from '@nap/shared';
+import { useToast } from '../../hooks/useToast.js';
+import { errMsg } from '../../utils/format.js';
 import { companyApi } from '../../services/companyApi.js';
-import {
-  pageContainerSx, formGridSx, formGroupCardSx, formFullSpanSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx,
-} from '../../config/layoutTokens.js';
+import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 
+import CompanyViewDialog from './companies/CompanyViewDialog.jsx';
+import CompanyEditDialog from './companies/CompanyEditDialog.jsx';
+import { useCompanyEditCollections } from './companies/useCompanyEditCollections.jsx';
+
 const BLANK_CREATE = { name: '', code: '', is_active: true };
 const BLANK_EDIT = { name: '', code: '', is_active: true };
+
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
   { field: 'name', headerName: 'Company Name', flex: 1, minWidth: 200 },
@@ -102,7 +86,7 @@ export default function CompaniesPage() {
   const importMut = useImportXls(companyApi.importXls, ['companies']);
   const exportMut = useExportXls(companyApi.exportXls, 'companies');
 
-  /* ── Selection (new system) ─────────────────────────────────── */
+  /* ── Selection ─────────────────────────────────────────────── */
   const selection = useListSelection(rows);
   const { selectedRows, allActive, allArchived } = selection;
 
@@ -115,71 +99,39 @@ export default function CompaniesPage() {
 
   const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
   const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
-
-  /* ── Edit: source-linked collections ────────────────────────── */
-  const [editSourceId, setEditSourceId] = useState(null);
-  const { data: addressesRes } = useAddresses(
-    { source_id: editSourceId, includeDeactivated: 'false' },
-    { enabled: !!editSourceId },
-  );
-  const { data: taxIdsRes } = useTaxIdentifiers(
-    { source_id: editSourceId, includeDeactivated: 'false' },
-    { enabled: !!editSourceId },
-  );
-
-  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
-  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
-  const editInitial = useRef({ form: null, addresses: null, taxIds: null });
-
-  /* ── View: source-linked collections ────────────────────────── */
-  const [viewSourceId, setViewSourceId] = useState(null);
-  const { data: viewAddressesRes } = useAddresses(
-    { source_id: viewSourceId, includeDeactivated: 'false' },
-    { enabled: !!viewSourceId },
-  );
-  const { data: viewTaxIdsRes } = useTaxIdentifiers(
-    { source_id: viewSourceId, includeDeactivated: 'false' },
-    { enabled: !!viewSourceId },
-  );
-  const viewAddresses = viewAddressesRes?.rows ?? [];
-  const viewTaxIds = viewTaxIdsRes?.rows ?? [];
-
   const { toast, snackProps } = useToast();
 
+  // View dialog child data
+  const viewSourceId = viewDialog.data?.source_id;
+  const { data: viewAddressesRes } = useAddresses({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
+  const { data: viewTaxIdsRes } = useTaxIdentifiers({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
 
-  /* ── Sync query → local state ───────────────────────────────── */
-  useEffect(() => {
-    if (editDialog.isOpen && addressesRes?.rows) {
-      addresses.reset(addressesRes.rows);
-      editInitial.current.addresses = addressesRes.rows;
-    }
-  }, [editDialog.isOpen, addressesRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && taxIdsRes?.rows) {
-      taxIds.reset(taxIdsRes.rows);
-      editInitial.current.taxIds = taxIdsRes.rows;
-    }
-  }, [editDialog.isOpen, taxIdsRes]);
+  const {
+    addresses, taxIds,
+    hasEditChanges, handleUpdate,
+    openEditSession, closeEditSession,
+  } = useCompanyEditCollections({
+    editOpen: editDialog.isOpen,
+    editRow: editDialog.data,
+    editForm,
+    updateMut,
+    toast,
+    addressMuts: { create: createAddrMut, update: updateAddrMut, archive: archiveAddrMut },
+    taxIdMuts: { create: createTaxIdMut, update: updateTaxIdMut, archive: archiveTaxIdMut },
+  });
 
   /* ── Row action callbacks ──────────────────────────────────── */
-  const handleView = useCallback((row) => {
-    setViewSourceId(row.source_id || null);
-    viewDialog.open(row);
-  }, []);
+  const handleView = useCallback((row) => viewDialog.open(row), [viewDialog.open]);
 
   const handleEdit = useCallback((row) => {
-    setEditForm({ name: row.name ?? '', code: row.code ?? '', is_active: row.is_active ?? true });
-    setEditSourceId(row.source_id || null);
-    if (!row.source_id) {
-      addresses.reset([]);
-      taxIds.reset([]);
-      editInitial.current.addresses = [];
-      editInitial.current.taxIds = [];
-    }
-    editInitial.current.form = { name: row.name ?? '', code: row.code ?? '', is_active: row.is_active ?? true };
+    openEditSession(row, setEditForm);
     editDialog.open(row);
-  }, []);
+  }, [openEditSession, editDialog.open]);
+
+  const handleEditClose = useCallback(() => {
+    editDialog.close();
+    closeEditSession();
+  }, [editDialog.close, closeEditSession]);
 
   const handleCreate = async () => {
     try {
@@ -187,38 +139,6 @@ export default function CompaniesPage() {
       toast('Company created');
       createDialog.close();
       resetCreateForm();
-    } catch (err) {
-      toast(errMsg(err), 'error');
-    }
-  };
-
-  const handleUpdate = async () => {
-    try {
-      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
-
-      /* ── Save addresses ──────────────────────────────────────── */
-      await saveCollection(addresses.items, {
-        sourceId: editDialog.data.source_id,
-        fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
-        createMut: createAddrMut.mutateAsync,
-        updateMut: updateAddrMut.mutateAsync,
-        archiveMut: archiveAddrMut.mutateAsync,
-      });
-
-      /* ── Save tax identifiers ────────────────────────────────── */
-      await saveCollection(taxIds.items, {
-        sourceId: editDialog.data.source_id,
-        fields: ['country_code', 'tax_type', 'tax_value'],
-        createMut: createTaxIdMut.mutateAsync,
-        updateMut: updateTaxIdMut.mutateAsync,
-        archiveMut: archiveTaxIdMut.mutateAsync,
-      });
-
-      toast('Company updated');
-      editDialog.close();
-      setEditSourceId(null);
-      addresses.reset([]);
-      taxIds.reset([]);
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -260,15 +180,14 @@ export default function CompaniesPage() {
     getLabel: (r) => r.name,
   });
 
-  /* ── ModuleBar: tabs + Create + Archive/Restore ────────────── */
+  /* ── ModuleBar ─────────────────────────────────────────────── */
   const toolbar = useMemo(() => {
     const primary = [];
 
     if (viewFilter === 'active' || viewFilter === 'all') {
       primary.push({
         label: selectedRows.length > 1 ? `Archive (${selectedRows.length})` : 'Archive',
-        variant: 'outlined',
-        color: 'error',
+        variant: 'outlined', color: 'error',
         disabled: selectedRows.length === 0 || !allActive,
         onClick: () => setArchiveOpen(true),
       });
@@ -276,33 +195,17 @@ export default function CompaniesPage() {
     if (viewFilter === 'archived' || viewFilter === 'all') {
       primary.push({
         label: selectedRows.length > 1 ? `Restore (${selectedRows.length})` : 'Restore',
-        variant: 'outlined',
-        color: 'success',
+        variant: 'outlined', color: 'success',
         disabled: selectedRows.length === 0 || !allArchived,
         onClick: () => setRestoreOpen(true),
       });
     }
 
-    if (canExport) {
-      primary.push({
-        label: 'Export',
-        variant: 'outlined',
-        disabled: exportMut.isPending,
-        onClick: handleExport,
-      });
-    }
-    if (canImport) {
-      primary.push({
-        label: 'Import',
-        variant: 'outlined',
-        onClick: () => importDialog.open(),
-      });
-    }
+    if (canExport) primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
+    if (canImport) primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
 
     primary.push({
-      label: 'Create Company',
-      variant: 'contained',
-      color: 'primary',
+      label: 'Create Company', variant: 'contained', color: 'primary',
       onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
@@ -320,206 +223,41 @@ export default function CompaniesPage() {
 
   return (
     <Box sx={pageContainerSx}>
-      <DataTable
-        rows={rows}
-        columns={columns}
-        loading={isLoading}
-        selection={selection}
-        onView={handleView}
-        onEdit={handleEdit}
+      <DataTable rows={rows} columns={columns} loading={isLoading} selection={selection} onView={handleView} onEdit={handleEdit} />
+
+      <CompanyViewDialog
+        open={viewDialog.isOpen}
+        onClose={viewDialog.close}
+        company={viewDialog.data}
+        viewAddresses={viewAddressesRes?.rows ?? []}
+        viewTaxIds={viewTaxIdsRes?.rows ?? []}
       />
 
-      {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog
-        open={viewDialog.isOpen}
-        onClose={() => { viewDialog.close(); setViewSourceId(null); }}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle sx={dialogHeaderSx}>
-          <Box>
-            <span>Company Details</span>
-            {viewDialog.data && (
-              <Typography variant="body2" color="text.secondary">
-                {viewDialog.data.name}
-              </Typography>
-            )}
-          </Box>
-          <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => { viewDialog.close(); setViewSourceId(null); }}>
-              Close
-            </Button>
-          </Box>
-        </DialogTitle>
-        <DialogContent dividers>
-          {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
-                <FieldRow label="Name" value={viewDialog.data.name} />
-                <FieldRow label="Active" value={viewDialog.data.is_active ? 'Yes' : 'No'} />
-                <FieldRow label="Status">
-                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
-                </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
-              </Box>
-              <AddressesSection addresses={viewAddresses} />
-              <TaxIdentifiersSection taxIds={viewTaxIds} />
-            </Box>
-          )}
-        </DialogContent>
-      </Dialog>
-
-      {/* ── Create Dialog ─────────────────────────────────────────── */}
       <FormDialog open={createDialog.isOpen} title="Create Company" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Company Name" required value={createForm.name} onChange={onCreateField('name')} />
         <TextField label="Code" value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
         <FormControlLabel
-          control={
-            <Checkbox
-              checked={createForm.is_active}
-              onChange={(e) => setCreateForm((p) => ({ ...p, is_active: e.target.checked }))}
-              size="small"
-            />
-          }
+          control={<Checkbox checked={createForm.is_active} onChange={(e) => setCreateForm((p) => ({ ...p, is_active: e.target.checked }))} size="small" />}
           label="Active"
         />
       </FormDialog>
 
-      {/* ── Edit Dialog ───────────────────────────────────────────── */}
-      <FormDialog
+      <CompanyEditDialog
         open={editDialog.isOpen}
-        title="Edit Company"
-        submitLabel="Save Changes"
+        onClose={handleEditClose}
+        editForm={editForm}
+        onEditField={onEditField}
+        setEditForm={setEditForm}
+        editRow={editDialog.data}
+        addresses={addresses}
+        taxIds={taxIds}
+        hasEditChanges={hasEditChanges}
+        onSubmit={async () => { if (await handleUpdate()) handleEditClose(); }}
         loading={updateMut.isPending}
-        onSubmit={handleUpdate}
-        onCancel={() => { editDialog.close(); setEditSourceId(null); addresses.reset([]); taxIds.reset([]); }}
-      >
-        <TextField label="Company Name" required value={editForm.name} onChange={onEditField('name')} />
-        <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={editForm.is_active}
-              onChange={(e) => setEditForm((p) => ({ ...p, is_active: e.target.checked }))}
-              size="small"
-            />
-          }
-          label="Active"
-        />
-
-        {/* ── Addresses ───────────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Addresses</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addresses.add} disabled={!editDialog.data?.source_id}>Add Address</Button>
-        </Box>
-        {!editDialog.data?.source_id && (
-          <Typography variant="body2" color="text.secondary">Save company first to manage addresses</Typography>
-        )}
-        {addresses.visibleItems.length === 0 && editDialog.data?.source_id && (
-          <Typography variant="body2" color="text.secondary">No addresses</Typography>
-        )}
-        {addresses.visibleItems.map((addr) => {
-          const idx = addresses.items.indexOf(addr);
-          return (
-            <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                <TextField
-                  label="Label"
-                  value={addr.label}
-                  onChange={(e) => addresses.update(idx, 'label', e.target.value)}
-                  size="small"
-                  sx={{ width: 200 }}
-                />
-                <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Box>
-              <Box sx={formGridSx}>
-                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
-                <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
-                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
-                <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
-              </Box>
-            </Box>
-          );
-        })}
-
-        {/* ── Tax Identifiers ─────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Tax Identifiers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add} disabled={!editDialog.data?.source_id}>Add Tax ID</Button>
-        </Box>
-        {!editDialog.data?.source_id && (
-          <Typography variant="body2" color="text.secondary">Save company first to manage tax identifiers</Typography>
-        )}
-        {taxIds.visibleItems.length === 0 && editDialog.data?.source_id && (
-          <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
-        )}
-        {taxIds.visibleItems.map((taxId) => {
-          const idx = taxIds.items.indexOf(taxId);
-          const countryCode = taxId.country_code?.trim() || '';
-          const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
-          return (
-            <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-                <TextField
-                  select
-                  label="Country"
-                  value={countryCode}
-                  onChange={(e) => {
-                    taxIds.update(idx, 'country_code', e.target.value);
-                    const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                    taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
-                  }}
-                  SelectProps={{ renderValue: (val) => val }}
-                  size="small"
-                  sx={{ minWidth: 80 }}
-                >
-                  {COUNTRIES.map((c) => (
-                    <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
-                  ))}
-                </TextField>
-                <TextField
-                  select
-                  label="Type"
-                  value={taxId.tax_type}
-                  onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
-                  SelectProps={{ renderValue: (val) => val }}
-                  size="small"
-                  sx={{ minWidth: 80 }}
-                >
-                  {taxTypes.map((t) => (
-                    <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
-                  ))}
-                </TextField>
-                <PatternTextField
-                  label="Tax ID Value"
-                  value={taxId.tax_value}
-                  onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
-                  pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
-                  size="small"
-                  sx={{ flex: 1, minWidth: 160 }}
-                />
-                <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            </Box>
-          );
-        })}
-      </FormDialog>
+      />
 
       <ImportDialog
-        open={importDialog.isOpen}
-        title="Import Companies"
-        loading={importMut.isPending}
+        open={importDialog.isOpen} title="Import Companies" loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
@@ -527,7 +265,6 @@ export default function CompaniesPage() {
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
-
       <ToastSnackbar {...snackProps} />
     </Box>
   );

--- a/apps/nap-client/src/pages/Core/ContactsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ContactsPage.jsx
@@ -1,78 +1,55 @@
 /**
- * @file Contacts CRUD page — DataTable + create/edit/view/archive/restore
+ * @file Contacts CRUD page — coordinator component
  * @module nap-client/pages/Core/ContactsPage
  *
  * Contacts are standalone miscellaneous payees (dual-purpose: AP and AR).
  * Child data (emails, phones, addresses, tax IDs) linked via polymorphic sources pattern.
  *
- * Migrated to standardised list-view selection system:
- *   useListSelection + DataTable + RowActionsMenu
- *
  * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
  */
 
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { useFormState } from '../../hooks/useFormState.js';
+import { useState, useMemo, useCallback } from 'react';
 import { useDialogState } from '../../hooks/useDialogState.js';
+import { useFormState } from '../../hooks/useFormState.js';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import Divider from '@mui/material/Divider';
-import IconButton from '@mui/material/IconButton';
-import MenuItem from '@mui/material/MenuItem';
-import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
-import { useToast } from '../../hooks/useToast.js';
-import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import AddIcon from '@mui/icons-material/Add';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import TextField from '@mui/material/TextField';
 
 import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
-import FieldRow from '../../components/shared/FieldRow.jsx';
 import FormDialog from '../../components/shared/FormDialog.jsx';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
-import PatternTextField from '../../components/shared/PatternTextField.jsx';
-import EmailsSection from '../../components/shared/EmailsSection.jsx';
-import PhoneNumbersSection from '../../components/shared/PhoneNumbersSection.jsx';
-import AddressesSection from '../../components/shared/AddressesSection.jsx';
-import TaxIdentifiersSection from '../../components/shared/TaxIdentifiersSection.jsx';
+import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
 import { useAuth } from '../../contexts/AuthContext.jsx';
 import {
   useContacts, useCreateContact, useUpdateContact, useArchiveContact, useRestoreContact,
 } from '../../hooks/useContacts.js';
-import {
-  useEmails, useCreateEmail, useUpdateEmail, useArchiveEmail,
-} from '../../hooks/useEmails.js';
-import {
-  usePhoneNumbers, useCreatePhoneNumber, useUpdatePhoneNumber, useArchivePhoneNumber,
-} from '../../hooks/usePhoneNumbers.js';
-import {
-  useAddresses, useCreateAddress, useUpdateAddress, useArchiveAddress,
-} from '../../hooks/useAddresses.js';
-import {
-  useTaxIdentifiers, useCreateTaxIdentifier, useUpdateTaxIdentifier, useArchiveTaxIdentifier,
-} from '../../hooks/useTaxIdentifiers.js';
+import { useCreateEmail, useUpdateEmail, useArchiveEmail } from '../../hooks/useEmails.js';
+import { useCreatePhoneNumber, useUpdatePhoneNumber, useArchivePhoneNumber } from '../../hooks/usePhoneNumbers.js';
+import { useCreateAddress, useUpdateAddress, useArchiveAddress } from '../../hooks/useAddresses.js';
+import { useCreateTaxIdentifier, useUpdateTaxIdentifier, useArchiveTaxIdentifier } from '../../hooks/useTaxIdentifiers.js';
+import { useEmails } from '../../hooks/useEmails.js';
+import { usePhoneNumbers } from '../../hooks/usePhoneNumbers.js';
+import { useAddresses } from '../../hooks/useAddresses.js';
+import { useTaxIdentifiers } from '../../hooks/useTaxIdentifiers.js';
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
-import { TAX_TYPES, COUNTRIES, resolveLevel } from '@nap/shared';
-import { cap, fmtDate, errMsg } from '../../utils/format.js';
-import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
+import { resolveLevel } from '@nap/shared';
+import { useToast } from '../../hooks/useToast.js';
+import { errMsg } from '../../utils/format.js';
 import { contactApi } from '../../services/contactApi.js';
-import { pageContainerSx, formGridSx, formGroupCardSx, formFullSpanSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
-import { useCollectionState } from '../../hooks/useCollectionState.js';
-import { saveCollection } from '../../utils/saveCollection.js';
+import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 
+import StandaloneContactViewDialog from './contacts/StandaloneContactViewDialog.jsx';
+import StandaloneContactEditDialog from './contacts/StandaloneContactEditDialog.jsx';
+import { useStandaloneContactEditCollections } from './contacts/useStandaloneContactEditCollections.jsx';
+
 const BLANK_CREATE = { name: '', code: '', is_active: true };
 const BLANK_EDIT = { name: '', code: '', is_active: true };
-
 
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
@@ -122,7 +99,7 @@ export default function ContactsPage() {
   const updateTaxIdMut = useUpdateTaxIdentifier();
   const archiveTaxIdMut = useArchiveTaxIdentifier();
 
-  /* ── Selection (new system) ─────────────────────────────────── */
+  /* ── Selection ─────────────────────────────────────────────── */
   const selection = useListSelection(rows);
   const { selectedRows, allActive, allArchived } = selection;
 
@@ -130,118 +107,48 @@ export default function ContactsPage() {
   const importDialog = useDialogState();
   const [importErrors, setImportErrors] = useState(null);
   const viewDialog = useDialogState();
-  const [viewSourceId, setViewSourceId] = useState(null);
   const createDialog = useDialogState();
   const editDialog = useDialogState();
 
-  const [editSourceId, setEditSourceId] = useState(null);
-  const { data: emailsRes } = useEmails({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
-  const { data: phonesRes } = usePhoneNumbers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
-  const { data: addressesRes } = useAddresses({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
-  const { data: taxIdsRes } = useTaxIdentifiers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
+  const { toast, snackProps } = useToast();
 
   // View dialog child data
+  const viewSourceId = viewDialog.data?.source_id;
   const { data: viewEmailsRes } = useEmails({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
   const { data: viewPhonesRes } = usePhoneNumbers({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
   const { data: viewAddressesRes } = useAddresses({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
   const { data: viewTaxIdsRes } = useTaxIdentifiers({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
-  const viewEmails = viewEmailsRes?.rows ?? [];
-  const viewPhones = viewPhonesRes?.rows ?? [];
-  const viewAddresses = viewAddressesRes?.rows ?? [];
-  const viewTaxIds = viewTaxIdsRes?.rows ?? [];
 
-  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
-  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
-  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
-  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
-  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
-  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
-  const editInitial = useRef({ form: null, emails: null, phones: null, addresses: null, taxIds: null });
+  const {
+    emails, phones, addresses, taxIds,
+    hasEditChanges, handleUpdate,
+    openEditSession, closeEditSession,
+  } = useStandaloneContactEditCollections({
+    editOpen: editDialog.isOpen,
+    editRow: editDialog.data,
+    editForm,
+    updateMut,
+    toast,
+    emailMuts: { create: createEmailMut, update: updateEmailMut, archive: archiveEmailMut },
+    phoneMuts: { create: createPhoneMut, update: updatePhoneMut, archive: archivePhoneMut },
+    addressMuts: { create: createAddrMut, update: updateAddrMut, archive: archiveAddrMut },
+    taxIdMuts: { create: createTaxIdMut, update: updateTaxIdMut, archive: archiveTaxIdMut },
+  });
 
-  const { toast, snackProps } = useToast();
-
-
-
-  /* ── Sync query-fetched child data into edit state ──────────── */
-  useEffect(() => {
-    if (editDialog.isOpen && emailsRes?.rows) {
-      emails.reset(emailsRes.rows);
-      editInitial.current.emails = emailsRes.rows;
-    }
-  }, [editDialog.isOpen, emailsRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && phonesRes?.rows) {
-      phones.reset(phonesRes.rows);
-      editInitial.current.phones = phonesRes.rows;
-    }
-  }, [editDialog.isOpen, phonesRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && addressesRes?.rows) {
-      addresses.reset(addressesRes.rows);
-      editInitial.current.addresses = addressesRes.rows;
-    }
-  }, [editDialog.isOpen, addressesRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && taxIdsRes?.rows) {
-      taxIds.reset(taxIdsRes.rows);
-      editInitial.current.taxIds = taxIdsRes.rows;
-    }
-  }, [editDialog.isOpen, taxIdsRes]);
-
-  /* ── Row action callbacks ───────────────────────────────────── */
-  const handleView = useCallback((row) => {
-    setViewSourceId(row.source_id || null);
-    viewDialog.open(row);
-  }, []);
+  /* ── Row action callbacks ──────────────────────────────────── */
+  const handleView = useCallback((row) => viewDialog.open(row), [viewDialog.open]);
 
   const handleEdit = useCallback((row) => {
-    const form = {
-      name: row.name ?? '',
-      code: row.code ?? '',
-      is_active: row.is_active ?? true,
-    };
-    setEditForm(form);
-    editInitial.current.form = form;
-
-    setEditSourceId(row.source_id || null);
-    if (!row.source_id) {
-      emails.reset([]);
-      phones.reset([]);
-      addresses.reset([]);
-      taxIds.reset([]);
-      editInitial.current.emails = [];
-      editInitial.current.phones = [];
-      editInitial.current.addresses = [];
-      editInitial.current.taxIds = [];
-    }
-
+    openEditSession(row, setEditForm);
     editDialog.open(row);
-  }, []);
+  }, [openEditSession, editDialog.open]);
 
-  /* ── Dirty-check: disable Save when nothing changed ─────────── */
-  const hasEditChanges = useMemo(() => {
-    const init = editInitial.current;
-    if (!init.form) return false;
-    if (JSON.stringify(editForm) !== JSON.stringify(init.form)) return true;
-    const collectionChanged = (current, initial, fields) => {
-      if (!initial) return false;
-      if (current.some((c) => c._deleted)) return true;
-      if (current.some((c) => !c.id && !c._deleted)) return true;
-      const initMap = new Map(initial.map((r) => [r.id, r]));
-      return current.filter((c) => c.id && !c._deleted).some((c) => {
-        const orig = initMap.get(c.id);
-        return !orig || fields.some((f) => c[f] !== orig[f]);
-      });
-    };
-    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary'])) return true;
-    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
-    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
-    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
-    return false;
-  }, [editForm, emails.items, phones.items, addresses.items, taxIds.items]);
+  const handleEditClose = useCallback(() => {
+    editDialog.close();
+    closeEditSession();
+  }, [editDialog.close, closeEditSession]);
 
   const handleCreate = async () => {
     try {
@@ -249,38 +156,6 @@ export default function ContactsPage() {
       toast('Contact created');
       createDialog.close();
       resetCreateForm();
-    } catch (err) {
-      toast(errMsg(err), 'error');
-    }
-  };
-
-  const handleUpdate = async () => {
-    try {
-      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes: editForm });
-
-      if (editDialog.data.source_id) {
-        const sid = editDialog.data.source_id;
-        await saveCollection(emails.items, {
-          sourceId: sid, fields: ['email', 'label', 'is_primary'],
-          createMut: createEmailMut.mutateAsync, updateMut: updateEmailMut.mutateAsync, archiveMut: archiveEmailMut.mutateAsync,
-        });
-        await saveCollection(phones.items, {
-          sourceId: sid, fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
-          createMut: createPhoneMut.mutateAsync, updateMut: updatePhoneMut.mutateAsync, archiveMut: archivePhoneMut.mutateAsync,
-        });
-        await saveCollection(addresses.items, {
-          sourceId: sid, fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
-          createMut: createAddrMut.mutateAsync, updateMut: updateAddrMut.mutateAsync, archiveMut: archiveAddrMut.mutateAsync,
-        });
-        await saveCollection(taxIds.items, {
-          sourceId: sid, fields: ['country_code', 'tax_type', 'tax_value'],
-          createMut: createTaxIdMut.mutateAsync, updateMut: updateTaxIdMut.mutateAsync, archiveMut: archiveTaxIdMut.mutateAsync,
-        });
-      }
-
-      toast('Contact updated');
-      editDialog.close();
-      setEditSourceId(null);
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -321,15 +196,14 @@ export default function ContactsPage() {
     errMsg,
   });
 
-  /* ── ModuleBar: tabs + Create + Archive/Restore ────────────── */
+  /* ── ModuleBar ─────────────────────────────────────────────── */
   const toolbar = useMemo(() => {
     const primary = [];
 
     if (viewFilter === 'active' || viewFilter === 'all') {
       primary.push({
         label: selectedRows.length > 1 ? `Archive (${selectedRows.length})` : 'Archive',
-        variant: 'outlined',
-        color: 'error',
+        variant: 'outlined', color: 'error',
         disabled: selectedRows.length === 0 || !allActive,
         onClick: () => setArchiveOpen(true),
       });
@@ -337,33 +211,17 @@ export default function ContactsPage() {
     if (viewFilter === 'archived' || viewFilter === 'all') {
       primary.push({
         label: selectedRows.length > 1 ? `Restore (${selectedRows.length})` : 'Restore',
-        variant: 'outlined',
-        color: 'success',
+        variant: 'outlined', color: 'success',
         disabled: selectedRows.length === 0 || !allArchived,
         onClick: () => setRestoreOpen(true),
       });
     }
 
-    if (canExport) {
-      primary.push({
-        label: 'Export',
-        variant: 'outlined',
-        disabled: exportMut.isPending,
-        onClick: handleExport,
-      });
-    }
-    if (canImport) {
-      primary.push({
-        label: 'Import',
-        variant: 'outlined',
-        onClick: () => importDialog.open(),
-      });
-    }
+    if (canExport) primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
+    if (canImport) primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
 
     primary.push({
-      label: 'Create Contact',
-      variant: 'contained',
-      color: 'primary',
+      label: 'Create Contact', variant: 'contained', color: 'primary',
       onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
@@ -381,297 +239,44 @@ export default function ContactsPage() {
 
   return (
     <Box sx={pageContainerSx}>
-      <DataTable
-        rows={rows}
-        columns={columns}
-        loading={isLoading}
-        selection={selection}
-        onView={handleView}
-        onEdit={handleEdit}
+      <DataTable rows={rows} columns={columns} loading={isLoading} selection={selection} onView={handleView} onEdit={handleEdit} />
+
+      <StandaloneContactViewDialog
+        open={viewDialog.isOpen}
+        onClose={viewDialog.close}
+        contact={viewDialog.data}
+        viewEmails={viewEmailsRes?.rows ?? []}
+        viewPhones={viewPhonesRes?.rows ?? []}
+        viewAddresses={viewAddressesRes?.rows ?? []}
+        viewTaxIds={viewTaxIdsRes?.rows ?? []}
       />
-
-      {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewDialog.isOpen} onClose={() => { viewDialog.close(); setViewSourceId(null); }} maxWidth="sm" fullWidth>
-        <DialogTitle sx={dialogHeaderSx}>
-          <Box>
-            <span>Contact Details</span>
-            {viewDialog.data && (
-              <Typography variant="body2" color="text.secondary">
-                {viewDialog.data.name}
-              </Typography>
-            )}
-          </Box>
-          <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => { viewDialog.close(); setViewSourceId(null); }}>
-              Close
-            </Button>
-          </Box>
-        </DialogTitle>
-        <DialogContent dividers>
-          {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
-                <FieldRow label="Name" value={viewDialog.data.name} />
-                <FieldRow label="Active" value={viewDialog.data.is_active ? 'Yes' : 'No'} />
-                <FieldRow label="Status">
-                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
-                </FieldRow>
-                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
-              </Box>
-
-              <EmailsSection emails={viewEmails} />
-              <PhoneNumbersSection phones={viewPhones} />
-              <AddressesSection addresses={viewAddresses} />
-              <TaxIdentifiersSection taxIds={viewTaxIds} />
-            </Box>
-          )}
-        </DialogContent>
-      </Dialog>
 
       <FormDialog open={createDialog.isOpen} title="Create Contact" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="Contact Name" required value={createForm.name} onChange={onCreateField('name')} />
         <TextField label="Code" value={createForm.code} onChange={onCreateField('code')} inputProps={{ maxLength: 16 }} />
         <FormControlLabel
-          control={
-            <Checkbox
-              checked={createForm.is_active}
-              onChange={(e) => setCreateForm((p) => ({ ...p, is_active: e.target.checked }))}
-              size="small"
-            />
-          }
+          control={<Checkbox checked={createForm.is_active} onChange={(e) => setCreateForm((p) => ({ ...p, is_active: e.target.checked }))} size="small" />}
           label="Active"
         />
       </FormDialog>
 
-      {/* ── Edit Contact Dialog ──────────────────────────────────── */}
-      <FormDialog open={editDialog.isOpen} title="Edit Contact" submitLabel="Save Changes" maxWidth="md" loading={updateMut.isPending} submitDisabled={!hasEditChanges} onSubmit={handleUpdate} onCancel={() => { editDialog.close(); setEditSourceId(null); }}>
-        <Box sx={formGridSx}>
-          <TextField label="Contact Name" required value={editForm.name} onChange={onEditField('name')} />
-          <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={editForm.is_active}
-                onChange={(e) => setEditForm((p) => ({ ...p, is_active: e.target.checked }))}
-                size="small"
-              />
-            }
-            label="Active"
-          />
-        </Box>
-
-        {/* ── Emails ─────────────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Emails</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
-        </Box>
-        {emails.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No emails</Typography>
-        )}
-        {emails.visibleItems.map((em) => {
-          const idx = emails.items.indexOf(em);
-          return (
-            <Box key={em.id || idx} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-              <TextField
-                label="Email"
-                type="email"
-                value={em.email}
-                onChange={(e) => emails.update(idx, 'email', e.target.value)}
-                size="small"
-                sx={{ flex: 1, minWidth: 200 }}
-              />
-              <TextField
-                select
-                label="Label"
-                value={em.label}
-                onChange={(e) => emails.update(idx, 'label', e.target.value)}
-                sx={{ minWidth: 120 }}
-                size="small"
-              >
-                {EMAIL_LABELS.map((l) => (
-                  <MenuItem key={l} value={l}>{cap(l)}</MenuItem>
-                ))}
-              </TextField>
-              <FormControlLabel
-                control={<Checkbox checked={em.is_primary} onChange={(e) => emails.update(idx, 'is_primary', e.target.checked)} size="small" />}
-                label="Primary"
-                sx={{ mr: 0 }}
-              />
-              <IconButton size="small" onClick={() => emails.remove(idx)} color="error">
-                <DeleteOutlineIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          );
-        })}
-
-        {/* ── Phone Numbers ──────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Phone Numbers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
-        </Box>
-        {phones.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
-        )}
-        {phones.visibleItems.map((phone) => {
-          const idx = phones.items.indexOf(phone);
-          const countryCode = phone.country_code?.trim() || 'US';
-          const country = COUNTRIES.find((c) => c.code === countryCode);
-          return (
-            <Box key={phone.id || idx} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-              <TextField
-                select
-                label="Type"
-                value={phone.phone_type}
-                onChange={(e) => phones.update(idx, 'phone_type', e.target.value)}
-                sx={{ minWidth: 120 }}
-                size="small"
-              >
-                {PHONE_TYPES.map((t) => (
-                  <MenuItem key={t} value={t}>{cap(t)}</MenuItem>
-                ))}
-              </TextField>
-              <TextField
-                select
-                label="Country"
-                value={countryCode}
-                onChange={(e) => phones.update(idx, 'country_code', e.target.value)}
-                SelectProps={{ renderValue: (val) => COUNTRIES.find((c) => c.code === val)?.dial_code || val }}
-                sx={{ minWidth: 80 }}
-                size="small"
-              >
-                {COUNTRIES.map((c) => (
-                  <MenuItem key={c.code} value={c.code}>{c.dial_code} {c.code} - {c.name}</MenuItem>
-                ))}
-              </TextField>
-              <PatternTextField
-                label="Number"
-                value={phone.phone_number}
-                onChange={(raw) => phones.update(idx, 'phone_number', raw)}
-                pattern={country?.placeholder}
-                size="small"
-                sx={{ flex: 1, minWidth: 160 }}
-              />
-              <FormControlLabel
-                control={<Checkbox checked={phone.is_primary} onChange={(e) => phones.update(idx, 'is_primary', e.target.checked)} size="small" />}
-                label="Primary"
-                sx={{ mr: 0 }}
-              />
-              <IconButton size="small" onClick={() => phones.remove(idx)} color="error">
-                <DeleteOutlineIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          );
-        })}
-
-        {/* ── Addresses ──────────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Addresses</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
-        </Box>
-        {addresses.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No addresses</Typography>
-        )}
-        {addresses.visibleItems.map((addr) => {
-          const idx = addresses.items.indexOf(addr);
-          return (
-            <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                <TextField
-                  label="Label"
-                  value={addr.label}
-                  onChange={(e) => addresses.update(idx, 'label', e.target.value)}
-                  size="small"
-                  sx={{ width: 200 }}
-                />
-                <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Box>
-              <Box sx={formGridSx}>
-                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
-                <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
-                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
-                <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
-              </Box>
-            </Box>
-          );
-        })}
-
-        {/* ── Tax Identifiers ────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Tax Identifiers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
-        </Box>
-        {taxIds.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
-        )}
-        {taxIds.visibleItems.map((taxId) => {
-          const idx = taxIds.items.indexOf(taxId);
-          const countryCode = taxId.country_code?.trim() || '';
-          const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
-          return (
-            <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-                <TextField
-                  select
-                  label="Country"
-                  value={countryCode}
-                  onChange={(e) => {
-                    taxIds.update(idx, 'country_code', e.target.value);
-                    const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                    taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
-                  }}
-                  SelectProps={{ renderValue: (val) => val }}
-                  size="small"
-                  sx={{ minWidth: 80 }}
-                >
-                  {COUNTRIES.map((c) => (
-                    <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
-                  ))}
-                </TextField>
-                <TextField
-                  select
-                  label="Type"
-                  value={taxId.tax_type}
-                  onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
-                  SelectProps={{ renderValue: (val) => val }}
-                  size="small"
-                  sx={{ minWidth: 80 }}
-                >
-                  {taxTypes.map((t) => (
-                    <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
-                  ))}
-                </TextField>
-                <PatternTextField
-                  label="Tax ID Value"
-                  value={taxId.tax_value}
-                  onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
-                  pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
-                  size="small"
-                  sx={{ flex: 1, minWidth: 160 }}
-                />
-                <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            </Box>
-          );
-        })}
-      </FormDialog>
+      <StandaloneContactEditDialog
+        open={editDialog.isOpen}
+        onClose={handleEditClose}
+        editForm={editForm}
+        onEditField={onEditField}
+        setEditForm={setEditForm}
+        emails={emails}
+        phones={phones}
+        addresses={addresses}
+        taxIds={taxIds}
+        hasEditChanges={hasEditChanges}
+        onSubmit={async () => { if (await handleUpdate()) handleEditClose(); }}
+        loading={updateMut.isPending}
+      />
 
       <ImportDialog
-        open={importDialog.isOpen}
-        title="Import Contacts"
-        loading={importMut.isPending}
+        open={importDialog.isOpen} title="Import Contacts" loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
@@ -679,7 +284,6 @@ export default function ContactsPage() {
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
-
       <ToastSnackbar {...snackProps} />
     </Box>
   );

--- a/apps/nap-client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/nap-client/src/pages/Core/EmployeesPage.jsx
@@ -1,78 +1,54 @@
 /**
- * @file Employees CRUD page — DataTable + create/edit/view/archive/restore with is_app_user toggle
+ * @file Employees CRUD page — coordinator component
  * @module nap-client/pages/Core/EmployeesPage
- *
- * Migrated to standardised list-view selection system:
- *   useListSelection + DataTable + RowActionsMenu
  *
  * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
  */
 
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useState, useMemo, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useDialogState } from '../../hooks/useDialogState.js';
 import { useFormState } from '../../hooks/useFormState.js';
-import { useCollectionState } from '../../hooks/useCollectionState.js';
-import { saveCollection } from '../../utils/saveCollection.js';
-import { useQueryClient } from '@tanstack/react-query';
 import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import Divider from '@mui/material/Divider';
-import IconButton from '@mui/material/IconButton';
-import MenuItem from '@mui/material/MenuItem';
-import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
-import { useToast } from '../../hooks/useToast.js';
-import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import AddIcon from '@mui/icons-material/Add';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import TextField from '@mui/material/TextField';
 import LockResetIcon from '@mui/icons-material/LockReset';
 
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
-import FieldRow from '../../components/shared/FieldRow.jsx';
 import FormDialog from '../../components/shared/FormDialog.jsx';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
-import PatternTextField from '../../components/shared/PatternTextField.jsx';
 import ResetPasswordDialog from '../../components/shared/ResetPasswordDialog.jsx';
 import SetPasswordPopover from '../../components/shared/SetPasswordPopover.jsx';
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
-import EmailsSection from '../../components/shared/EmailsSection.jsx';
-import PhoneNumbersSection from '../../components/shared/PhoneNumbersSection.jsx';
-import AddressesSection from '../../components/shared/AddressesSection.jsx';
-import TaxIdentifiersSection from '../../components/shared/TaxIdentifiersSection.jsx';
+import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
+import { useAuth } from '../../contexts/AuthContext.jsx';
 import {
   useEmployees, useCreateEmployee, useUpdateEmployee, useArchiveEmployee, useRestoreEmployee, useResetEmployeePassword,
 } from '../../hooks/useEmployees.js';
-import { useRoles } from '../../hooks/useRoles.js';
-import {
-  usePhoneNumbers, useCreatePhoneNumber, useUpdatePhoneNumber, useArchivePhoneNumber,
-} from '../../hooks/usePhoneNumbers.js';
-import {
-  useEmails, useCreateEmail, useUpdateEmail, useArchiveEmail,
-} from '../../hooks/useEmails.js';
-import {
-  useAddresses, useCreateAddress, useUpdateAddress, useArchiveAddress,
-} from '../../hooks/useAddresses.js';
-import {
-  useTaxIdentifiers, useCreateTaxIdentifier, useUpdateTaxIdentifier, useArchiveTaxIdentifier,
-} from '../../hooks/useTaxIdentifiers.js';
+import { useCreateEmail, useUpdateEmail, useArchiveEmail } from '../../hooks/useEmails.js';
+import { useCreatePhoneNumber, useUpdatePhoneNumber, useArchivePhoneNumber } from '../../hooks/usePhoneNumbers.js';
+import { useCreateAddress, useUpdateAddress, useArchiveAddress } from '../../hooks/useAddresses.js';
+import { useCreateTaxIdentifier, useUpdateTaxIdentifier, useArchiveTaxIdentifier } from '../../hooks/useTaxIdentifiers.js';
+import { useEmails } from '../../hooks/useEmails.js';
+import { usePhoneNumbers } from '../../hooks/usePhoneNumbers.js';
+import { useAddresses } from '../../hooks/useAddresses.js';
+import { useTaxIdentifiers } from '../../hooks/useTaxIdentifiers.js';
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
-import { TAX_TYPES, COUNTRIES } from '@nap/shared';
-import { cap, fmtDate, errMsg } from '../../utils/format.js';
-import { BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID, PHONE_TYPES, EMAIL_LABELS } from '../../utils/formConstants.js';
+import { useRoles } from '../../hooks/useRoles.js';
+import { resolveLevel } from '@nap/shared';
+import { useToast } from '../../hooks/useToast.js';
+import { errMsg } from '../../utils/format.js';
 import { employeeApi } from '../../services/employeeApi.js';
-import { pageContainerSx, formGridSx, formGroupCardSx, formFullSpanSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
+import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
-import { useAuth } from '../../contexts/AuthContext.jsx';
-import { resolveLevel } from '@nap/shared';
+
+import EmployeeViewDialog from './employees/EmployeeViewDialog.jsx';
+import EmployeeEditDialog from './employees/EmployeeEditDialog.jsx';
+import { useEmployeeEditCollections } from './employees/useEmployeeEditCollections.jsx';
 
 const BLANK_CREATE = {
   first_name: '', last_name: '', code: '', position: '', department: '', email: '',
@@ -83,26 +59,14 @@ const BLANK_EDIT = {
   is_app_user: false, password: '', roles: [], is_primary_contact: false, is_billing_contact: false,
 };
 
-const BLANK_EMAIL = { email: '', label: 'work', is_primary: false, is_login: false };
-
 const columns = [
   { field: 'code', headerName: 'Code', width: 100 },
   { field: 'first_name', headerName: 'First Name', width: 140 },
   { field: 'last_name', headerName: 'Last Name', width: 140 },
   { field: 'position', headerName: 'Position', width: 140 },
   { field: 'department', headerName: 'Department', width: 140 },
-  {
-    field: 'roles',
-    headerName: 'Roles',
-    width: 160,
-    valueGetter: (params) => (params.row.roles ?? []).join(', '),
-  },
-  {
-    field: 'is_app_user',
-    headerName: 'App User',
-    width: 100,
-    valueGetter: (params) => (params.row.is_app_user ? 'Yes' : 'No'),
-  },
+  { field: 'roles', headerName: 'Roles', width: 160, valueGetter: (params) => (params.row.roles ?? []).join(', ') },
+  { field: 'is_app_user', headerName: 'App User', width: 100, valueGetter: (params) => (params.row.is_app_user ? 'Yes' : 'No') },
 ];
 
 export default function EmployeesPage() {
@@ -115,7 +79,6 @@ export default function EmployeesPage() {
 
   const { data: res, isLoading } = useEmployees();
   const allRows = res?.rows ?? [];
-
   const { data: rolesRes } = useRoles();
   const roleOptions = rolesRes?.rows ?? [];
 
@@ -135,12 +98,12 @@ export default function EmployeesPage() {
   const importMut = useImportXls(employeeApi.importXls, ['employees'], [['nap-users']]);
   const exportMut = useExportXls(employeeApi.exportXls, 'employees');
 
-  const createPhoneMut = useCreatePhoneNumber();
-  const updatePhoneMut = useUpdatePhoneNumber();
-  const archivePhoneMut = useArchivePhoneNumber();
   const createEmailMut = useCreateEmail();
   const updateEmailMut = useUpdateEmail();
   const archiveEmailMut = useArchiveEmail();
+  const createPhoneMut = useCreatePhoneNumber();
+  const updatePhoneMut = useUpdatePhoneNumber();
+  const archivePhoneMut = useArchivePhoneNumber();
   const createAddrMut = useCreateAddress();
   const updateAddrMut = useUpdateAddress();
   const archiveAddrMut = useArchiveAddress();
@@ -148,7 +111,7 @@ export default function EmployeesPage() {
   const updateTaxIdMut = useUpdateTaxIdentifier();
   const archiveTaxIdMut = useArchiveTaxIdentifier();
 
-  /* ── Selection (new system) ─────────────────────────────────── */
+  /* ── Selection ─────────────────────────────────────────────── */
   const selection = useListSelection(rows);
   const { selectedRows, allActive, allArchived } = selection;
 
@@ -156,132 +119,76 @@ export default function EmployeesPage() {
   const importDialog = useDialogState();
   const [importErrors, setImportErrors] = useState(null);
   const viewDialog = useDialogState();
-  const [viewSourceId, setViewSourceId] = useState(null);
   const createDialog = useDialogState();
   const editDialog = useDialogState();
   const resetPwDialog = useDialogState();
 
-  const [editSourceId, setEditSourceId] = useState(null);
-  const { data: phonesRes } = usePhoneNumbers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
-  const { data: emailsRes } = useEmails({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
-  const { data: addressesRes } = useAddresses({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
-  const { data: taxIdsRes } = useTaxIdentifiers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
+  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
+  const { toast, snackProps } = useToast();
 
   // View dialog child data
+  const viewSourceId = viewDialog.data?.source_id;
   const { data: viewPhonesRes } = usePhoneNumbers({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
   const { data: viewEmailsRes } = useEmails({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
   const { data: viewAddressesRes } = useAddresses({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
   const { data: viewTaxIdsRes } = useTaxIdentifiers({ source_id: viewSourceId, includeDeactivated: 'false' }, { enabled: !!viewSourceId });
-  const viewPhones = viewPhonesRes?.rows ?? [];
-  const viewEmails = viewEmailsRes?.rows ?? [];
-  const viewAddresses = viewAddressesRes?.rows ?? [];
-  const viewTaxIds = viewTaxIdsRes?.rows ?? [];
 
-  const { form: createForm, setForm: setCreateForm, field: onCreateField, reset: resetCreateForm } = useFormState(BLANK_CREATE);
-  const { form: editForm, setForm: setEditForm, field: onEditField } = useFormState(BLANK_EDIT);
-  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary', 'is_login'] });
-  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
-  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
-  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
-  const editInitial = useRef({ form: null, phones: null, emails: null, addresses: null, taxIds: null });
+  const {
+    emails, phones, addresses, taxIds,
+    hasEditChanges, handleUpdate,
+    openEditSession, closeEditSession,
+  } = useEmployeeEditCollections({
+    editOpen: editDialog.isOpen,
+    editRow: editDialog.data,
+    editForm,
+    updateMut,
+    toast,
+    qc,
+    emailMuts: { create: createEmailMut, update: updateEmailMut, archive: archiveEmailMut },
+    phoneMuts: { create: createPhoneMut, update: updatePhoneMut, archive: archivePhoneMut },
+    addressMuts: { create: createAddrMut, update: updateAddrMut, archive: archiveAddrMut },
+    taxIdMuts: { create: createTaxIdMut, update: updateTaxIdMut, archive: archiveTaxIdMut },
+  });
 
-  const { toast, snackProps } = useToast();
-
-
-  const onCreateCheck = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.checked }));
-  const onEditCheck = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.checked }));
-
-  /* ── App-user password popover state ────────────────────────── */
+  /* ── App-user password popover ─────────────────────────────── */
   const [pwAnchor, setPwAnchor] = useState(null);
-  const [pwTarget, setPwTarget] = useState(null); // 'create' | 'edit'
+  const [pwTarget, setPwTarget] = useState(null);
 
-  const handleAppUserToggle = (target, setForm) => (e) => {
+  const handleAppUserToggle = useCallback((target, setForm) => (e) => {
     if (e.target.checked) {
       setPwTarget(target);
       setPwAnchor(e.currentTarget);
     } else {
       setForm((p) => ({ ...p, is_app_user: false, password: '' }));
     }
-  };
+  }, []);
 
-  const handlePwConfirm = (password) => {
+  const handlePwConfirm = useCallback((password) => {
     const setForm = pwTarget === 'create' ? setCreateForm : setEditForm;
     setForm((p) => ({ ...p, is_app_user: true, password }));
     setPwAnchor(null);
     setPwTarget(null);
-  };
+  }, [pwTarget, setCreateForm, setEditForm]);
 
-  const handlePwCancel = () => {
+  const handlePwCancel = useCallback(() => {
     setPwAnchor(null);
     setPwTarget(null);
-  };
-
-  /* ── Sync query-fetched phones/addresses/taxIds into edit state */
-  useEffect(() => {
-    if (editDialog.isOpen && phonesRes?.rows) {
-      phones.reset(phonesRes.rows);
-      editInitial.current.phones = phonesRes.rows;
-    }
-  }, [editDialog.isOpen, phonesRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && emailsRes?.rows) {
-      emails.reset(emailsRes.rows);
-      editInitial.current.emails = emailsRes.rows;
-    }
-  }, [editDialog.isOpen, emailsRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && addressesRes?.rows) {
-      addresses.reset(addressesRes.rows);
-      editInitial.current.addresses = addressesRes.rows;
-    }
-  }, [editDialog.isOpen, addressesRes]);
-
-  useEffect(() => {
-    if (editDialog.isOpen && taxIdsRes?.rows) {
-      taxIds.reset(taxIdsRes.rows);
-      editInitial.current.taxIds = taxIdsRes.rows;
-    }
-  }, [editDialog.isOpen, taxIdsRes]);
+  }, []);
 
   /* ── Row action callbacks ──────────────────────────────────── */
-  const handleView = useCallback((row) => {
-    viewDialog.open(row);
-    setViewSourceId(row.source_id || null);
-  }, []);
+  const handleView = useCallback((row) => viewDialog.open(row), [viewDialog.open]);
 
   const handleEdit = useCallback((row) => {
-    const form = {
-      first_name: row.first_name ?? '',
-      last_name: row.last_name ?? '',
-      code: row.code ?? '',
-      position: row.position ?? '',
-      department: row.department ?? '',
-      is_app_user: !!row.is_app_user,
-      roles: row.roles ?? [],
-      is_primary_contact: !!row.is_primary_contact,
-      is_billing_contact: !!row.is_billing_contact,
-    };
-    setEditForm(form);
-    editInitial.current.form = form;
-
-    setEditSourceId(row.source_id || null);
-    if (!row.source_id) {
-      phones.reset([]);
-      emails.reset([]);
-      addresses.reset([]);
-      taxIds.reset([]);
-      editInitial.current.phones = [];
-      editInitial.current.emails = [];
-      editInitial.current.addresses = [];
-      editInitial.current.taxIds = [];
-    }
-
+    openEditSession(row, setEditForm);
     editDialog.open(row);
-  }, []);
+  }, [openEditSession, editDialog.open]);
 
-  /** Per-row kebab actions — Reset Password shown for app users when permitted */
+  const handleEditClose = useCallback(() => {
+    editDialog.close();
+    closeEditSession();
+  }, [editDialog.close, closeEditSession]);
+
   const getRowActions = useCallback(
     (row) => {
       const actions = [];
@@ -297,82 +204,12 @@ export default function EmployeesPage() {
     [canResetPassword],
   );
 
-  /* ── Dirty-check: disable Save when nothing changed ──────── */
-  const hasEditChanges = useMemo(() => {
-    const init = editInitial.current;
-    if (!init.form) return false;
-    // Form fields
-    if (JSON.stringify(editForm) !== JSON.stringify(init.form)) return true;
-    // Collections — any addition, deletion, or field change counts
-    const collectionChanged = (current, initial, fields) => {
-      if (!initial) return false;
-      if (current.some((c) => c._deleted)) return true;
-      if (current.some((c) => !c.id && !c._deleted)) return true;
-      const initMap = new Map(initial.map((r) => [r.id, r]));
-      return current.filter((c) => c.id && !c._deleted).some((c) => {
-        const orig = initMap.get(c.id);
-        return !orig || fields.some((f) => c[f] !== orig[f]);
-      });
-    };
-    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
-    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary', 'is_login'])) return true;
-    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
-    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
-    return false;
-  }, [editForm, phones.items, emails.items, addresses.items, taxIds.items]);
-
   const handleCreate = async () => {
     try {
       await createMut.mutateAsync(createForm);
       toast('Employee created');
       createDialog.close();
       resetCreateForm();
-    } catch (err) {
-      toast(errMsg(err), 'error');
-    }
-  };
-
-  const handleUpdate = async () => {
-    try {
-      // When toggling is_app_user on, include the selected login email in the
-      // employee update payload so the backend can provision before email mutations run
-      const changes = { ...editForm };
-      if (changes.is_app_user && !editDialog.data.is_app_user) {
-        const loginEm = emails.items.find((em) => em.is_login && !em._deleted);
-        if (loginEm) changes.email = loginEm.email;
-      }
-      await updateMut.mutateAsync({ filter: { id: editDialog.data.id }, changes });
-
-      if (editDialog.data.source_id) {
-        const sid = editDialog.data.source_id;
-        await saveCollection(phones.items, {
-          sourceId: sid,
-          fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
-          createMut: createPhoneMut.mutateAsync, updateMut: updatePhoneMut.mutateAsync, archiveMut: archivePhoneMut.mutateAsync,
-        });
-        await saveCollection(emails.items, {
-          sourceId: sid,
-          fields: ['email', 'label', 'is_primary', 'is_login'],
-          createMut: createEmailMut.mutateAsync, updateMut: updateEmailMut.mutateAsync, archiveMut: archiveEmailMut.mutateAsync,
-        });
-        await saveCollection(addresses.items, {
-          sourceId: sid,
-          fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
-          createMut: createAddrMut.mutateAsync, updateMut: updateAddrMut.mutateAsync, archiveMut: archiveAddrMut.mutateAsync,
-        });
-        await saveCollection(taxIds.items, {
-          sourceId: sid,
-          fields: ['country_code', 'tax_type', 'tax_value'],
-          createMut: createTaxIdMut.mutateAsync, updateMut: updateTaxIdMut.mutateAsync, archiveMut: archiveTaxIdMut.mutateAsync,
-        });
-      }
-
-      if (editForm.is_app_user !== editDialog.data.is_app_user) {
-        qc.invalidateQueries({ queryKey: ['nap-users'] });
-      }
-      toast('Employee updated');
-      editDialog.close();
-      setEditSourceId(null);
     } catch (err) {
       toast(errMsg(err), 'error');
     }
@@ -414,15 +251,16 @@ export default function EmployeesPage() {
     getLabel: (r) => `${r.first_name} ${r.last_name}`,
   });
 
-  /* ── ModuleBar: tabs + Create + Archive/Restore ────────────── */
+  const onCreateCheck = (f) => (e) => setCreateForm((p) => ({ ...p, [f]: e.target.checked }));
+
+  /* ── ModuleBar ─────────────────────────────────────────────── */
   const toolbar = useMemo(() => {
     const primary = [];
 
     if (viewFilter === 'active' || viewFilter === 'all') {
       primary.push({
         label: selectedRows.length > 1 ? `Archive (${selectedRows.length})` : 'Archive',
-        variant: 'outlined',
-        color: 'error',
+        variant: 'outlined', color: 'error',
         disabled: selectedRows.length === 0 || !allActive,
         onClick: () => setArchiveOpen(true),
       });
@@ -430,33 +268,17 @@ export default function EmployeesPage() {
     if (viewFilter === 'archived' || viewFilter === 'all') {
       primary.push({
         label: selectedRows.length > 1 ? `Restore (${selectedRows.length})` : 'Restore',
-        variant: 'outlined',
-        color: 'success',
+        variant: 'outlined', color: 'success',
         disabled: selectedRows.length === 0 || !allArchived,
         onClick: () => setRestoreOpen(true),
       });
     }
 
-    if (canExport) {
-      primary.push({
-        label: 'Export',
-        variant: 'outlined',
-        disabled: exportMut.isPending,
-        onClick: handleExport,
-      });
-    }
-    if (canImport) {
-      primary.push({
-        label: 'Import',
-        variant: 'outlined',
-        onClick: () => importDialog.open(),
-      });
-    }
+    if (canExport) primary.push({ label: 'Export', variant: 'outlined', disabled: exportMut.isPending, onClick: handleExport });
+    if (canImport) primary.push({ label: 'Import', variant: 'outlined', onClick: () => importDialog.open() });
 
     primary.push({
-      label: 'Create Employee',
-      variant: 'contained',
-      color: 'primary',
+      label: 'Create Employee', variant: 'contained', color: 'primary',
       onClick: () => { resetCreateForm(); createDialog.open(); },
     });
 
@@ -474,63 +296,18 @@ export default function EmployeesPage() {
 
   return (
     <Box sx={pageContainerSx}>
-      <DataTable
-        rows={rows}
-        columns={columns}
-        loading={isLoading}
-        selection={selection}
-        onView={handleView}
-        onEdit={handleEdit}
-        rowActions={getRowActions}
+      <DataTable rows={rows} columns={columns} loading={isLoading} selection={selection} onView={handleView} onEdit={handleEdit} rowActions={getRowActions} />
+
+      <EmployeeViewDialog
+        open={viewDialog.isOpen}
+        onClose={viewDialog.close}
+        employee={viewDialog.data}
+        viewPhones={viewPhonesRes?.rows ?? []}
+        viewEmails={viewEmailsRes?.rows ?? []}
+        viewAddresses={viewAddressesRes?.rows ?? []}
+        viewTaxIds={viewTaxIdsRes?.rows ?? []}
       />
 
-      {/* ── View Details Dialog ──────────────────────────────────── */}
-      <Dialog open={viewDialog.isOpen} onClose={() => { viewDialog.close(); setViewSourceId(null); }} maxWidth="sm" fullWidth>
-        <DialogTitle sx={dialogHeaderSx}>
-          <Box>
-            <span>Employee Details</span>
-            {viewDialog.data && (
-              <Typography variant="body2" color="text.secondary">
-                {viewDialog.data.first_name} {viewDialog.data.last_name}
-              </Typography>
-            )}
-          </Box>
-          <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={() => { viewDialog.close(); setViewSourceId(null); }}>
-              Close
-            </Button>
-          </Box>
-        </DialogTitle>
-        <DialogContent dividers>
-          {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
-                <FieldRow label="First Name" value={viewDialog.data.first_name} />
-                <FieldRow label="Last Name" value={viewDialog.data.last_name} />
-                <FieldRow label="Position" value={viewDialog.data.position || '\u2014'} />
-                <FieldRow label="Department" value={viewDialog.data.department || '\u2014'} />
-                <FieldRow label="App User" value={viewDialog.data.is_app_user ? 'Yes' : 'No'} />
-                <FieldRow label="Roles" value={(viewDialog.data.roles ?? []).join(', ') || '\u2014'} />
-                <FieldRow label="Status">
-                  <StatusBadge status={viewDialog.data.deactivated_at ? 'archived' : 'active'} />
-                </FieldRow>
-                <FieldRow label="Primary Contact" value={viewDialog.data.is_primary_contact ? 'Yes' : 'No'} />
-                <FieldRow label="Billing Contact" value={viewDialog.data.is_billing_contact ? 'Yes' : 'No'} />
-                <FieldRow label="Created" value={fmtDate(viewDialog.data.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(viewDialog.data.updated_at)} />
-              </Box>
-
-              <PhoneNumbersSection phones={viewPhones} />
-              <EmailsSection emails={viewEmails} showLogin />
-              <AddressesSection addresses={viewAddresses} />
-              <TaxIdentifiersSection taxIds={viewTaxIds} />
-            </Box>
-          )}
-        </DialogContent>
-      </Dialog>
-
-      {/* ── Create Employee Dialog ───────────────────────────────── */}
       <FormDialog open={createDialog.isOpen} title="Create Employee" submitLabel="Create" loading={createMut.isPending} onSubmit={handleCreate} onCancel={createDialog.close}>
         <TextField label="First Name" required value={createForm.first_name} onChange={onCreateField('first_name')} />
         <TextField label="Last Name" required value={createForm.last_name} onChange={onCreateField('last_name')} />
@@ -540,9 +317,7 @@ export default function EmployeesPage() {
         <TextField label="Email" type="email" value={createForm.email} onChange={onCreateField('email')} helperText={createForm.is_app_user && !createForm.email ? 'Email required for app users' : ''} error={createForm.is_app_user && !createForm.email} />
         <FormControlLabel control={<Checkbox checked={createForm.is_app_user} onChange={handleAppUserToggle('create', setCreateForm)} />} label="App User (creates login account)" />
         <Autocomplete
-          multiple
-          options={roleOptions}
-          getOptionLabel={(opt) => opt.name}
+          multiple options={roleOptions} getOptionLabel={(opt) => opt.name}
           isOptionEqualToValue={(opt, val) => opt.code === val.code}
           value={roleOptions.filter((r) => createForm.roles.includes(r.code))}
           onChange={(_, v) => setCreateForm((p) => ({ ...p, roles: v.map((r) => r.code) }))}
@@ -552,252 +327,28 @@ export default function EmployeesPage() {
         <FormControlLabel control={<Checkbox checked={createForm.is_billing_contact} onChange={onCreateCheck('is_billing_contact')} />} label="Billing Contact" />
       </FormDialog>
 
-      {/* ── Edit Employee Dialog ─────────────────────────────── */}
-      <FormDialog open={editDialog.isOpen} title="Edit Employee" submitLabel="Save Changes" maxWidth="md" loading={updateMut.isPending} submitDisabled={!hasEditChanges} onSubmit={handleUpdate} onCancel={() => { editDialog.close(); setEditSourceId(null); }}>
-        <Box sx={formGridSx}>
-          <TextField label="First Name" required value={editForm.first_name} onChange={onEditField('first_name')} />
-          <TextField label="Last Name" required value={editForm.last_name} onChange={onEditField('last_name')} />
-          <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
-          <TextField label="Position" value={editForm.position} onChange={onEditField('position')} />
-          <TextField label="Department" value={editForm.department} onChange={onEditField('department')} />
-          <FormControlLabel control={<Checkbox checked={editForm.is_app_user} onChange={handleAppUserToggle('edit', setEditForm)} />} label="App User (creates login account)" />
-          <Autocomplete
-            multiple
-            options={roleOptions}
-            getOptionLabel={(opt) => opt.name}
-            isOptionEqualToValue={(opt, val) => opt.code === val.code}
-            value={roleOptions.filter((r) => editForm.roles.includes(r.code))}
-            onChange={(_, v) => setEditForm((p) => ({ ...p, roles: v.map((r) => r.code) }))}
-            renderInput={(params) => <TextField {...params} label="Roles" />}
-          />
-          <FormControlLabel control={<Checkbox checked={editForm.is_primary_contact} onChange={onEditCheck('is_primary_contact')} />} label="Primary Contact" />
-          <FormControlLabel control={<Checkbox checked={editForm.is_billing_contact} onChange={onEditCheck('is_billing_contact')} />} label="Billing Contact" />
-        </Box>
-
-        {editForm.is_app_user && canResetPassword && (
-          <Button variant="outlined" size="small" onClick={() => resetPwDialog.open(editDialog.data)}>
-            Reset Password
-          </Button>
-        )}
-
-        {/* ── Phone Numbers ──────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Phone Numbers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
-        </Box>
-        {phones.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
-        )}
-        {phones.visibleItems.map((phone) => {
-          const idx = phones.items.indexOf(phone);
-          const countryCode = phone.country_code?.trim() || 'US';
-          const country = COUNTRIES.find((c) => c.code === countryCode);
-          return (
-            <Box key={phone.id || idx} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-              <TextField
-                select
-                label="Type"
-                value={phone.phone_type}
-                onChange={(e) => phones.update(idx, 'phone_type', e.target.value)}
-                sx={{ minWidth: 120 }}
-                size="small"
-              >
-                {PHONE_TYPES.map((t) => (
-                  <MenuItem key={t} value={t}>{cap(t)}</MenuItem>
-                ))}
-              </TextField>
-              <TextField
-                select
-                label="Country"
-                value={countryCode}
-                onChange={(e) => phones.update(idx, 'country_code', e.target.value)}
-                SelectProps={{ renderValue: (val) => COUNTRIES.find((c) => c.code === val)?.dial_code || val }}
-                sx={{ minWidth: 80 }}
-                size="small"
-              >
-                {COUNTRIES.map((c) => (
-                  <MenuItem key={c.code} value={c.code}>{c.dial_code} {c.code} - {c.name}</MenuItem>
-                ))}
-              </TextField>
-              <PatternTextField
-                label="Number"
-                value={phone.phone_number}
-                onChange={(raw) => phones.update(idx, 'phone_number', raw)}
-                pattern={country?.placeholder}
-                size="small"
-                sx={{ flex: 1, minWidth: 160 }}
-              />
-              <FormControlLabel
-                control={<Checkbox checked={phone.is_primary} onChange={(e) => phones.update(idx, 'is_primary', e.target.checked)} size="small" />}
-                label="Primary"
-                sx={{ mr: 0 }}
-              />
-              <IconButton size="small" onClick={() => phones.remove(idx)} color="error">
-                <DeleteOutlineIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          );
-        })}
-
-        {/* ── Emails ────────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Emails</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
-        </Box>
-        {emails.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No emails</Typography>
-        )}
-        {emails.visibleItems.map((em) => {
-          const idx = emails.items.indexOf(em);
-          const isLoginEmail = em.is_login && editForm.is_app_user;
-          return (
-            <Box key={em.id || idx} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-              <TextField
-                label="Email"
-                type="email"
-                value={em.email}
-                onChange={(e) => emails.update(idx, 'email', e.target.value)}
-                size="small"
-                sx={{ flex: 1, minWidth: 200 }}
-              />
-              <TextField
-                select
-                label="Label"
-                value={em.label}
-                onChange={(e) => emails.update(idx, 'label', e.target.value)}
-                sx={{ minWidth: 120 }}
-                size="small"
-              >
-                {EMAIL_LABELS.map((l) => (
-                  <MenuItem key={l} value={l}>{cap(l)}</MenuItem>
-                ))}
-              </TextField>
-              <FormControlLabel
-                control={<Checkbox checked={em.is_primary} onChange={(e) => emails.update(idx, 'is_primary', e.target.checked)} size="small" />}
-                label="Primary"
-                sx={{ mr: 0 }}
-              />
-              {editForm.is_app_user && (
-                <FormControlLabel
-                  control={<Checkbox checked={em.is_login} onChange={(e) => emails.update(idx, 'is_login', e.target.checked)} size="small" disabled={editDialog.data?.is_app_user} />}
-                  label="Login"
-                  sx={{ mr: 0 }}
-                />
-              )}
-              <IconButton size="small" onClick={() => emails.remove(idx)} color="error" disabled={isLoginEmail}>
-                <DeleteOutlineIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          );
-        })}
-
-        {/* ── Addresses ──────────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Addresses</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
-        </Box>
-        {addresses.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No addresses</Typography>
-        )}
-        {addresses.visibleItems.map((addr) => {
-          const idx = addresses.items.indexOf(addr);
-          return (
-            <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                <TextField
-                  label="Label"
-                  value={addr.label}
-                  onChange={(e) => addresses.update(idx, 'label', e.target.value)}
-                  size="small"
-                  sx={{ width: 200 }}
-                />
-                <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Box>
-              <Box sx={formGridSx}>
-                <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
-                <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
-                <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
-                <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
-              </Box>
-            </Box>
-          );
-        })}
-
-        {/* ── Tax Identifiers ──────────────────────────────────── */}
-        <Divider />
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Typography variant="subtitle2">Tax Identifiers</Typography>
-          <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
-        </Box>
-        {taxIds.visibleItems.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
-        )}
-        {taxIds.visibleItems.map((taxId) => {
-          const idx = taxIds.items.indexOf(taxId);
-          const countryCode = taxId.country_code?.trim() || '';
-          const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
-          return (
-            <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-                <TextField
-                  select
-                  label="Country"
-                  value={countryCode}
-                  onChange={(e) => {
-                    taxIds.update(idx, 'country_code', e.target.value);
-                    const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                    taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
-                  }}
-                  SelectProps={{ renderValue: (val) => val }}
-                  size="small"
-                  sx={{ minWidth: 80 }}
-                >
-                  {COUNTRIES.map((c) => (
-                    <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
-                  ))}
-                </TextField>
-                <TextField
-                  select
-                  label="Type"
-                  value={taxId.tax_type}
-                  onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
-                  SelectProps={{ renderValue: (val) => val }}
-                  size="small"
-                  sx={{ minWidth: 80 }}
-                >
-                  {taxTypes.map((t) => (
-                    <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
-                  ))}
-                </TextField>
-                <PatternTextField
-                  label="Tax ID Value"
-                  value={taxId.tax_value}
-                  onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
-                  pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
-                  size="small"
-                  sx={{ flex: 1, minWidth: 160 }}
-                />
-                <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            </Box>
-          );
-        })}
-      </FormDialog>
+      <EmployeeEditDialog
+        open={editDialog.isOpen}
+        onClose={handleEditClose}
+        editForm={editForm}
+        onEditField={onEditField}
+        setEditForm={setEditForm}
+        editRow={editDialog.data}
+        emails={emails}
+        phones={phones}
+        addresses={addresses}
+        taxIds={taxIds}
+        roleOptions={roleOptions}
+        hasEditChanges={hasEditChanges}
+        onSubmit={async () => { if (await handleUpdate()) handleEditClose(); }}
+        loading={updateMut.isPending}
+        canResetPassword={canResetPassword}
+        onResetPassword={() => resetPwDialog.open(editDialog.data)}
+        onAppUserToggle={handleAppUserToggle('edit', setEditForm)}
+      />
 
       <ImportDialog
-        open={importDialog.isOpen}
-        title="Import Employees"
-        loading={importMut.isPending}
+        open={importDialog.isOpen} title="Import Employees" loading={importMut.isPending}
         errors={importErrors}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
@@ -816,7 +367,6 @@ export default function EmployeesPage() {
       />
 
       <SetPasswordPopover anchorEl={pwAnchor} onConfirm={handlePwConfirm} onCancel={handlePwCancel} />
-
       <ToastSnackbar {...snackProps} />
     </Box>
   );

--- a/apps/nap-client/src/pages/Core/clients/ClientEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/clients/ClientEditDialog.jsx
@@ -1,0 +1,192 @@
+/**
+ * @file Edit Client dialog with sub-collection editors
+ * @module nap-client/pages/Core/clients/ClientEditDialog
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Autocomplete from '@mui/material/Autocomplete';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import LockResetIcon from '@mui/icons-material/LockReset';
+
+import FormDialog from '../../../components/shared/FormDialog.jsx';
+import PatternTextField from '../../../components/shared/PatternTextField.jsx';
+import EmailRow from '../../../components/shared/EmailRow.jsx';
+import PhoneRow from '../../../components/shared/PhoneRow.jsx';
+import { TAX_TYPES, COUNTRIES } from '@nap/shared';
+import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
+
+export default function ClientEditDialog({
+  open,
+  onClose,
+  editForm,
+  onEditField,
+  setEditForm,
+  editRow,
+  emails,
+  phones,
+  addresses,
+  taxIds,
+  roleOptions,
+  hasEditChanges,
+  onSubmit,
+  loading,
+  onResetPassword,
+  onAppUserToggle,
+}) {
+  return (
+    <FormDialog open={open} title="Edit Client" submitLabel="Save Changes" maxWidth="md" loading={loading} submitDisabled={!hasEditChanges} onSubmit={onSubmit} onCancel={onClose}>
+      <Box sx={formGridSx}>
+        <TextField label="Client Name" required value={editForm.name} onChange={onEditField('name')} />
+        <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={editForm.is_active}
+              onChange={(e) => setEditForm((p) => ({ ...p, is_active: e.target.checked }))}
+              size="small"
+            />
+          }
+          label="Active"
+        />
+        <FormControlLabel
+          control={<Checkbox checked={editForm.is_app_user} onChange={onAppUserToggle} size="small" />}
+          label="App User (creates login account)"
+        />
+        {editForm.is_app_user && editRow?.is_app_user && (
+          <Button size="small" startIcon={<LockResetIcon />} onClick={onResetPassword}>
+            Reset Password
+          </Button>
+        )}
+        <Autocomplete
+          multiple
+          options={roleOptions}
+          getOptionLabel={(opt) => opt.name}
+          isOptionEqualToValue={(opt, val) => opt.code === val.code}
+          value={roleOptions.filter((r) => editForm.roles.includes(r.code))}
+          onChange={(_, v) => setEditForm((p) => ({ ...p, roles: v.map((r) => r.code) }))}
+          renderInput={(params) => <TextField {...params} label="Roles" />}
+          sx={formFullSpanSx}
+        />
+      </Box>
+
+      {/* ── Emails ────────────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Emails</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
+      </Box>
+      {emails.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No emails</Typography>
+      )}
+      {emails.indexedItems.map(({ item: em, index: idx }) => (
+        <EmailRow key={em.id || idx} item={em} index={idx} onUpdate={emails.update} onRemove={emails.remove} />
+      ))}
+
+      {/* ── Phone Numbers ──────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Phone Numbers</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
+      </Box>
+      {phones.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
+      )}
+      {phones.indexedItems.map(({ item: phone, index: idx }) => (
+        <PhoneRow key={phone.id || idx} item={phone} index={idx} onUpdate={phones.update} onRemove={phones.remove} />
+      ))}
+
+      {/* ── Addresses ──────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Addresses</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
+      </Box>
+      {addresses.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No addresses</Typography>
+      )}
+      {addresses.indexedItems.map(({ item: addr, index: idx }) => (
+        <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+            <TextField label="Label" value={addr.label} onChange={(e) => addresses.update(idx, 'label', e.target.value)} size="small" sx={{ width: 200 }} />
+            <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
+              <DeleteOutlineIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <Box sx={formGridSx}>
+            <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
+            <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
+            <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
+            <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
+          </Box>
+        </Box>
+      ))}
+
+      {/* ── Tax Identifiers ──────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Tax Identifiers</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
+      </Box>
+      {taxIds.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
+      )}
+      {taxIds.indexedItems.map(({ item: taxId, index: idx }) => {
+        const countryCode = taxId.country_code?.trim() || '';
+        const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
+        return (
+          <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+              <TextField
+                select label="Country" value={countryCode}
+                onChange={(e) => {
+                  taxIds.update(idx, 'country_code', e.target.value);
+                  const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
+                  taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
+                }}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small" sx={{ minWidth: 80 }}
+              >
+                {COUNTRIES.map((c) => (
+                  <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                select label="Type" value={taxId.tax_type}
+                onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small" sx={{ minWidth: 80 }}
+              >
+                {taxTypes.map((t) => (
+                  <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
+                ))}
+              </TextField>
+              <PatternTextField
+                label="Tax ID Value" value={taxId.tax_value}
+                onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
+                pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
+                size="small" sx={{ flex: 1, minWidth: 160 }}
+              />
+              <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
+                <DeleteOutlineIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          </Box>
+        );
+      })}
+    </FormDialog>
+  );
+}

--- a/apps/nap-client/src/pages/Core/clients/ClientViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/clients/ClientViewDialog.jsx
@@ -1,0 +1,75 @@
+/**
+ * @file Read-only Client detail dialog
+ * @module nap-client/pages/Core/clients/ClientViewDialog
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+
+import FieldRow from '../../../components/shared/FieldRow.jsx';
+import StatusBadge from '../../../components/shared/StatusBadge.jsx';
+import EmailsSection from '../../../components/shared/EmailsSection.jsx';
+import PhoneNumbersSection from '../../../components/shared/PhoneNumbersSection.jsx';
+import AddressesSection from '../../../components/shared/AddressesSection.jsx';
+import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
+import { fmtDate } from '../../../utils/format.js';
+import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+
+export default function ClientViewDialog({
+  open,
+  onClose,
+  client,
+  viewEmails,
+  viewPhones,
+  viewAddresses,
+  viewTaxIds,
+}) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={dialogHeaderSx}>
+        <Box>
+          <span>Client Details</span>
+          {client && (
+            <Typography variant="body2" color="text.secondary">
+              {client.name}
+            </Typography>
+          )}
+        </Box>
+        <Box sx={dialogActionBoxSx}>
+          <Button size="small" color="inherit" onClick={onClose}>
+            Close
+          </Button>
+        </Box>
+      </DialogTitle>
+      <DialogContent dividers>
+        {client && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={detailGridSx}>
+              <FieldRow label="Code" value={client.code || '\u2014'} />
+              <FieldRow label="Name" value={client.name} />
+              <FieldRow label="Active" value={client.is_active ? 'Yes' : 'No'} />
+              <FieldRow label="App User" value={client.is_app_user ? 'Yes' : 'No'} />
+              <FieldRow label="Roles" value={client.roles?.length ? client.roles.join(', ') : '\u2014'} />
+              <FieldRow label="Status">
+                <StatusBadge status={client.deactivated_at ? 'archived' : 'active'} />
+              </FieldRow>
+              <FieldRow label="Created" value={fmtDate(client.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(client.updated_at)} />
+            </Box>
+
+            <EmailsSection emails={viewEmails} />
+            <PhoneNumbersSection phones={viewPhones} />
+            <AddressesSection addresses={viewAddresses} />
+            <TaxIdentifiersSection taxIds={viewTaxIds} />
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/nap-client/src/pages/Core/clients/useClientEditCollections.jsx
+++ b/apps/nap-client/src/pages/Core/clients/useClientEditCollections.jsx
@@ -149,14 +149,15 @@ export function useClientEditCollections({
     setEditForm(form);
     editInitial.current.form = form;
 
+    // Always clear sub-collection state when starting a new edit session
+    // to avoid briefly showing the previous row's data while queries load.
+    emails.reset([]); phones.reset([]); addresses.reset([]); taxIds.reset([]);
+    editInitial.current.emails = [];
+    editInitial.current.phones = [];
+    editInitial.current.addresses = [];
+    editInitial.current.taxIds = [];
+
     setEditSourceId(row.source_id || null);
-    if (!row.source_id) {
-      emails.reset([]); phones.reset([]); addresses.reset([]); taxIds.reset([]);
-      editInitial.current.emails = [];
-      editInitial.current.phones = [];
-      editInitial.current.addresses = [];
-      editInitial.current.taxIds = [];
-    }
   }, []);
 
   /** Reset all edit state. */

--- a/apps/nap-client/src/pages/Core/clients/useClientEditCollections.jsx
+++ b/apps/nap-client/src/pages/Core/clients/useClientEditCollections.jsx
@@ -1,0 +1,177 @@
+/**
+ * @file Client edit sub-collection management hook
+ * @module nap-client/pages/Core/clients/useClientEditCollections
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+
+import { useEmails } from '../../../hooks/useEmails.js';
+import { usePhoneNumbers } from '../../../hooks/usePhoneNumbers.js';
+import { useAddresses } from '../../../hooks/useAddresses.js';
+import { useTaxIdentifiers } from '../../../hooks/useTaxIdentifiers.js';
+import { useCollectionState } from '../../../hooks/useCollectionState.js';
+import { saveCollection } from '../../../utils/saveCollection.js';
+import { errMsg } from '../../../utils/format.js';
+import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID } from '../../../utils/formConstants.js';
+
+export function useClientEditCollections({
+  editOpen,
+  editRow,
+  editForm,
+  updateMut,
+  toast,
+  qc,
+  emailMuts,
+  phoneMuts,
+  addressMuts,
+  taxIdMuts,
+}) {
+  /* ── Query-trigger state ─────────────────────────────────────── */
+  const [editSourceId, setEditSourceId] = useState(null);
+
+  /* ── React Query: edit-mode sub-collection queries ───────────── */
+  const { data: emailsRes } = useEmails({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: phonesRes } = usePhoneNumbers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: addressesRes } = useAddresses({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: taxIdsRes } = useTaxIdentifiers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+
+  /* ── Collection state ────────────────────────────────────────── */
+  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
+  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
+  const editInitial = useRef({ form: null, emails: null, phones: null, addresses: null, taxIds: null });
+
+  /* ── Sync query data into collection state ───────────────────── */
+  useEffect(() => {
+    if (editOpen && emailsRes?.rows) {
+      emails.reset(emailsRes.rows);
+      editInitial.current.emails = emailsRes.rows;
+    }
+  }, [editOpen, emailsRes]);
+
+  useEffect(() => {
+    if (editOpen && phonesRes?.rows) {
+      phones.reset(phonesRes.rows);
+      editInitial.current.phones = phonesRes.rows;
+    }
+  }, [editOpen, phonesRes]);
+
+  useEffect(() => {
+    if (editOpen && addressesRes?.rows) {
+      addresses.reset(addressesRes.rows);
+      editInitial.current.addresses = addressesRes.rows;
+    }
+  }, [editOpen, addressesRes]);
+
+  useEffect(() => {
+    if (editOpen && taxIdsRes?.rows) {
+      taxIds.reset(taxIdsRes.rows);
+      editInitial.current.taxIds = taxIdsRes.rows;
+    }
+  }, [editOpen, taxIdsRes]);
+
+  /* ── Dirty check ─────────────────────────────────────────────── */
+  const hasEditChanges = useMemo(() => {
+    const init = editInitial.current;
+    if (!init.form) return false;
+    if (JSON.stringify(editForm) !== JSON.stringify(init.form)) return true;
+    const collectionChanged = (current, initial, fields) => {
+      if (!initial) return false;
+      if (current.some((c) => c._deleted)) return true;
+      if (current.some((c) => !c.id && !c._deleted)) return true;
+      const initMap = new Map(initial.map((r) => [r.id, r]));
+      return current.filter((c) => c.id && !c._deleted).some((c) => {
+        const orig = initMap.get(c.id);
+        return !orig || fields.some((f) => c[f] !== orig[f]);
+      });
+    };
+    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary'])) return true;
+    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
+    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
+    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
+    return false;
+  }, [editForm, emails.items, phones.items, addresses.items, taxIds.items]);
+
+  /* ── Save handler ────────────────────────────────────────────── */
+  const handleUpdate = async () => {
+    try {
+      const changes = { ...editForm };
+      if (changes.is_app_user && !editRow.is_app_user) {
+        const loginEm = emails.items.find((em) => em.is_login && !em._deleted)
+          || emails.items.find((em) => em.is_primary && !em._deleted)
+          || emails.items.find((em) => !em._deleted);
+        if (loginEm) changes.email = loginEm.email;
+      }
+      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes });
+
+      if (editRow.source_id) {
+        const sid = editRow.source_id;
+        await saveCollection(emails.items, {
+          sourceId: sid, fields: ['email', 'label', 'is_primary'],
+          createMut: emailMuts.create.mutateAsync, updateMut: emailMuts.update.mutateAsync, archiveMut: emailMuts.archive.mutateAsync,
+        });
+        await saveCollection(phones.items, {
+          sourceId: sid, fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
+          createMut: phoneMuts.create.mutateAsync, updateMut: phoneMuts.update.mutateAsync, archiveMut: phoneMuts.archive.mutateAsync,
+        });
+        await saveCollection(addresses.items, {
+          sourceId: sid, fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+          createMut: addressMuts.create.mutateAsync, updateMut: addressMuts.update.mutateAsync, archiveMut: addressMuts.archive.mutateAsync,
+        });
+        await saveCollection(taxIds.items, {
+          sourceId: sid, fields: ['country_code', 'tax_type', 'tax_value'],
+          createMut: taxIdMuts.create.mutateAsync, updateMut: taxIdMuts.update.mutateAsync, archiveMut: taxIdMuts.archive.mutateAsync,
+        });
+      }
+
+      await qc.invalidateQueries({ queryKey: ['clients'] });
+      if (editForm.is_app_user !== editRow.is_app_user) {
+        qc.invalidateQueries({ queryKey: ['nap-users'] });
+      }
+      toast('Client updated');
+      return true;
+    } catch (err) {
+      toast(errMsg(err), 'error');
+      return false;
+    }
+  };
+
+  /** Seed all edit state from a client row. */
+  const openEditSession = useCallback((row, setEditForm) => {
+    const form = {
+      name: row.name ?? '', code: row.code ?? '',
+      is_active: row.is_active ?? true, is_app_user: row.is_app_user ?? false,
+      roles: row.roles ?? [],
+    };
+    setEditForm(form);
+    editInitial.current.form = form;
+
+    setEditSourceId(row.source_id || null);
+    if (!row.source_id) {
+      emails.reset([]); phones.reset([]); addresses.reset([]); taxIds.reset([]);
+      editInitial.current.emails = [];
+      editInitial.current.phones = [];
+      editInitial.current.addresses = [];
+      editInitial.current.taxIds = [];
+    }
+  }, []);
+
+  /** Reset all edit state. */
+  const closeEditSession = useCallback(() => {
+    setEditSourceId(null);
+  }, []);
+
+  return {
+    emails,
+    phones,
+    addresses,
+    taxIds,
+    hasEditChanges,
+    handleUpdate,
+    openEditSession,
+    closeEditSession,
+  };
+}

--- a/apps/nap-client/src/pages/Core/companies/CompanyEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/companies/CompanyEditDialog.jsx
@@ -1,0 +1,144 @@
+/**
+ * @file Edit Company dialog with address + tax ID editors
+ * @module nap-client/pages/Core/companies/CompanyEditDialog
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import FormDialog from '../../../components/shared/FormDialog.jsx';
+import PatternTextField from '../../../components/shared/PatternTextField.jsx';
+import { TAX_TYPES, COUNTRIES } from '@nap/shared';
+import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
+
+export default function CompanyEditDialog({
+  open,
+  onClose,
+  editForm,
+  onEditField,
+  setEditForm,
+  editRow,
+  addresses,
+  taxIds,
+  hasEditChanges,
+  onSubmit,
+  loading,
+}) {
+  const hasSource = !!editRow?.source_id;
+
+  return (
+    <FormDialog open={open} title="Edit Company" submitLabel="Save Changes" loading={loading} submitDisabled={!hasEditChanges} onSubmit={onSubmit} onCancel={onClose}>
+      <TextField label="Company Name" required value={editForm.name} onChange={onEditField('name')} />
+      <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={editForm.is_active}
+            onChange={(e) => setEditForm((p) => ({ ...p, is_active: e.target.checked }))}
+            size="small"
+          />
+        }
+        label="Active"
+      />
+
+      {/* ── Addresses ───────────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Addresses</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={addresses.add} disabled={!hasSource}>Add Address</Button>
+      </Box>
+      {!hasSource && (
+        <Typography variant="body2" color="text.secondary">Save company first to manage addresses</Typography>
+      )}
+      {addresses.indexedItems.length === 0 && hasSource && (
+        <Typography variant="body2" color="text.secondary">No addresses</Typography>
+      )}
+      {addresses.indexedItems.map(({ item: addr, index: idx }) => (
+        <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+            <TextField label="Label" value={addr.label} onChange={(e) => addresses.update(idx, 'label', e.target.value)} size="small" sx={{ width: 200 }} />
+            <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
+              <DeleteOutlineIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <Box sx={formGridSx}>
+            <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
+            <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
+            <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
+            <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
+          </Box>
+        </Box>
+      ))}
+
+      {/* ── Tax Identifiers ─────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Tax Identifiers</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add} disabled={!hasSource}>Add Tax ID</Button>
+      </Box>
+      {!hasSource && (
+        <Typography variant="body2" color="text.secondary">Save company first to manage tax identifiers</Typography>
+      )}
+      {taxIds.indexedItems.length === 0 && hasSource && (
+        <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
+      )}
+      {taxIds.indexedItems.map(({ item: taxId, index: idx }) => {
+        const countryCode = taxId.country_code?.trim() || '';
+        const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
+        return (
+          <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+              <TextField
+                select label="Country" value={countryCode}
+                onChange={(e) => {
+                  taxIds.update(idx, 'country_code', e.target.value);
+                  const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
+                  taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
+                }}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small" sx={{ minWidth: 80 }}
+              >
+                {COUNTRIES.map((c) => (
+                  <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                select label="Type" value={taxId.tax_type}
+                onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small" sx={{ minWidth: 80 }}
+              >
+                {taxTypes.map((t) => (
+                  <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
+                ))}
+              </TextField>
+              <PatternTextField
+                label="Tax ID Value" value={taxId.tax_value}
+                onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
+                pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
+                size="small" sx={{ flex: 1, minWidth: 160 }}
+              />
+              <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
+                <DeleteOutlineIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          </Box>
+        );
+      })}
+    </FormDialog>
+  );
+}

--- a/apps/nap-client/src/pages/Core/companies/CompanyViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/companies/CompanyViewDialog.jsx
@@ -1,0 +1,66 @@
+/**
+ * @file Read-only Company detail dialog
+ * @module nap-client/pages/Core/companies/CompanyViewDialog
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+
+import FieldRow from '../../../components/shared/FieldRow.jsx';
+import StatusBadge from '../../../components/shared/StatusBadge.jsx';
+import AddressesSection from '../../../components/shared/AddressesSection.jsx';
+import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
+import { fmtDate } from '../../../utils/format.js';
+import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+
+export default function CompanyViewDialog({
+  open,
+  onClose,
+  company,
+  viewAddresses,
+  viewTaxIds,
+}) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={dialogHeaderSx}>
+        <Box>
+          <span>Company Details</span>
+          {company && (
+            <Typography variant="body2" color="text.secondary">
+              {company.name}
+            </Typography>
+          )}
+        </Box>
+        <Box sx={dialogActionBoxSx}>
+          <Button size="small" color="inherit" onClick={onClose}>
+            Close
+          </Button>
+        </Box>
+      </DialogTitle>
+      <DialogContent dividers>
+        {company && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={detailGridSx}>
+              <FieldRow label="Code" value={company.code || '\u2014'} />
+              <FieldRow label="Name" value={company.name} />
+              <FieldRow label="Active" value={company.is_active ? 'Yes' : 'No'} />
+              <FieldRow label="Status">
+                <StatusBadge status={company.deactivated_at ? 'archived' : 'active'} />
+              </FieldRow>
+              <FieldRow label="Created" value={fmtDate(company.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(company.updated_at)} />
+            </Box>
+            <AddressesSection addresses={viewAddresses} />
+            <TaxIdentifiersSection taxIds={viewTaxIds} />
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/nap-client/src/pages/Core/companies/useCompanyEditCollections.jsx
+++ b/apps/nap-client/src/pages/Core/companies/useCompanyEditCollections.jsx
@@ -95,12 +95,13 @@ export function useCompanyEditCollections({
     setEditForm(form);
     editInitial.current.form = form;
 
+    // Always clear sub-collection state when starting a new edit session
+    // to avoid briefly showing the previous row's data while queries load.
+    addresses.reset([]); taxIds.reset([]);
+    editInitial.current.addresses = [];
+    editInitial.current.taxIds = [];
+
     setEditSourceId(row.source_id || null);
-    if (!row.source_id) {
-      addresses.reset([]); taxIds.reset([]);
-      editInitial.current.addresses = [];
-      editInitial.current.taxIds = [];
-    }
   }, []);
 
   const closeEditSession = useCallback(() => {

--- a/apps/nap-client/src/pages/Core/companies/useCompanyEditCollections.jsx
+++ b/apps/nap-client/src/pages/Core/companies/useCompanyEditCollections.jsx
@@ -1,0 +1,115 @@
+/**
+ * @file Company edit sub-collection management hook (addresses + tax IDs only)
+ * @module nap-client/pages/Core/companies/useCompanyEditCollections
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+
+import { useAddresses } from '../../../hooks/useAddresses.js';
+import { useTaxIdentifiers } from '../../../hooks/useTaxIdentifiers.js';
+import { useCollectionState } from '../../../hooks/useCollectionState.js';
+import { saveCollection } from '../../../utils/saveCollection.js';
+import { errMsg } from '../../../utils/format.js';
+import { BLANK_ADDRESS, BLANK_TAX_ID } from '../../../utils/formConstants.js';
+
+export function useCompanyEditCollections({
+  editOpen,
+  editRow,
+  editForm,
+  updateMut,
+  toast,
+  addressMuts,
+  taxIdMuts,
+}) {
+  const [editSourceId, setEditSourceId] = useState(null);
+
+  const { data: addressesRes } = useAddresses({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: taxIdsRes } = useTaxIdentifiers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+
+  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
+  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
+  const editInitial = useRef({ form: null, addresses: null, taxIds: null });
+
+  useEffect(() => {
+    if (editOpen && addressesRes?.rows) {
+      addresses.reset(addressesRes.rows);
+      editInitial.current.addresses = addressesRes.rows;
+    }
+  }, [editOpen, addressesRes]);
+
+  useEffect(() => {
+    if (editOpen && taxIdsRes?.rows) {
+      taxIds.reset(taxIdsRes.rows);
+      editInitial.current.taxIds = taxIdsRes.rows;
+    }
+  }, [editOpen, taxIdsRes]);
+
+  const hasEditChanges = useMemo(() => {
+    const init = editInitial.current;
+    if (!init.form) return false;
+    if (JSON.stringify(editForm) !== JSON.stringify(init.form)) return true;
+    const collectionChanged = (current, initial, fields) => {
+      if (!initial) return false;
+      if (current.some((c) => c._deleted)) return true;
+      if (current.some((c) => !c.id && !c._deleted)) return true;
+      const initMap = new Map(initial.map((r) => [r.id, r]));
+      return current.filter((c) => c.id && !c._deleted).some((c) => {
+        const orig = initMap.get(c.id);
+        return !orig || fields.some((f) => c[f] !== orig[f]);
+      });
+    };
+    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
+    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
+    return false;
+  }, [editForm, addresses.items, taxIds.items]);
+
+  const handleUpdate = async () => {
+    try {
+      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+
+      if (editRow.source_id) {
+        await saveCollection(addresses.items, {
+          sourceId: editRow.source_id,
+          fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+          createMut: addressMuts.create.mutateAsync, updateMut: addressMuts.update.mutateAsync, archiveMut: addressMuts.archive.mutateAsync,
+        });
+        await saveCollection(taxIds.items, {
+          sourceId: editRow.source_id,
+          fields: ['country_code', 'tax_type', 'tax_value'],
+          createMut: taxIdMuts.create.mutateAsync, updateMut: taxIdMuts.update.mutateAsync, archiveMut: taxIdMuts.archive.mutateAsync,
+        });
+      }
+
+      toast('Company updated');
+      return true;
+    } catch (err) {
+      toast(errMsg(err), 'error');
+      return false;
+    }
+  };
+
+  const openEditSession = useCallback((row, setEditForm) => {
+    const form = { name: row.name ?? '', code: row.code ?? '', is_active: row.is_active ?? true };
+    setEditForm(form);
+    editInitial.current.form = form;
+
+    setEditSourceId(row.source_id || null);
+    if (!row.source_id) {
+      addresses.reset([]); taxIds.reset([]);
+      editInitial.current.addresses = [];
+      editInitial.current.taxIds = [];
+    }
+  }, []);
+
+  const closeEditSession = useCallback(() => {
+    setEditSourceId(null);
+  }, []);
+
+  return {
+    addresses, taxIds,
+    hasEditChanges, handleUpdate,
+    openEditSession, closeEditSession,
+  };
+}

--- a/apps/nap-client/src/pages/Core/contacts/StandaloneContactEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/contacts/StandaloneContactEditDialog.jsx
@@ -1,0 +1,167 @@
+/**
+ * @file Edit standalone Contact dialog with sub-collection editors
+ * @module nap-client/pages/Core/contacts/StandaloneContactEditDialog
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import FormDialog from '../../../components/shared/FormDialog.jsx';
+import PatternTextField from '../../../components/shared/PatternTextField.jsx';
+import EmailRow from '../../../components/shared/EmailRow.jsx';
+import PhoneRow from '../../../components/shared/PhoneRow.jsx';
+import { TAX_TYPES, COUNTRIES } from '@nap/shared';
+import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
+
+export default function StandaloneContactEditDialog({
+  open,
+  onClose,
+  editForm,
+  onEditField,
+  setEditForm,
+  emails,
+  phones,
+  addresses,
+  taxIds,
+  hasEditChanges,
+  onSubmit,
+  loading,
+}) {
+  return (
+    <FormDialog open={open} title="Edit Contact" submitLabel="Save Changes" maxWidth="md" loading={loading} submitDisabled={!hasEditChanges} onSubmit={onSubmit} onCancel={onClose}>
+      <Box sx={formGridSx}>
+        <TextField label="Contact Name" required value={editForm.name} onChange={onEditField('name')} />
+        <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={editForm.is_active}
+              onChange={(e) => setEditForm((p) => ({ ...p, is_active: e.target.checked }))}
+              size="small"
+            />
+          }
+          label="Active"
+        />
+      </Box>
+
+      {/* ── Emails ─────────────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Emails</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
+      </Box>
+      {emails.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No emails</Typography>
+      )}
+      {emails.indexedItems.map(({ item: em, index: idx }) => (
+        <EmailRow key={em.id || idx} item={em} index={idx} onUpdate={emails.update} onRemove={emails.remove} />
+      ))}
+
+      {/* ── Phone Numbers ──────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Phone Numbers</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
+      </Box>
+      {phones.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
+      )}
+      {phones.indexedItems.map(({ item: phone, index: idx }) => (
+        <PhoneRow key={phone.id || idx} item={phone} index={idx} onUpdate={phones.update} onRemove={phones.remove} />
+      ))}
+
+      {/* ── Addresses ──────────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Addresses</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
+      </Box>
+      {addresses.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No addresses</Typography>
+      )}
+      {addresses.indexedItems.map(({ item: addr, index: idx }) => (
+        <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+            <TextField label="Label" value={addr.label} onChange={(e) => addresses.update(idx, 'label', e.target.value)} size="small" sx={{ width: 200 }} />
+            <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
+              <DeleteOutlineIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <Box sx={formGridSx}>
+            <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
+            <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
+            <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
+            <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
+          </Box>
+        </Box>
+      ))}
+
+      {/* ── Tax Identifiers ────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Tax Identifiers</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
+      </Box>
+      {taxIds.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
+      )}
+      {taxIds.indexedItems.map(({ item: taxId, index: idx }) => {
+        const countryCode = taxId.country_code?.trim() || '';
+        const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
+        return (
+          <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+              <TextField
+                select label="Country" value={countryCode}
+                onChange={(e) => {
+                  taxIds.update(idx, 'country_code', e.target.value);
+                  const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
+                  taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
+                }}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small" sx={{ minWidth: 80 }}
+              >
+                {COUNTRIES.map((c) => (
+                  <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                select label="Type" value={taxId.tax_type}
+                onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small" sx={{ minWidth: 80 }}
+              >
+                {taxTypes.map((t) => (
+                  <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
+                ))}
+              </TextField>
+              <PatternTextField
+                label="Tax ID Value" value={taxId.tax_value}
+                onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
+                pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
+                size="small" sx={{ flex: 1, minWidth: 160 }}
+              />
+              <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
+                <DeleteOutlineIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          </Box>
+        );
+      })}
+    </FormDialog>
+  );
+}

--- a/apps/nap-client/src/pages/Core/contacts/StandaloneContactViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/contacts/StandaloneContactViewDialog.jsx
@@ -1,0 +1,73 @@
+/**
+ * @file Read-only standalone Contact detail dialog
+ * @module nap-client/pages/Core/contacts/StandaloneContactViewDialog
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+
+import FieldRow from '../../../components/shared/FieldRow.jsx';
+import StatusBadge from '../../../components/shared/StatusBadge.jsx';
+import EmailsSection from '../../../components/shared/EmailsSection.jsx';
+import PhoneNumbersSection from '../../../components/shared/PhoneNumbersSection.jsx';
+import AddressesSection from '../../../components/shared/AddressesSection.jsx';
+import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
+import { fmtDate } from '../../../utils/format.js';
+import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+
+export default function StandaloneContactViewDialog({
+  open,
+  onClose,
+  contact,
+  viewEmails,
+  viewPhones,
+  viewAddresses,
+  viewTaxIds,
+}) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={dialogHeaderSx}>
+        <Box>
+          <span>Contact Details</span>
+          {contact && (
+            <Typography variant="body2" color="text.secondary">
+              {contact.name}
+            </Typography>
+          )}
+        </Box>
+        <Box sx={dialogActionBoxSx}>
+          <Button size="small" color="inherit" onClick={onClose}>
+            Close
+          </Button>
+        </Box>
+      </DialogTitle>
+      <DialogContent dividers>
+        {contact && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={detailGridSx}>
+              <FieldRow label="Code" value={contact.code || '\u2014'} />
+              <FieldRow label="Name" value={contact.name} />
+              <FieldRow label="Active" value={contact.is_active ? 'Yes' : 'No'} />
+              <FieldRow label="Status">
+                <StatusBadge status={contact.deactivated_at ? 'archived' : 'active'} />
+              </FieldRow>
+              <FieldRow label="Created" value={fmtDate(contact.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(contact.updated_at)} />
+            </Box>
+
+            <EmailsSection emails={viewEmails} />
+            <PhoneNumbersSection phones={viewPhones} />
+            <AddressesSection addresses={viewAddresses} />
+            <TaxIdentifiersSection taxIds={viewTaxIds} />
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/nap-client/src/pages/Core/contacts/useStandaloneContactEditCollections.jsx
+++ b/apps/nap-client/src/pages/Core/contacts/useStandaloneContactEditCollections.jsx
@@ -129,14 +129,15 @@ export function useStandaloneContactEditCollections({
     setEditForm(form);
     editInitial.current.form = form;
 
+    // Always clear sub-collection state when starting a new edit session
+    // to avoid briefly showing the previous row's data while queries load.
+    emails.reset([]); phones.reset([]); addresses.reset([]); taxIds.reset([]);
+    editInitial.current.emails = [];
+    editInitial.current.phones = [];
+    editInitial.current.addresses = [];
+    editInitial.current.taxIds = [];
+
     setEditSourceId(row.source_id || null);
-    if (!row.source_id) {
-      emails.reset([]); phones.reset([]); addresses.reset([]); taxIds.reset([]);
-      editInitial.current.emails = [];
-      editInitial.current.phones = [];
-      editInitial.current.addresses = [];
-      editInitial.current.taxIds = [];
-    }
   }, []);
 
   const closeEditSession = useCallback(() => {

--- a/apps/nap-client/src/pages/Core/contacts/useStandaloneContactEditCollections.jsx
+++ b/apps/nap-client/src/pages/Core/contacts/useStandaloneContactEditCollections.jsx
@@ -1,0 +1,151 @@
+/**
+ * @file Standalone contact edit sub-collection management hook
+ * @module nap-client/pages/Core/contacts/useStandaloneContactEditCollections
+ *
+ * "Standalone" contacts are the miscellaneous payees on the Core > Contacts page,
+ * distinct from vendor contacts which live under VendorsPage.
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+
+import { useEmails } from '../../../hooks/useEmails.js';
+import { usePhoneNumbers } from '../../../hooks/usePhoneNumbers.js';
+import { useAddresses } from '../../../hooks/useAddresses.js';
+import { useTaxIdentifiers } from '../../../hooks/useTaxIdentifiers.js';
+import { useCollectionState } from '../../../hooks/useCollectionState.js';
+import { saveCollection } from '../../../utils/saveCollection.js';
+import { errMsg } from '../../../utils/format.js';
+import { BLANK_EMAIL, BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID } from '../../../utils/formConstants.js';
+
+export function useStandaloneContactEditCollections({
+  editOpen,
+  editRow,
+  editForm,
+  updateMut,
+  toast,
+  emailMuts,
+  phoneMuts,
+  addressMuts,
+  taxIdMuts,
+}) {
+  const [editSourceId, setEditSourceId] = useState(null);
+
+  const { data: emailsRes } = useEmails({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: phonesRes } = usePhoneNumbers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: addressesRes } = useAddresses({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: taxIdsRes } = useTaxIdentifiers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+
+  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
+  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
+  const editInitial = useRef({ form: null, emails: null, phones: null, addresses: null, taxIds: null });
+
+  useEffect(() => {
+    if (editOpen && emailsRes?.rows) {
+      emails.reset(emailsRes.rows);
+      editInitial.current.emails = emailsRes.rows;
+    }
+  }, [editOpen, emailsRes]);
+
+  useEffect(() => {
+    if (editOpen && phonesRes?.rows) {
+      phones.reset(phonesRes.rows);
+      editInitial.current.phones = phonesRes.rows;
+    }
+  }, [editOpen, phonesRes]);
+
+  useEffect(() => {
+    if (editOpen && addressesRes?.rows) {
+      addresses.reset(addressesRes.rows);
+      editInitial.current.addresses = addressesRes.rows;
+    }
+  }, [editOpen, addressesRes]);
+
+  useEffect(() => {
+    if (editOpen && taxIdsRes?.rows) {
+      taxIds.reset(taxIdsRes.rows);
+      editInitial.current.taxIds = taxIdsRes.rows;
+    }
+  }, [editOpen, taxIdsRes]);
+
+  const hasEditChanges = useMemo(() => {
+    const init = editInitial.current;
+    if (!init.form) return false;
+    if (JSON.stringify(editForm) !== JSON.stringify(init.form)) return true;
+    const collectionChanged = (current, initial, fields) => {
+      if (!initial) return false;
+      if (current.some((c) => c._deleted)) return true;
+      if (current.some((c) => !c.id && !c._deleted)) return true;
+      const initMap = new Map(initial.map((r) => [r.id, r]));
+      return current.filter((c) => c.id && !c._deleted).some((c) => {
+        const orig = initMap.get(c.id);
+        return !orig || fields.some((f) => c[f] !== orig[f]);
+      });
+    };
+    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary'])) return true;
+    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
+    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
+    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
+    return false;
+  }, [editForm, emails.items, phones.items, addresses.items, taxIds.items]);
+
+  const handleUpdate = async () => {
+    try {
+      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes: editForm });
+
+      if (editRow.source_id) {
+        const sid = editRow.source_id;
+        await saveCollection(emails.items, {
+          sourceId: sid, fields: ['email', 'label', 'is_primary'],
+          createMut: emailMuts.create.mutateAsync, updateMut: emailMuts.update.mutateAsync, archiveMut: emailMuts.archive.mutateAsync,
+        });
+        await saveCollection(phones.items, {
+          sourceId: sid, fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
+          createMut: phoneMuts.create.mutateAsync, updateMut: phoneMuts.update.mutateAsync, archiveMut: phoneMuts.archive.mutateAsync,
+        });
+        await saveCollection(addresses.items, {
+          sourceId: sid, fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+          createMut: addressMuts.create.mutateAsync, updateMut: addressMuts.update.mutateAsync, archiveMut: addressMuts.archive.mutateAsync,
+        });
+        await saveCollection(taxIds.items, {
+          sourceId: sid, fields: ['country_code', 'tax_type', 'tax_value'],
+          createMut: taxIdMuts.create.mutateAsync, updateMut: taxIdMuts.update.mutateAsync, archiveMut: taxIdMuts.archive.mutateAsync,
+        });
+      }
+
+      toast('Contact updated');
+      return true;
+    } catch (err) {
+      toast(errMsg(err), 'error');
+      return false;
+    }
+  };
+
+  const openEditSession = useCallback((row, setEditForm) => {
+    const form = { name: row.name ?? '', code: row.code ?? '', is_active: row.is_active ?? true };
+    setEditForm(form);
+    editInitial.current.form = form;
+
+    setEditSourceId(row.source_id || null);
+    if (!row.source_id) {
+      emails.reset([]); phones.reset([]); addresses.reset([]); taxIds.reset([]);
+      editInitial.current.emails = [];
+      editInitial.current.phones = [];
+      editInitial.current.addresses = [];
+      editInitial.current.taxIds = [];
+    }
+  }, []);
+
+  const closeEditSession = useCallback(() => {
+    setEditSourceId(null);
+  }, []);
+
+  return {
+    emails, phones, addresses, taxIds,
+    hasEditChanges, handleUpdate,
+    openEditSession, closeEditSession,
+  };
+}

--- a/apps/nap-client/src/pages/Core/employees/EmployeeEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/employees/EmployeeEditDialog.jsx
@@ -1,0 +1,189 @@
+/**
+ * @file Edit Employee dialog with sub-collection editors
+ * @module nap-client/pages/Core/employees/EmployeeEditDialog
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Autocomplete from '@mui/material/Autocomplete';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import FormDialog from '../../../components/shared/FormDialog.jsx';
+import PatternTextField from '../../../components/shared/PatternTextField.jsx';
+import EmailRow from '../../../components/shared/EmailRow.jsx';
+import PhoneRow from '../../../components/shared/PhoneRow.jsx';
+import { TAX_TYPES, COUNTRIES } from '@nap/shared';
+import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
+
+export default function EmployeeEditDialog({
+  open,
+  onClose,
+  editForm,
+  onEditField,
+  setEditForm,
+  editRow,
+  emails,
+  phones,
+  addresses,
+  taxIds,
+  roleOptions,
+  hasEditChanges,
+  onSubmit,
+  loading,
+  canResetPassword,
+  onResetPassword,
+  onAppUserToggle,
+}) {
+  const onEditCheck = (f) => (e) => setEditForm((p) => ({ ...p, [f]: e.target.checked }));
+
+  return (
+    <FormDialog open={open} title="Edit Employee" submitLabel="Save Changes" maxWidth="md" loading={loading} submitDisabled={!hasEditChanges} onSubmit={onSubmit} onCancel={onClose}>
+      <Box sx={formGridSx}>
+        <TextField label="First Name" required value={editForm.first_name} onChange={onEditField('first_name')} />
+        <TextField label="Last Name" required value={editForm.last_name} onChange={onEditField('last_name')} />
+        <TextField label="Code" value={editForm.code} onChange={onEditField('code')} inputProps={{ maxLength: 16 }} />
+        <TextField label="Position" value={editForm.position} onChange={onEditField('position')} />
+        <TextField label="Department" value={editForm.department} onChange={onEditField('department')} />
+        <FormControlLabel control={<Checkbox checked={editForm.is_app_user} onChange={onAppUserToggle} />} label="App User (creates login account)" />
+        <Autocomplete
+          multiple options={roleOptions} getOptionLabel={(opt) => opt.name}
+          isOptionEqualToValue={(opt, val) => opt.code === val.code}
+          value={roleOptions.filter((r) => editForm.roles.includes(r.code))}
+          onChange={(_, v) => setEditForm((p) => ({ ...p, roles: v.map((r) => r.code) }))}
+          renderInput={(params) => <TextField {...params} label="Roles" />}
+        />
+        <FormControlLabel control={<Checkbox checked={editForm.is_primary_contact} onChange={onEditCheck('is_primary_contact')} />} label="Primary Contact" />
+        <FormControlLabel control={<Checkbox checked={editForm.is_billing_contact} onChange={onEditCheck('is_billing_contact')} />} label="Billing Contact" />
+      </Box>
+
+      {editForm.is_app_user && canResetPassword && (
+        <Button variant="outlined" size="small" onClick={onResetPassword}>
+          Reset Password
+        </Button>
+      )}
+
+      {/* ── Phone Numbers ──────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Phone Numbers</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
+      </Box>
+      {phones.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
+      )}
+      {phones.indexedItems.map(({ item: phone, index: idx }) => (
+        <PhoneRow key={phone.id || idx} item={phone} index={idx} onUpdate={phones.update} onRemove={phones.remove} />
+      ))}
+
+      {/* ── Emails ────────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Emails</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
+      </Box>
+      {emails.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No emails</Typography>
+      )}
+      {emails.indexedItems.map(({ item: em, index: idx }) => (
+        <EmailRow
+          key={em.id || idx} item={em} index={idx}
+          onUpdate={emails.update} onRemove={emails.remove}
+          showLogin={editForm.is_app_user}
+          loginDisabled={editRow?.is_app_user}
+        />
+      ))}
+
+      {/* ── Addresses ──────────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Addresses</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
+      </Box>
+      {addresses.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No addresses</Typography>
+      )}
+      {addresses.indexedItems.map(({ item: addr, index: idx }) => (
+        <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+            <TextField label="Label" value={addr.label} onChange={(e) => addresses.update(idx, 'label', e.target.value)} size="small" sx={{ width: 200 }} />
+            <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
+              <DeleteOutlineIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <Box sx={formGridSx}>
+            <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
+            <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
+            <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
+            <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
+            <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
+          </Box>
+        </Box>
+      ))}
+
+      {/* ── Tax Identifiers ──────────────────────────────────── */}
+      <Divider />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="subtitle2">Tax Identifiers</Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
+      </Box>
+      {taxIds.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
+      )}
+      {taxIds.indexedItems.map(({ item: taxId, index: idx }) => {
+        const countryCode = taxId.country_code?.trim() || '';
+        const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
+        return (
+          <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+              <TextField
+                select label="Country" value={countryCode}
+                onChange={(e) => {
+                  taxIds.update(idx, 'country_code', e.target.value);
+                  const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
+                  taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
+                }}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small" sx={{ minWidth: 80 }}
+              >
+                {COUNTRIES.map((c) => (
+                  <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                select label="Type" value={taxId.tax_type}
+                onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small" sx={{ minWidth: 80 }}
+              >
+                {taxTypes.map((t) => (
+                  <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
+                ))}
+              </TextField>
+              <PatternTextField
+                label="Tax ID Value" value={taxId.tax_value}
+                onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
+                pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
+                size="small" sx={{ flex: 1, minWidth: 160 }}
+              />
+              <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
+                <DeleteOutlineIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          </Box>
+        );
+      })}
+    </FormDialog>
+  );
+}

--- a/apps/nap-client/src/pages/Core/employees/EmployeeEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/employees/EmployeeEditDialog.jsx
@@ -66,7 +66,7 @@ export default function EmployeeEditDialog({
         <FormControlLabel control={<Checkbox checked={editForm.is_billing_contact} onChange={onEditCheck('is_billing_contact')} />} label="Billing Contact" />
       </Box>
 
-      {editForm.is_app_user && canResetPassword && (
+      {editRow?.is_app_user && canResetPassword && (
         <Button variant="outlined" size="small" onClick={onResetPassword}>
           Reset Password
         </Button>

--- a/apps/nap-client/src/pages/Core/employees/EmployeeViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/employees/EmployeeViewDialog.jsx
@@ -1,0 +1,79 @@
+/**
+ * @file Read-only Employee detail dialog
+ * @module nap-client/pages/Core/employees/EmployeeViewDialog
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+
+import FieldRow from '../../../components/shared/FieldRow.jsx';
+import StatusBadge from '../../../components/shared/StatusBadge.jsx';
+import EmailsSection from '../../../components/shared/EmailsSection.jsx';
+import PhoneNumbersSection from '../../../components/shared/PhoneNumbersSection.jsx';
+import AddressesSection from '../../../components/shared/AddressesSection.jsx';
+import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
+import { fmtDate } from '../../../utils/format.js';
+import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+
+export default function EmployeeViewDialog({
+  open,
+  onClose,
+  employee,
+  viewPhones,
+  viewEmails,
+  viewAddresses,
+  viewTaxIds,
+}) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={dialogHeaderSx}>
+        <Box>
+          <span>Employee Details</span>
+          {employee && (
+            <Typography variant="body2" color="text.secondary">
+              {employee.first_name} {employee.last_name}
+            </Typography>
+          )}
+        </Box>
+        <Box sx={dialogActionBoxSx}>
+          <Button size="small" color="inherit" onClick={onClose}>
+            Close
+          </Button>
+        </Box>
+      </DialogTitle>
+      <DialogContent dividers>
+        {employee && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={detailGridSx}>
+              <FieldRow label="Code" value={employee.code || '\u2014'} />
+              <FieldRow label="First Name" value={employee.first_name} />
+              <FieldRow label="Last Name" value={employee.last_name} />
+              <FieldRow label="Position" value={employee.position || '\u2014'} />
+              <FieldRow label="Department" value={employee.department || '\u2014'} />
+              <FieldRow label="App User" value={employee.is_app_user ? 'Yes' : 'No'} />
+              <FieldRow label="Roles" value={(employee.roles ?? []).join(', ') || '\u2014'} />
+              <FieldRow label="Status">
+                <StatusBadge status={employee.deactivated_at ? 'archived' : 'active'} />
+              </FieldRow>
+              <FieldRow label="Primary Contact" value={employee.is_primary_contact ? 'Yes' : 'No'} />
+              <FieldRow label="Billing Contact" value={employee.is_billing_contact ? 'Yes' : 'No'} />
+              <FieldRow label="Created" value={fmtDate(employee.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(employee.updated_at)} />
+            </Box>
+
+            <PhoneNumbersSection phones={viewPhones} />
+            <EmailsSection emails={viewEmails} showLogin />
+            <AddressesSection addresses={viewAddresses} />
+            <TaxIdentifiersSection taxIds={viewTaxIds} />
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/nap-client/src/pages/Core/employees/useEmployeeEditCollections.jsx
+++ b/apps/nap-client/src/pages/Core/employees/useEmployeeEditCollections.jsx
@@ -16,6 +16,7 @@ import { saveCollection } from '../../../utils/saveCollection.js';
 import { errMsg } from '../../../utils/format.js';
 import { BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID } from '../../../utils/formConstants.js';
 
+// Extends shared BLANK_EMAIL with is_login — specific to app-user entities (employees/clients).
 const BLANK_EMAIL = { email: '', label: 'work', is_primary: false, is_login: false };
 
 export function useEmployeeEditCollections({

--- a/apps/nap-client/src/pages/Core/employees/useEmployeeEditCollections.jsx
+++ b/apps/nap-client/src/pages/Core/employees/useEmployeeEditCollections.jsx
@@ -142,14 +142,15 @@ export function useEmployeeEditCollections({
     setEditForm(form);
     editInitial.current.form = form;
 
+    // Always clear sub-collection state when starting a new edit session
+    // to avoid briefly showing the previous row's data while queries load.
+    emails.reset([]); phones.reset([]); addresses.reset([]); taxIds.reset([]);
+    editInitial.current.emails = [];
+    editInitial.current.phones = [];
+    editInitial.current.addresses = [];
+    editInitial.current.taxIds = [];
+
     setEditSourceId(row.source_id || null);
-    if (!row.source_id) {
-      emails.reset([]); phones.reset([]); addresses.reset([]); taxIds.reset([]);
-      editInitial.current.emails = [];
-      editInitial.current.phones = [];
-      editInitial.current.addresses = [];
-      editInitial.current.taxIds = [];
-    }
   }, []);
 
   const closeEditSession = useCallback(() => {

--- a/apps/nap-client/src/pages/Core/employees/useEmployeeEditCollections.jsx
+++ b/apps/nap-client/src/pages/Core/employees/useEmployeeEditCollections.jsx
@@ -1,0 +1,164 @@
+/**
+ * @file Employee edit sub-collection management hook
+ * @module nap-client/pages/Core/employees/useEmployeeEditCollections
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+
+import { useEmails } from '../../../hooks/useEmails.js';
+import { usePhoneNumbers } from '../../../hooks/usePhoneNumbers.js';
+import { useAddresses } from '../../../hooks/useAddresses.js';
+import { useTaxIdentifiers } from '../../../hooks/useTaxIdentifiers.js';
+import { useCollectionState } from '../../../hooks/useCollectionState.js';
+import { saveCollection } from '../../../utils/saveCollection.js';
+import { errMsg } from '../../../utils/format.js';
+import { BLANK_PHONE, BLANK_ADDRESS, BLANK_TAX_ID } from '../../../utils/formConstants.js';
+
+const BLANK_EMAIL = { email: '', label: 'work', is_primary: false, is_login: false };
+
+export function useEmployeeEditCollections({
+  editOpen,
+  editRow,
+  editForm,
+  updateMut,
+  toast,
+  qc,
+  emailMuts,
+  phoneMuts,
+  addressMuts,
+  taxIdMuts,
+}) {
+  const [editSourceId, setEditSourceId] = useState(null);
+
+  const { data: emailsRes } = useEmails({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: phonesRes } = usePhoneNumbers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: addressesRes } = useAddresses({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+  const { data: taxIdsRes } = useTaxIdentifiers({ source_id: editSourceId, includeDeactivated: 'false' }, { enabled: !!editSourceId });
+
+  const emails = useCollectionState([], { blank: BLANK_EMAIL, autoPrimary: 'is_primary', exclusive: ['is_primary', 'is_login'] });
+  const phones = useCollectionState([], { blank: BLANK_PHONE, autoPrimary: 'is_primary', exclusive: ['is_primary'] });
+  const addresses = useCollectionState([], { blank: BLANK_ADDRESS });
+  const taxIds = useCollectionState([], { blank: BLANK_TAX_ID });
+  const editInitial = useRef({ form: null, emails: null, phones: null, addresses: null, taxIds: null });
+
+  useEffect(() => {
+    if (editOpen && emailsRes?.rows) {
+      emails.reset(emailsRes.rows);
+      editInitial.current.emails = emailsRes.rows;
+    }
+  }, [editOpen, emailsRes]);
+
+  useEffect(() => {
+    if (editOpen && phonesRes?.rows) {
+      phones.reset(phonesRes.rows);
+      editInitial.current.phones = phonesRes.rows;
+    }
+  }, [editOpen, phonesRes]);
+
+  useEffect(() => {
+    if (editOpen && addressesRes?.rows) {
+      addresses.reset(addressesRes.rows);
+      editInitial.current.addresses = addressesRes.rows;
+    }
+  }, [editOpen, addressesRes]);
+
+  useEffect(() => {
+    if (editOpen && taxIdsRes?.rows) {
+      taxIds.reset(taxIdsRes.rows);
+      editInitial.current.taxIds = taxIdsRes.rows;
+    }
+  }, [editOpen, taxIdsRes]);
+
+  const hasEditChanges = useMemo(() => {
+    const init = editInitial.current;
+    if (!init.form) return false;
+    if (JSON.stringify(editForm) !== JSON.stringify(init.form)) return true;
+    const collectionChanged = (current, initial, fields) => {
+      if (!initial) return false;
+      if (current.some((c) => c._deleted)) return true;
+      if (current.some((c) => !c.id && !c._deleted)) return true;
+      const initMap = new Map(initial.map((r) => [r.id, r]));
+      return current.filter((c) => c.id && !c._deleted).some((c) => {
+        const orig = initMap.get(c.id);
+        return !orig || fields.some((f) => c[f] !== orig[f]);
+      });
+    };
+    if (collectionChanged(emails.items, init.emails, ['email', 'label', 'is_primary', 'is_login'])) return true;
+    if (collectionChanged(phones.items, init.phones, ['country_code', 'phone_type', 'phone_number', 'is_primary'])) return true;
+    if (collectionChanged(addresses.items, init.addresses, ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'])) return true;
+    if (collectionChanged(taxIds.items, init.taxIds, ['country_code', 'tax_type', 'tax_value'])) return true;
+    return false;
+  }, [editForm, emails.items, phones.items, addresses.items, taxIds.items]);
+
+  const handleUpdate = async () => {
+    try {
+      const changes = { ...editForm };
+      if (changes.is_app_user && !editRow.is_app_user) {
+        const loginEm = emails.items.find((em) => em.is_login && !em._deleted);
+        if (loginEm) changes.email = loginEm.email;
+      }
+      await updateMut.mutateAsync({ filter: { id: editRow.id }, changes });
+
+      if (editRow.source_id) {
+        const sid = editRow.source_id;
+        await saveCollection(phones.items, {
+          sourceId: sid, fields: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
+          createMut: phoneMuts.create.mutateAsync, updateMut: phoneMuts.update.mutateAsync, archiveMut: phoneMuts.archive.mutateAsync,
+        });
+        await saveCollection(emails.items, {
+          sourceId: sid, fields: ['email', 'label', 'is_primary', 'is_login'],
+          createMut: emailMuts.create.mutateAsync, updateMut: emailMuts.update.mutateAsync, archiveMut: emailMuts.archive.mutateAsync,
+        });
+        await saveCollection(addresses.items, {
+          sourceId: sid, fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+          createMut: addressMuts.create.mutateAsync, updateMut: addressMuts.update.mutateAsync, archiveMut: addressMuts.archive.mutateAsync,
+        });
+        await saveCollection(taxIds.items, {
+          sourceId: sid, fields: ['country_code', 'tax_type', 'tax_value'],
+          createMut: taxIdMuts.create.mutateAsync, updateMut: taxIdMuts.update.mutateAsync, archiveMut: taxIdMuts.archive.mutateAsync,
+        });
+      }
+
+      if (editForm.is_app_user !== editRow.is_app_user) {
+        qc.invalidateQueries({ queryKey: ['nap-users'] });
+      }
+      toast('Employee updated');
+      return true;
+    } catch (err) {
+      toast(errMsg(err), 'error');
+      return false;
+    }
+  };
+
+  const openEditSession = useCallback((row, setEditForm) => {
+    const form = {
+      first_name: row.first_name ?? '', last_name: row.last_name ?? '',
+      code: row.code ?? '', position: row.position ?? '', department: row.department ?? '',
+      is_app_user: !!row.is_app_user, roles: row.roles ?? [],
+      is_primary_contact: !!row.is_primary_contact, is_billing_contact: !!row.is_billing_contact,
+    };
+    setEditForm(form);
+    editInitial.current.form = form;
+
+    setEditSourceId(row.source_id || null);
+    if (!row.source_id) {
+      emails.reset([]); phones.reset([]); addresses.reset([]); taxIds.reset([]);
+      editInitial.current.emails = [];
+      editInitial.current.phones = [];
+      editInitial.current.addresses = [];
+      editInitial.current.taxIds = [];
+    }
+  }, []);
+
+  const closeEditSession = useCallback(() => {
+    setEditSourceId(null);
+  }, []);
+
+  return {
+    emails, phones, addresses, taxIds,
+    hasEditChanges, handleUpdate,
+    openEditSession, closeEditSession,
+  };
+}

--- a/apps/nap-client/src/pages/Core/vendors/ContactFormDialog.jsx
+++ b/apps/nap-client/src/pages/Core/vendors/ContactFormDialog.jsx
@@ -21,8 +21,8 @@ import AddIcon from '@mui/icons-material/Add';
 import FormDialog from '../../../components/shared/FormDialog.jsx';
 import { formGridSx } from '../../../config/layoutTokens.js';
 import { BLANK_EMAIL, BLANK_PHONE } from '../../../utils/formConstants.js';
-import EmailRow from './EmailRow.jsx';
-import PhoneRow from './PhoneRow.jsx';
+import EmailRow from '../../../components/shared/EmailRow.jsx';
+import PhoneRow from '../../../components/shared/PhoneRow.jsx';
 
 export default function ContactFormDialog({
   open,

--- a/apps/nap-client/src/pages/Core/vendors/VendorEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/vendors/VendorEditDialog.jsx
@@ -27,8 +27,8 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ConfirmDialog from '../../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../../components/shared/DataTable.jsx';
 import PatternTextField from '../../../components/shared/PatternTextField.jsx';
-import EmailRow from './EmailRow.jsx';
-import PhoneRow from './PhoneRow.jsx';
+import EmailRow from '../../../components/shared/EmailRow.jsx';
+import PhoneRow from '../../../components/shared/PhoneRow.jsx';
 import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
 import { TAX_TYPES, COUNTRIES } from '@nap/shared';
 


### PR DESCRIPTION
## Summary
- Extract edit/view dialogs and edit-collection hooks for **Clients**, **Companies**, **Contacts**, and **Employees** into feature subdirectories (`clients/`, `companies/`, `contacts/`, `employees/`)
- Promote `EmailRow` and `PhoneRow` from `vendors/` to `components/shared/` for reuse across all entity dialogs
- Reduce the 4 Core page files from ~2400 to ~400 lines of orchestration logic

## Test plan
- [ ] Verify create/edit/view dialogs for Clients, Companies, Contacts, and Employees
- [ ] Verify sub-collection editing (emails, phones, addresses, tax IDs) in all entity edit dialogs
- [ ] Verify vendor contact dialogs still work with shared EmailRow/PhoneRow
- [ ] Verify archive/restore and import/export on all Core pages