### PR TITLE
refactor: add column helpers and DataTable empty state

### DIFF
--- a/apps/nap-client/src/components/shared/DataTable.jsx
+++ b/apps/nap-client/src/components/shared/DataTable.jsx
@@ -122,8 +122,9 @@ export default function DataTable({
       pageSizeOptions={PAGE_SIZE_OPTIONS}
       initialState={{ pagination: { paginationModel: { pageSize: defaultPageSize } } }}
       getRowClassName={mergedGetRowClassName}
-      slots={{ noRowsOverlay: NoRowsOverlay }}
       {...dataGridProps}
+      slots={{ noRowsOverlay: NoRowsOverlay, ...(dataGridProps.slots || {}) }}
+      slotProps={{ ...dataGridProps.slotProps, noRowsOverlay: { ...(dataGridProps.slotProps?.noRowsOverlay || {}) } }}
     />
   );
 }

--- a/apps/nap-client/src/components/shared/DataTable.jsx
+++ b/apps/nap-client/src/components/shared/DataTable.jsx
@@ -15,7 +15,10 @@
  */
 
 import { useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import { DataGrid } from '@mui/x-data-grid';
+import InboxOutlinedIcon from '@mui/icons-material/InboxOutlined';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import RowActionsMenu from './RowActionsMenu.jsx';
@@ -32,6 +35,7 @@ const PAGE_SIZE_OPTIONS = [25, 50, 100, 200, 500, 1000];
  * @param {Function} [props.onView]            - (row) => void; adds View to row actions
  * @param {Function} [props.onEdit]            - (row) => void; adds Edit to row actions
  * @param {Array|Function} [props.rowActions] - static [{ label, icon?, onClick(row) }] or (row) => actions[]
+ * @param {string}   [props.emptyMessage]      - message shown when no rows (default: 'No records found')
  * @param {Function} [props.getRowClassName]   - custom className builder (merged with archived default)
  * @param {Object}   [props.dataGridProps]     - pass-through props for DataGrid
  */
@@ -43,6 +47,7 @@ export default function DataTable({
   onView,
   onEdit,
   rowActions = [],
+  emptyMessage = 'No records found',
   getRowClassName,
   dataGridProps = {},
 }) {
@@ -90,6 +95,18 @@ export default function DataTable({
     };
   }, [getRowClassName]);
 
+  const NoRowsOverlay = useMemo(() => {
+    const msg = emptyMessage;
+    return function Overlay() {
+      return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 1, py: 4 }}>
+          <InboxOutlinedIcon sx={{ fontSize: 48, color: 'text.disabled' }} />
+          <Typography variant="body2" color="text.secondary">{msg}</Typography>
+        </Box>
+      );
+    };
+  }, [emptyMessage]);
+
   return (
     <DataGrid
       key={defaultPageSize}
@@ -105,6 +122,7 @@ export default function DataTable({
       pageSizeOptions={PAGE_SIZE_OPTIONS}
       initialState={{ pagination: { paginationModel: { pageSize: defaultPageSize } } }}
       getRowClassName={mergedGetRowClassName}
+      slots={{ noRowsOverlay: NoRowsOverlay }}
       {...dataGridProps}
     />
   );

--- a/apps/nap-client/src/components/shared/DataTable.jsx
+++ b/apps/nap-client/src/components/shared/DataTable.jsx
@@ -97,9 +97,9 @@ export default function DataTable({
 
   const NoRowsOverlay = useMemo(() => {
     const msg = emptyMessage;
-    return function Overlay() {
+    return function Overlay(props) {
       return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 1, py: 4 }}>
+        <Box {...props} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 1, py: 4, ...props?.sx }}>
           <InboxOutlinedIcon sx={{ fontSize: 48, color: 'text.disabled' }} />
           <Typography variant="body2" color="text.secondary">{msg}</Typography>
         </Box>

--- a/apps/nap-client/src/pages/AP/ApInvoicesPage.jsx
+++ b/apps/nap-client/src/pages/AP/ApInvoicesPage.jsx
@@ -17,9 +17,7 @@ import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
-import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
 import FieldRow from '../../components/shared/FieldRow.jsx';
@@ -39,6 +37,7 @@ import { resolveLevel } from '@nap/shared';
 import { apInvoiceApi } from '../../services/apApi.js';
 import { useToast } from '../../hooks/useToast.js';
 import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
+import { statusColumn, dateColumn, currencyColumn } from '../../utils/columnHelpers.jsx';
 
 const STATUS_OPTS = ['open', 'approved', 'paid', 'voided'];
 
@@ -48,10 +47,10 @@ const BLANK_EDIT = { invoice_number: '', invoice_date: '', due_date: '', total_a
 const columns = [
   { field: 'invoice_number', headerName: 'Invoice #', width: 140 },
   { field: 'vendor_id', headerName: 'Vendor', width: 120, valueGetter: (params) => params.row.vendor_id?.slice(0, 8) ?? '\u2014' },
-  { field: 'invoice_date', headerName: 'Date', width: 120, valueGetter: (params) => fmtDate(params.row.invoice_date) },
-  { field: 'due_date', headerName: 'Due', width: 120, valueGetter: (params) => fmtDate(params.row.due_date) },
-  { field: 'total_amount', headerName: 'Total', width: 140, renderCell: (params) => <CurrencyCell value={params.value} /> },
-  { field: 'status', headerName: 'Status', width: 120, renderCell: ({ value }) => <StatusBadge status={value} /> },
+  dateColumn('invoice_date', 'Date'),
+  dateColumn('due_date', 'Due'),
+  currencyColumn('total_amount', 'Total'),
+  statusColumn(),
 ];
 
 export default function ApInvoicesPage() {

--- a/apps/nap-client/src/pages/AP/PaymentsPage.jsx
+++ b/apps/nap-client/src/pages/AP/PaymentsPage.jsx
@@ -17,7 +17,6 @@ import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
-import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
@@ -36,6 +35,7 @@ import { resolveLevel } from '@nap/shared';
 import { paymentApi } from '../../services/apApi.js';
 import { useToast } from '../../hooks/useToast.js';
 import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
+import { dateColumn, currencyColumn, capColumn } from '../../utils/columnHelpers.jsx';
 
 const METHOD_OPTS = ['check', 'ach', 'wire'];
 
@@ -45,9 +45,9 @@ const BLANK_EDIT = { payment_date: '', amount: '', method: 'check', reference: '
 const columns = [
   { field: 'id', headerName: 'ID', width: 100, valueGetter: (params) => params.row.id?.slice(0, 8) },
   { field: 'vendor_id', headerName: 'Vendor', width: 120, valueGetter: (params) => params.row.vendor_id?.slice(0, 8) ?? '\u2014' },
-  { field: 'payment_date', headerName: 'Date', width: 120, valueGetter: (params) => fmtDate(params.row.payment_date) },
-  { field: 'amount', headerName: 'Amount', width: 140, renderCell: (params) => <CurrencyCell value={params.value} /> },
-  { field: 'method', headerName: 'Method', width: 120, valueGetter: (params) => capSnake(params.row.method) },
+  dateColumn('payment_date', 'Date'),
+  currencyColumn('amount', 'Amount'),
+  capColumn('method', 'Method', { snake: true }),
   { field: 'reference', headerName: 'Reference', flex: 1, minWidth: 160 },
 ];
 

--- a/apps/nap-client/src/pages/AR/ArInvoicesPage.jsx
+++ b/apps/nap-client/src/pages/AR/ArInvoicesPage.jsx
@@ -20,9 +20,7 @@ import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
-import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
 import FieldRow from '../../components/shared/FieldRow.jsx';
@@ -43,6 +41,7 @@ import { resolveLevel } from '@nap/shared';
 import { arInvoiceApi } from '../../services/arApi.js';
 import { useToast } from '../../hooks/useToast.js';
 import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
+import { statusColumn, dateColumn, currencyColumn } from '../../utils/columnHelpers.jsx';
 
 const STATUS_OPTS = ['open', 'sent', 'paid', 'voided'];
 
@@ -52,10 +51,10 @@ const BLANK_EDIT = { invoice_number: '', invoice_date: '', due_date: '', total_a
 const columns = [
   { field: 'invoice_number', headerName: 'Invoice #', width: 140 },
   { field: 'client_id', headerName: 'Client', width: 120, valueGetter: (params) => params.row.client_id?.slice(0, 8) ?? '\u2014' },
-  { field: 'invoice_date', headerName: 'Date', width: 120, valueGetter: (params) => fmtDate(params.row.invoice_date) },
-  { field: 'due_date', headerName: 'Due', width: 120, valueGetter: (params) => fmtDate(params.row.due_date) },
-  { field: 'total_amount', headerName: 'Total', width: 140, renderCell: (params) => <CurrencyCell value={params.value} /> },
-  { field: 'status', headerName: 'Status', width: 120, renderCell: ({ value }) => <StatusBadge status={value} /> },
+  dateColumn('invoice_date', 'Date'),
+  dateColumn('due_date', 'Due'),
+  currencyColumn('total_amount', 'Total'),
+  statusColumn(),
 ];
 
 export default function ArInvoicesPage() {

--- a/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
@@ -22,7 +22,6 @@ import { useToast } from '../../hooks/useToast.js';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
 import FieldRow from '../../components/shared/FieldRow.jsx';
@@ -40,6 +39,7 @@ import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 import { cap, fmtDate, errMsg } from '../../utils/format.js';
+import { statusColumn, boolColumn, capColumn } from '../../utils/columnHelpers.jsx';
 
 const ACCT_TYPES = ['asset', 'liability', 'equity', 'income', 'expense', 'cash', 'bank'];
 
@@ -49,19 +49,9 @@ const BLANK_EDIT = { name: '', type: 'asset', is_active: true, cash_basis: false
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
   { field: 'name', headerName: 'Account Name', flex: 1, minWidth: 200 },
-  { field: 'type', headerName: 'Type', width: 120, valueGetter: (params) => cap(params.row.type) },
-  {
-    field: 'is_active',
-    headerName: 'Active',
-    width: 100,
-    renderCell: ({ value }) => <StatusBadge status={value ? 'active' : 'suspended'} />,
-  },
-  {
-    field: 'cash_basis',
-    headerName: 'Cash Basis',
-    width: 110,
-    valueGetter: (params) => (params.row.cash_basis ? 'Yes' : 'No'),
-  },
+  capColumn('type', 'Type'),
+  statusColumn('is_active', 'Active', { width: 100, map: (v) => v ? 'active' : 'suspended' }),
+  boolColumn('cash_basis', 'Cash Basis', { width: 110 }),
 ];
 
 export default function ChartOfAccountsPage() {

--- a/apps/nap-client/src/pages/Accounting/JournalEntriesPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/JournalEntriesPage.jsx
@@ -19,7 +19,6 @@ import { useToast } from '../../hooks/useToast.js';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
 import FieldRow from '../../components/shared/FieldRow.jsx';
@@ -39,6 +38,7 @@ import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
+import { statusColumn, dateColumn, capColumn } from '../../utils/columnHelpers.jsx';
 
 const STATUS_OPTS = ['pending', 'posted', 'reversed'];
 
@@ -47,10 +47,10 @@ const BLANK_EDIT = { entry_date: '', description: '', status: 'pending', source_
 
 const columns = [
   { field: 'id', headerName: 'ID', width: 100, valueGetter: (params) => params.row.id?.slice(0, 8) },
-  { field: 'entry_date', headerName: 'Date', width: 120, valueGetter: (params) => fmtDate(params.row.entry_date) },
+  dateColumn('entry_date', 'Date'),
   { field: 'description', headerName: 'Description', flex: 1, minWidth: 200 },
-  { field: 'status', headerName: 'Status', width: 120, renderCell: ({ value }) => <StatusBadge status={value} /> },
-  { field: 'source_type', headerName: 'Source', width: 140, valueGetter: (params) => capSnake(params.row.source_type || '') },
+  statusColumn(),
+  capColumn('source_type', 'Source', { snake: true, width: 140 }),
 ];
 
 export default function JournalEntriesPage() {

--- a/apps/nap-client/src/pages/Accounting/LedgerPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/LedgerPage.jsx
@@ -9,15 +9,14 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { DataGrid } from '@mui/x-data-grid';
 
-import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
 import { useLedgerBalances } from '../../hooks/useAccounting.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
-import { fmtDate } from '../../utils/format.js';
+import { dateColumn, currencyColumn } from '../../utils/columnHelpers.jsx';
 
 const columns = [
   { field: 'account_id', headerName: 'Account', width: 140, valueGetter: (params) => params.row.account_id?.slice(0, 8) ?? '\u2014' },
-  { field: 'as_of_date', headerName: 'As Of', width: 130, valueGetter: (params) => fmtDate(params.row.as_of_date) },
-  { field: 'balance', headerName: 'Balance', width: 160, renderCell: (params) => <CurrencyCell value={params.value} /> },
+  dateColumn('as_of_date', 'As Of', { width: 130 }),
+  currencyColumn('balance', 'Balance', { width: 160 }),
 ];
 
 export default function LedgerPage() {

--- a/apps/nap-client/src/pages/Core/ClientsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ClientsPage.jsx
@@ -15,7 +15,6 @@ import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import TextField from '@mui/material/TextField';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import ResetPasswordDialog from '../../components/shared/ResetPasswordDialog.jsx';
 import SetPasswordPopover from '../../components/shared/SetPasswordPopover.jsx';
@@ -49,6 +48,7 @@ import { useRoles } from '../../hooks/useRoles.js';
 import { resolveLevel } from '@nap/shared';
 import { useToast } from '../../hooks/useToast.js';
 import { errMsg } from '../../utils/format.js';
+import { statusColumn } from '../../utils/columnHelpers.jsx';
 import { clientApi } from '../../services/clientApi.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
@@ -64,12 +64,7 @@ const BLANK_EDIT = { name: '', code: '', is_active: true, is_app_user: false, ro
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
   { field: 'name', headerName: 'Client Name', flex: 1, minWidth: 200 },
-  {
-    field: 'is_active',
-    headerName: 'Active',
-    width: 100,
-    renderCell: ({ value }) => <StatusBadge status={value ? 'active' : 'suspended'} />,
-  },
+  statusColumn('is_active', 'Active', { width: 100, map: (v) => v ? 'active' : 'suspended' }),
 ];
 
 export default function ClientsPage() {

--- a/apps/nap-client/src/pages/Core/CompaniesPage.jsx
+++ b/apps/nap-client/src/pages/Core/CompaniesPage.jsx
@@ -13,7 +13,6 @@ import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import TextField from '@mui/material/TextField';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
 import FormDialog from '../../components/shared/FormDialog.jsx';
@@ -32,6 +31,7 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import { resolveLevel } from '@nap/shared';
 import { useToast } from '../../hooks/useToast.js';
 import { errMsg } from '../../utils/format.js';
+import { statusColumn } from '../../utils/columnHelpers.jsx';
 import { companyApi } from '../../services/companyApi.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
@@ -47,12 +47,7 @@ const BLANK_EDIT = { name: '', code: '', is_active: true };
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
   { field: 'name', headerName: 'Company Name', flex: 1, minWidth: 200 },
-  {
-    field: 'is_active',
-    headerName: 'Active',
-    width: 100,
-    renderCell: ({ value }) => <StatusBadge status={value ? 'active' : 'suspended'} />,
-  },
+  statusColumn('is_active', 'Active', { width: 100, map: (v) => v ? 'active' : 'suspended' }),
 ];
 
 export default function CompaniesPage() {

--- a/apps/nap-client/src/pages/Core/ContactsPage.jsx
+++ b/apps/nap-client/src/pages/Core/ContactsPage.jsx
@@ -16,7 +16,6 @@ import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import TextField from '@mui/material/TextField';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
 import FormDialog from '../../components/shared/FormDialog.jsx';
@@ -39,6 +38,7 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import { resolveLevel } from '@nap/shared';
 import { useToast } from '../../hooks/useToast.js';
 import { errMsg } from '../../utils/format.js';
+import { statusColumn } from '../../utils/columnHelpers.jsx';
 import { contactApi } from '../../services/contactApi.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
@@ -54,12 +54,7 @@ const BLANK_EDIT = { name: '', code: '', is_active: true };
 const columns = [
   { field: 'code', headerName: 'Code', width: 120 },
   { field: 'name', headerName: 'Contact Name', flex: 1, minWidth: 200 },
-  {
-    field: 'is_active',
-    headerName: 'Active',
-    width: 100,
-    renderCell: ({ value }) => <StatusBadge status={value ? 'active' : 'suspended'} />,
-  },
+  statusColumn('is_active', 'Active', { width: 100, map: (v) => v ? 'active' : 'suspended' }),
 ];
 
 export default function ContactsPage() {

--- a/apps/nap-client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/nap-client/src/pages/Core/EmployeesPage.jsx
@@ -41,6 +41,7 @@ import { useRoles } from '../../hooks/useRoles.js';
 import { resolveLevel } from '@nap/shared';
 import { useToast } from '../../hooks/useToast.js';
 import { errMsg } from '../../utils/format.js';
+import { boolColumn } from '../../utils/columnHelpers.jsx';
 import { employeeApi } from '../../services/employeeApi.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
@@ -66,7 +67,7 @@ const columns = [
   { field: 'position', headerName: 'Position', width: 140 },
   { field: 'department', headerName: 'Department', width: 140 },
   { field: 'roles', headerName: 'Roles', width: 160, valueGetter: (params) => (params.row.roles ?? []).join(', ') },
-  { field: 'is_app_user', headerName: 'App User', width: 100, valueGetter: (params) => (params.row.is_app_user ? 'Yes' : 'No') },
+  boolColumn('is_app_user', 'App User'),
 ];
 
 export default function EmployeesPage() {

--- a/apps/nap-client/src/pages/Core/VendorsPage.jsx
+++ b/apps/nap-client/src/pages/Core/VendorsPage.jsx
@@ -16,7 +16,6 @@ import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import LockResetIcon from '@mui/icons-material/LockReset';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import ResetPasswordDialog from '../../components/shared/ResetPasswordDialog.jsx';
@@ -49,6 +48,7 @@ import { useRoles } from '../../hooks/useRoles.js';
 import { resolveLevel } from '@nap/shared';
 import { useToast } from '../../hooks/useToast.js';
 import { errMsg } from '../../utils/format.js';
+import { statusColumn } from '../../utils/columnHelpers.jsx';
 import { useFormState } from '../../hooks/useFormState.js';
 import { vendorApi } from '../../services/vendorApi.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
@@ -69,12 +69,7 @@ const baseColumns = [
   { field: 'code', headerName: 'Code', width: 120 },
   { field: 'name', headerName: 'Vendor Name', flex: 1, minWidth: 200 },
   { field: 'payment_term_id', headerName: 'Terms', width: 160 },
-  {
-    field: 'is_active',
-    headerName: 'Active',
-    width: 100,
-    renderCell: ({ value }) => <StatusBadge status={value ? 'active' : 'suspended'} />,
-  },
+  statusColumn('is_active', 'Active', { width: 100, map: (v) => v ? 'active' : 'suspended' }),
 ];
 
 export default function VendorsPage() {

--- a/apps/nap-client/src/pages/Reports/MarginAnalysisPage.jsx
+++ b/apps/nap-client/src/pages/Reports/MarginAnalysisPage.jsx
@@ -12,11 +12,10 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { DataGrid } from '@mui/x-data-grid';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
-import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
 import PercentCell from '../../components/shared/PercentCell.jsx';
 import { useMarginAnalysis } from '../../hooks/useReports.js';
 import { pageContainerSx } from '../../config/layoutTokens.js';
+import { statusColumn, currencyColumn } from '../../utils/columnHelpers.jsx';
 
 const SORT_FIELDS = new Set([
   'project_code',
@@ -32,24 +31,13 @@ const SORT_FIELDS = new Set([
 const columns = [
   { field: 'project_code', headerName: 'Code', width: 120 },
   { field: 'project_name', headerName: 'Project', flex: 1, minWidth: 180 },
-  {
-    field: 'project_status',
-    headerName: 'Status',
-    width: 120,
-    sortable: false,
-    renderCell: ({ value }) => (value ? <StatusBadge status={value} /> : null),
-  },
-  { field: 'invoiced_revenue', headerName: 'Revenue', width: 140, renderCell: (params) => <CurrencyCell value={params.value} /> },
-  { field: 'committed_cost', headerName: 'Committed Cost', width: 140, renderCell: (params) => <CurrencyCell value={params.value} /> },
-  { field: 'gross_profit', headerName: 'Gross Profit', width: 140, renderCell: (params) => <CurrencyCell value={params.value} variance /> },
+  statusColumn('project_status', 'Status', { sortable: false }),
+  currencyColumn('invoiced_revenue', 'Revenue'),
+  currencyColumn('committed_cost', 'Committed Cost'),
+  currencyColumn('gross_profit', 'Gross Profit', { variance: true }),
   { field: 'gross_margin_pct', headerName: 'Margin %', width: 110, renderCell: (params) => <PercentCell value={params.value} /> },
-  { field: 'net_cashflow', headerName: 'Net Cashflow', width: 140, renderCell: (params) => <CurrencyCell value={params.value} variance /> },
-  {
-    field: 'budget_variance',
-    headerName: 'Budget Var.',
-    width: 140,
-    renderCell: (params) => <CurrencyCell value={params.value} variance />,
-  },
+  currencyColumn('net_cashflow', 'Net Cashflow', { variance: true }),
+  currencyColumn('budget_variance', 'Budget Var.', { variance: true }),
 ];
 
 export default function MarginAnalysisPage() {

--- a/apps/nap-client/src/pages/Reports/MarginAnalysisPage.jsx
+++ b/apps/nap-client/src/pages/Reports/MarginAnalysisPage.jsx
@@ -31,7 +31,7 @@ const SORT_FIELDS = new Set([
 const columns = [
   { field: 'project_code', headerName: 'Code', width: 120 },
   { field: 'project_name', headerName: 'Project', flex: 1, minWidth: 180 },
-  statusColumn('project_status', 'Status', { sortable: false }),
+  statusColumn('project_status', 'Status', { sortable: false, hideEmpty: true }),
   currencyColumn('invoiced_revenue', 'Revenue'),
   currencyColumn('committed_cost', 'Committed Cost'),
   currencyColumn('gross_profit', 'Gross Profit', { variance: true }),

--- a/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
@@ -55,6 +55,7 @@ import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, formFullSpanSx, det
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useToast } from '../../hooks/useToast.js';
 import { cap, fmtDate, errMsg } from '../../utils/format.js';
+import { statusColumn, capColumn } from '../../utils/columnHelpers.jsx';
 
 /* ── Enums ────────────────────────────────────────────────────── */
 
@@ -77,25 +78,10 @@ const BLANK_EDIT = {
 const columns = [
   { field: 'tenant_code', headerName: 'Code', width: 100 },
   { field: 'company', headerName: 'Tenant Name', flex: 1, minWidth: 180 },
-  {
-    field: 'status',
-    headerName: 'Status',
-    width: 120,
-    renderCell: ({ value }) => <StatusBadge status={value} />,
-  },
-  {
-    field: 'tier',
-    headerName: 'Tier',
-    width: 120,
-    valueGetter: (params) => cap(params.row.tier),
-  },
+  statusColumn(),
+  capColumn('tier', 'Tier'),
   { field: 'region', headerName: 'Region', width: 130 },
-  {
-    field: 'deactivated_at',
-    headerName: 'Active',
-    width: 90,
-    valueGetter: (params) => (params.row.deactivated_at ? 'No' : 'Yes'),
-  },
+  { field: 'deactivated_at', headerName: 'Active', width: 90, valueGetter: (params) => (params.row.deactivated_at ? 'No' : 'Yes') },
 ];
 
 /* ── Detail dialog helpers ────────────────────────────────────── */

--- a/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
@@ -25,7 +25,6 @@ import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
-import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import FieldRow from '../../components/shared/FieldRow.jsx';
@@ -37,6 +36,7 @@ import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useToast } from '../../hooks/useToast.js';
 import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
+import { statusColumn, capColumn } from '../../utils/columnHelpers.jsx';
 
 /* ── Enums ────────────────────────────────────────────────────── */
 
@@ -69,18 +69,8 @@ const PW_RULES = [
 
 const columns = [
   { field: 'email', headerName: 'Email', flex: 1, minWidth: 220 },
-  {
-    field: 'entity_type',
-    headerName: 'Entity Type',
-    width: 140,
-    valueGetter: (params) => capSnake(params.row.entity_type) || '\u2014',
-  },
-  {
-    field: 'status',
-    headerName: 'Status',
-    width: 110,
-    renderCell: ({ value }) => <StatusBadge status={value} />,
-  },
+  capColumn('entity_type', 'Entity Type', { snake: true, width: 140 }),
+  statusColumn('status', 'Status', { width: 110 }),
 ];
 
 /* ── Component ────────────────────────────────────────────────── */

--- a/apps/nap-client/src/utils/columnHelpers.jsx
+++ b/apps/nap-client/src/utils/columnHelpers.jsx
@@ -25,14 +25,16 @@ import { fmtDate, cap, capSnake } from './format.js';
  *     → maps the raw value through the function before passing to StatusBadge
  */
 export function statusColumn(field = 'status', headerName = 'Status', overrides = {}) {
-  const { map, ...rest } = overrides;
+  const { map, hideEmpty, ...rest } = overrides;
   return {
     field,
     headerName,
     width: 120,
-    renderCell: map
-      ? ({ value }) => <StatusBadge status={map(value)} />
-      : ({ value }) => <StatusBadge status={value} />,
+    renderCell: ({ value }) => {
+      const display = map ? map(value) : value;
+      if (hideEmpty && !display) return null;
+      return <StatusBadge status={display} />;
+    },
     ...rest,
   };
 }

--- a/apps/nap-client/src/utils/columnHelpers.jsx
+++ b/apps/nap-client/src/utils/columnHelpers.jsx
@@ -1,0 +1,130 @@
+/**
+ * @file DataGrid column definition helpers — reduce repeated renderCell / valueGetter boilerplate
+ * @module nap-client/utils/columnHelpers
+ *
+ * Each helper returns a partial column definition object that can be spread
+ * or merged with additional overrides (width, flex, etc.).
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import StatusBadge from '../components/shared/StatusBadge.jsx';
+import CurrencyCell from '../components/shared/CurrencyCell.jsx';
+import { fmtDate, cap, capSnake } from './format.js';
+
+/**
+ * Status badge column — renders a StatusBadge chip.
+ *
+ * @param {string}  field       Column field name (default: 'status')
+ * @param {string}  headerName  Column header (default: 'Status')
+ * @param {object}  [overrides] Additional column props (width, etc.)
+ *
+ * Handles two common patterns:
+ *   statusColumn()                              → renders params.row.status directly
+ *   statusColumn('is_active', 'Active', { map: (v) => v ? 'active' : 'suspended' })
+ *     → maps the raw value through the function before passing to StatusBadge
+ */
+export function statusColumn(field = 'status', headerName = 'Status', overrides = {}) {
+  const { map, ...rest } = overrides;
+  return {
+    field,
+    headerName,
+    width: 120,
+    renderCell: map
+      ? ({ value }) => <StatusBadge status={map(value)} />
+      : ({ value }) => <StatusBadge status={value} />,
+    ...rest,
+  };
+}
+
+/**
+ * Date column — formats a date field via fmtDate.
+ *
+ * @param {string}  field       Column field name
+ * @param {string}  headerName  Column header
+ * @param {object}  [overrides] Additional column props
+ */
+export function dateColumn(field, headerName, overrides = {}) {
+  return {
+    field,
+    headerName,
+    width: 120,
+    valueGetter: (params) => fmtDate(params.row[field]),
+    ...overrides,
+  };
+}
+
+/**
+ * Map-lookup column — resolves an ID to a display label via a Map or object.
+ *
+ * @param {string}       field       Column field name
+ * @param {string}       headerName  Column header
+ * @param {Map|object}   lookup      Map or plain object for id→label resolution
+ * @param {object}       [overrides] Additional column props
+ */
+export function lookupColumn(field, headerName, lookup, overrides = {}) {
+  const get = lookup instanceof Map
+    ? (id) => lookup.get(id)
+    : (id) => lookup[id];
+  return {
+    field,
+    headerName,
+    width: 160,
+    valueGetter: (params) => get(params.row[field]) || '\u2014',
+    ...overrides,
+  };
+}
+
+/**
+ * Currency column — renders a CurrencyCell.
+ *
+ * @param {string}  field       Column field name
+ * @param {string}  headerName  Column header
+ * @param {object}  [overrides] Additional column props (e.g. { variance: true })
+ */
+export function currencyColumn(field, headerName, overrides = {}) {
+  const { variance, ...rest } = overrides;
+  return {
+    field,
+    headerName,
+    width: 140,
+    renderCell: (params) => <CurrencyCell value={params.value} variance={variance} />,
+    ...rest,
+  };
+}
+
+/**
+ * Boolean column — displays Yes/No text.
+ *
+ * @param {string}  field       Column field name
+ * @param {string}  headerName  Column header
+ * @param {object}  [overrides] Additional column props
+ */
+export function boolColumn(field, headerName, overrides = {}) {
+  return {
+    field,
+    headerName,
+    width: 100,
+    valueGetter: (params) => (params.row[field] ? 'Yes' : 'No'),
+    ...overrides,
+  };
+}
+
+/**
+ * Capitalized column — formats a snake_case or lowercase value via cap or capSnake.
+ *
+ * @param {string}  field       Column field name
+ * @param {string}  headerName  Column header
+ * @param {object}  [overrides] Additional column props; set { snake: true } for capSnake
+ */
+export function capColumn(field, headerName, overrides = {}) {
+  const { snake, ...rest } = overrides;
+  const fmt = snake ? capSnake : cap;
+  return {
+    field,
+    headerName,
+    width: 120,
+    valueGetter: (params) => fmt(params.row[field] || '') || '\u2014',
+    ...rest,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `columnHelpers.jsx` with `statusColumn`, `dateColumn`, `currencyColumn`, `capColumn`, `boolColumn`, and `lookupColumn` helpers to eliminate repeated renderCell/valueGetter boilerplate
- Add `emptyMessage` prop and `noRowsOverlay` to DataTable — all grids now show a friendly empty state when no rows are present
- Apply helpers across 14 page files, removing ~70 lines of duplicated column definition code

## Test plan
- [ ] Verify all DataTable pages render columns correctly (status badges, dates, currency, booleans)
- [ ] Verify empty state overlay appears on a page with no data (e.g. filter to archived on a page with none)
- [ ] Spot-check sorting still works on columns using helpers
- [ ] Verify MarginAnalysisPage variance-colored currency cells still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)