### PR TITLE
refactor: consolidate inline sx patterns into layout tokens

### DIFF
--- a/apps/nap-client/src/components/shared/ChangePasswordDialog.jsx
+++ b/apps/nap-client/src/components/shared/ChangePasswordDialog.jsx
@@ -18,6 +18,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import { flexColumnSx } from '../../config/layoutTokens.js';
 import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 import CheckIcon from '@mui/icons-material/Check';
@@ -113,7 +114,7 @@ export default function ChangePasswordDialog({ open, onClose, onSuccess, forced 
           component="form"
           id="change-password-form"
           onSubmit={handleSubmit}
-          sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+          sx={flexColumnSx}
         >
           <PasswordField
             label="Current Password"

--- a/apps/nap-client/src/components/shared/ResetPasswordDialog.jsx
+++ b/apps/nap-client/src/components/shared/ResetPasswordDialog.jsx
@@ -23,6 +23,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 import CheckIcon from '@mui/icons-material/Check';
+import { flexColumnSx } from '../../config/layoutTokens.js';
 import CloseIcon from '@mui/icons-material/Close';
 import PasswordField from './PasswordField.jsx';
 
@@ -111,7 +112,7 @@ export default function ResetPasswordDialog({ open, onClose, onSuccess, onReset,
           component="form"
           id="reset-password-form"
           onSubmit={handleSubmit}
-          sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+          sx={flexColumnSx}
         >
           <PasswordField
             label="New Password"

--- a/apps/nap-client/src/components/shared/StepperFormDialog.jsx
+++ b/apps/nap-client/src/components/shared/StepperFormDialog.jsx
@@ -17,6 +17,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
 import Stepper from '@mui/material/Stepper';
+import { flexColumnSx } from '../../config/layoutTokens.js';
 
 import { density } from '../../config/tokens.js';
 
@@ -57,7 +58,7 @@ export default function StepperFormDialog({
   return (
     <Dialog open={open} onClose={onCancel} maxWidth={maxWidth} fullWidth disableRestoreFocus sx={dialogSx}>
       <form onSubmit={handleSubmit}>
-        <DialogTitle sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <DialogTitle sx={flexColumnSx}>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <span>{title}</span>
             <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>

--- a/apps/nap-client/src/config/layoutTokens.js
+++ b/apps/nap-client/src/config/layoutTokens.js
@@ -111,6 +111,12 @@ export const flexBetweenSx = {
   justifyContent: 'space-between',
 };
 
+export const flexColumnSx = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+};
+
 /* ── Detail / report presets ─────────────────────────────────── */
 
 export const detailGridSx = {

--- a/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
+++ b/apps/nap-client/src/pages/Accounting/ChartOfAccountsPage.jsx
@@ -35,7 +35,7 @@ import {
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import { resolveLevel } from '@nap/shared';
 import { chartOfAccountsApi } from '../../services/accountingApi.js';
-import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 import { cap, fmtDate, errMsg } from '../../utils/format.js';
@@ -234,7 +234,7 @@ export default function ChartOfAccountsPage() {
         </DialogTitle>
         <DialogContent dividers>
           {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={flexColumnSx}>
               <Box sx={detailGridSx}>
                 <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
                 <FieldRow label="Name" value={viewDialog.data.name} />

--- a/apps/nap-client/src/pages/Activities/ActivitiesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/ActivitiesPage.jsx
@@ -43,7 +43,7 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { resolveLevel } from '@nap/shared';
 import { activityApi } from '../../services/activityApi.js';
-import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 import { useToast } from '../../hooks/useToast.js';
@@ -261,7 +261,7 @@ export default function ActivitiesPage() {
         </DialogTitle>
         <DialogContent dividers>
           {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={flexColumnSx}>
               <Box sx={detailGridSx}>
                 <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
                 <FieldRow label="Name" value={viewDialog.data.name} />

--- a/apps/nap-client/src/pages/Activities/BudgetManagementPage.jsx
+++ b/apps/nap-client/src/pages/Activities/BudgetManagementPage.jsx
@@ -38,7 +38,7 @@ import { resolveLevel } from '@nap/shared';
 import { budgetApi } from '../../services/budgetApi.js';
 import { useDeliverables } from '../../hooks/useDeliverables.js';
 import { useActivities } from '../../hooks/useActivities.js';
-import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 import { useToast } from '../../hooks/useToast.js';
@@ -285,7 +285,7 @@ export default function BudgetManagementPage() {
         </DialogTitle>
         <DialogContent dividers>
           {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={flexColumnSx}>
               <Box sx={detailGridSx}>
                 <FieldRow label="Deliverable" value={deliverableMap[viewDialog.data.deliverable_id] || viewDialog.data.deliverable_id} />
                 <FieldRow label="Activity" value={activityMap[viewDialog.data.activity_id] || viewDialog.data.activity_id} />

--- a/apps/nap-client/src/pages/Activities/CategoriesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/CategoriesPage.jsx
@@ -42,7 +42,7 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { resolveLevel } from '@nap/shared';
 import { categoryApi } from '../../services/categoryApi.js';
-import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 import { useToast } from '../../hooks/useToast.js';
@@ -243,7 +243,7 @@ export default function CategoriesPage() {
         </DialogTitle>
         <DialogContent dividers>
           {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={flexColumnSx}>
               <Box sx={detailGridSx}>
                 <FieldRow label="Code" value={viewDialog.data.code || '\u2014'} />
                 <FieldRow label="Name" value={viewDialog.data.name} />

--- a/apps/nap-client/src/pages/Activities/DeliverablesPage.jsx
+++ b/apps/nap-client/src/pages/Activities/DeliverablesPage.jsx
@@ -41,7 +41,7 @@ import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { resolveLevel } from '@nap/shared';
 import { deliverableApi } from '../../services/deliverableApi.js';
-import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, formFullSpanSx, detailGridSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, formGridSx, dialogHeaderSx, dialogActionBoxSx, formFullSpanSx, detailGridSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useArchiveRestore } from '../../hooks/useArchiveRestore.js';
 import { useToast } from '../../hooks/useToast.js';
@@ -250,7 +250,7 @@ export default function DeliverablesPage() {
         </DialogTitle>
         <DialogContent dividers>
           {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={flexColumnSx}>
               <Box sx={detailGridSx}>
                 <FieldRow label="Name" value={viewDialog.data.name} />
                 <FieldRow label="Status">

--- a/apps/nap-client/src/pages/Core/clients/ClientEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/clients/ClientEditDialog.jsx
@@ -24,7 +24,7 @@ import PatternTextField from '../../../components/shared/PatternTextField.jsx';
 import EmailRow from '../../../components/shared/EmailRow.jsx';
 import PhoneRow from '../../../components/shared/PhoneRow.jsx';
 import { TAX_TYPES, COUNTRIES } from '@nap/shared';
-import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
+import { formGridSx, formGroupCardSx, formFullSpanSx, flexBetweenSx } from '../../../config/layoutTokens.js';
 
 export default function ClientEditDialog({
   open,
@@ -82,7 +82,7 @@ export default function ClientEditDialog({
 
       {/* ── Emails ────────────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Emails</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
       </Box>
@@ -95,7 +95,7 @@ export default function ClientEditDialog({
 
       {/* ── Phone Numbers ──────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Phone Numbers</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
       </Box>
@@ -108,7 +108,7 @@ export default function ClientEditDialog({
 
       {/* ── Addresses ──────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Addresses</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
       </Box>
@@ -137,7 +137,7 @@ export default function ClientEditDialog({
 
       {/* ── Tax Identifiers ──────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Tax Identifiers</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
       </Box>

--- a/apps/nap-client/src/pages/Core/clients/ClientViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/clients/ClientViewDialog.jsx
@@ -19,7 +19,7 @@ import PhoneNumbersSection from '../../../components/shared/PhoneNumbersSection.
 import AddressesSection from '../../../components/shared/AddressesSection.jsx';
 import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
 import { fmtDate } from '../../../utils/format.js';
-import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+import { dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../../config/layoutTokens.js';
 
 export default function ClientViewDialog({
   open,
@@ -49,7 +49,7 @@ export default function ClientViewDialog({
       </DialogTitle>
       <DialogContent dividers>
         {client && (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box sx={flexColumnSx}>
             <Box sx={detailGridSx}>
               <FieldRow label="Code" value={client.code || '\u2014'} />
               <FieldRow label="Name" value={client.name} />

--- a/apps/nap-client/src/pages/Core/companies/CompanyEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/companies/CompanyEditDialog.jsx
@@ -20,7 +20,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import FormDialog from '../../../components/shared/FormDialog.jsx';
 import PatternTextField from '../../../components/shared/PatternTextField.jsx';
 import { TAX_TYPES, COUNTRIES } from '@nap/shared';
-import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
+import { formGridSx, formGroupCardSx, formFullSpanSx, flexBetweenSx } from '../../../config/layoutTokens.js';
 
 export default function CompanyEditDialog({
   open,
@@ -54,7 +54,7 @@ export default function CompanyEditDialog({
 
       {/* ── Addresses ───────────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Addresses</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={addresses.add} disabled={!hasSource}>Add Address</Button>
       </Box>
@@ -86,7 +86,7 @@ export default function CompanyEditDialog({
 
       {/* ── Tax Identifiers ─────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Tax Identifiers</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add} disabled={!hasSource}>Add Tax ID</Button>
       </Box>

--- a/apps/nap-client/src/pages/Core/companies/CompanyViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/companies/CompanyViewDialog.jsx
@@ -17,7 +17,7 @@ import StatusBadge from '../../../components/shared/StatusBadge.jsx';
 import AddressesSection from '../../../components/shared/AddressesSection.jsx';
 import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
 import { fmtDate } from '../../../utils/format.js';
-import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+import { dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../../config/layoutTokens.js';
 
 export default function CompanyViewDialog({
   open,
@@ -45,7 +45,7 @@ export default function CompanyViewDialog({
       </DialogTitle>
       <DialogContent dividers>
         {company && (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box sx={flexColumnSx}>
             <Box sx={detailGridSx}>
               <FieldRow label="Code" value={company.code || '\u2014'} />
               <FieldRow label="Name" value={company.name} />

--- a/apps/nap-client/src/pages/Core/contacts/StandaloneContactEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/contacts/StandaloneContactEditDialog.jsx
@@ -22,7 +22,7 @@ import PatternTextField from '../../../components/shared/PatternTextField.jsx';
 import EmailRow from '../../../components/shared/EmailRow.jsx';
 import PhoneRow from '../../../components/shared/PhoneRow.jsx';
 import { TAX_TYPES, COUNTRIES } from '@nap/shared';
-import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
+import { formGridSx, formGroupCardSx, formFullSpanSx, flexBetweenSx } from '../../../config/layoutTokens.js';
 
 export default function StandaloneContactEditDialog({
   open,
@@ -57,7 +57,7 @@ export default function StandaloneContactEditDialog({
 
       {/* ── Emails ─────────────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Emails</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
       </Box>
@@ -70,7 +70,7 @@ export default function StandaloneContactEditDialog({
 
       {/* ── Phone Numbers ──────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Phone Numbers</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
       </Box>
@@ -83,7 +83,7 @@ export default function StandaloneContactEditDialog({
 
       {/* ── Addresses ──────────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Addresses</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
       </Box>
@@ -112,7 +112,7 @@ export default function StandaloneContactEditDialog({
 
       {/* ── Tax Identifiers ────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Tax Identifiers</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
       </Box>

--- a/apps/nap-client/src/pages/Core/contacts/StandaloneContactViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/contacts/StandaloneContactViewDialog.jsx
@@ -19,7 +19,7 @@ import PhoneNumbersSection from '../../../components/shared/PhoneNumbersSection.
 import AddressesSection from '../../../components/shared/AddressesSection.jsx';
 import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
 import { fmtDate } from '../../../utils/format.js';
-import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+import { dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../../config/layoutTokens.js';
 
 export default function StandaloneContactViewDialog({
   open,
@@ -49,7 +49,7 @@ export default function StandaloneContactViewDialog({
       </DialogTitle>
       <DialogContent dividers>
         {contact && (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box sx={flexColumnSx}>
             <Box sx={detailGridSx}>
               <FieldRow label="Code" value={contact.code || '\u2014'} />
               <FieldRow label="Name" value={contact.name} />

--- a/apps/nap-client/src/pages/Core/employees/EmployeeEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/employees/EmployeeEditDialog.jsx
@@ -23,7 +23,7 @@ import PatternTextField from '../../../components/shared/PatternTextField.jsx';
 import EmailRow from '../../../components/shared/EmailRow.jsx';
 import PhoneRow from '../../../components/shared/PhoneRow.jsx';
 import { TAX_TYPES, COUNTRIES } from '@nap/shared';
-import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
+import { formGridSx, formGroupCardSx, formFullSpanSx, flexBetweenSx } from '../../../config/layoutTokens.js';
 
 export default function EmployeeEditDialog({
   open,
@@ -74,7 +74,7 @@ export default function EmployeeEditDialog({
 
       {/* ── Phone Numbers ──────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Phone Numbers</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
       </Box>
@@ -87,7 +87,7 @@ export default function EmployeeEditDialog({
 
       {/* ── Emails ────────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Emails</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
       </Box>
@@ -105,7 +105,7 @@ export default function EmployeeEditDialog({
 
       {/* ── Addresses ──────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Addresses</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
       </Box>
@@ -134,7 +134,7 @@ export default function EmployeeEditDialog({
 
       {/* ── Tax Identifiers ──────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Tax Identifiers</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
       </Box>

--- a/apps/nap-client/src/pages/Core/employees/EmployeeViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/employees/EmployeeViewDialog.jsx
@@ -19,7 +19,7 @@ import PhoneNumbersSection from '../../../components/shared/PhoneNumbersSection.
 import AddressesSection from '../../../components/shared/AddressesSection.jsx';
 import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
 import { fmtDate } from '../../../utils/format.js';
-import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+import { dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../../config/layoutTokens.js';
 
 export default function EmployeeViewDialog({
   open,
@@ -49,7 +49,7 @@ export default function EmployeeViewDialog({
       </DialogTitle>
       <DialogContent dividers>
         {employee && (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box sx={flexColumnSx}>
             <Box sx={detailGridSx}>
               <FieldRow label="Code" value={employee.code || '\u2014'} />
               <FieldRow label="First Name" value={employee.first_name} />

--- a/apps/nap-client/src/pages/Core/vendors/ContactFormDialog.jsx
+++ b/apps/nap-client/src/pages/Core/vendors/ContactFormDialog.jsx
@@ -19,7 +19,7 @@ import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 
 import FormDialog from '../../../components/shared/FormDialog.jsx';
-import { formGridSx } from '../../../config/layoutTokens.js';
+import { formGridSx, flexBetweenSx } from '../../../config/layoutTokens.js';
 import { BLANK_EMAIL, BLANK_PHONE } from '../../../utils/formConstants.js';
 import EmailRow from '../../../components/shared/EmailRow.jsx';
 import PhoneRow from '../../../components/shared/PhoneRow.jsx';
@@ -113,7 +113,7 @@ export default function ContactFormDialog({
 
       {/* ── Emails ──────────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Emails</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={addEmail}>Add Email</Button>
       </Box>
@@ -126,7 +126,7 @@ export default function ContactFormDialog({
 
       {/* ── Phones ─────────────────────────────────────────── */}
       <Divider />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box sx={flexBetweenSx}>
         <Typography variant="subtitle2">Phone Numbers</Typography>
         <Button size="small" startIcon={<AddIcon />} onClick={addPhone}>Add Phone</Button>
       </Box>

--- a/apps/nap-client/src/pages/Core/vendors/ContactViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/vendors/ContactViewDialog.jsx
@@ -15,7 +15,7 @@ import Divider from '@mui/material/Divider';
 import FieldRow from '../../../components/shared/FieldRow.jsx';
 import EmailsSection from '../../../components/shared/EmailsSection.jsx';
 import PhoneNumbersSection from '../../../components/shared/PhoneNumbersSection.jsx';
-import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+import { dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../../config/layoutTokens.js';
 
 export default function ContactViewDialog({ open, onClose, contact, emails, phones }) {
   return (
@@ -28,7 +28,7 @@ export default function ContactViewDialog({ open, onClose, contact, emails, phon
       </DialogTitle>
       <DialogContent dividers>
         {contact && (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box sx={flexColumnSx}>
             <Box sx={detailGridSx}>
               <FieldRow label="First Name" value={contact.first_name} />
               <FieldRow label="Last Name" value={contact.last_name} />

--- a/apps/nap-client/src/pages/Core/vendors/VendorCreateDialog.jsx
+++ b/apps/nap-client/src/pages/Core/vendors/VendorCreateDialog.jsx
@@ -18,6 +18,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
+import { flexColumnSx } from '../../../config/layoutTokens.js';
 import Typography from '@mui/material/Typography';
 
 const dialogSx = { '& .MuiDialogTitle-root + .MuiDialogContent-root': { paddingTop: '16px' } };
@@ -50,7 +51,7 @@ export default function VendorCreateDialog({ open, onClose, createForm, onCreate
             </Button>
           </Box>
         </DialogTitle>
-        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <DialogContent sx={flexColumnSx}>
           <Tabs value={createTab} onChange={(_, v) => setCreateTab(v)} sx={{ borderBottom: 1, borderColor: 'divider' }}>
             <Tab label="Vendor" />
             <Tab label="Contacts" />

--- a/apps/nap-client/src/pages/Core/vendors/VendorEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/vendors/VendorEditDialog.jsx
@@ -29,7 +29,7 @@ import DataTable from '../../../components/shared/DataTable.jsx';
 import PatternTextField from '../../../components/shared/PatternTextField.jsx';
 import EmailRow from '../../../components/shared/EmailRow.jsx';
 import PhoneRow from '../../../components/shared/PhoneRow.jsx';
-import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../../config/layoutTokens.js';
+import { formGridSx, formGroupCardSx, formFullSpanSx, flexBetweenSx, flexColumnSx } from '../../../config/layoutTokens.js';
 import { TAX_TYPES, COUNTRIES } from '@nap/shared';
 
 const dialogSx = { '& .MuiDialogTitle-root + .MuiDialogContent-root': { paddingTop: '16px' } };
@@ -88,7 +88,7 @@ export default function VendorEditDialog({
             </Button>
           </Box>
         </DialogTitle>
-        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <DialogContent sx={flexColumnSx}>
           <Tabs value={editTab} onChange={(_, v) => setEditTab(v)} sx={{ borderBottom: 1, borderColor: 'divider' }}>
             <Tab label="Vendor" />
             <Tab label="Contacts" />
@@ -127,7 +127,7 @@ export default function VendorEditDialog({
 
               {/* ── Emails ──────────────────────────────────────────── */}
               <Divider />
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <Box sx={flexBetweenSx}>
                 <Typography variant="subtitle2">Emails</Typography>
                 <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
               </Box>
@@ -140,7 +140,7 @@ export default function VendorEditDialog({
 
               {/* ── Phone Numbers ──────────────────────────────────── */}
               <Divider />
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <Box sx={flexBetweenSx}>
                 <Typography variant="subtitle2">Phone Numbers</Typography>
                 <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
               </Box>
@@ -153,7 +153,7 @@ export default function VendorEditDialog({
 
               {/* ── Addresses ──────────────────────────────────────── */}
               <Divider />
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <Box sx={flexBetweenSx}>
                 <Typography variant="subtitle2">Addresses</Typography>
                 <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
               </Box>
@@ -188,7 +188,7 @@ export default function VendorEditDialog({
 
               {/* ── Tax Identifiers ──────────────────────────────────── */}
               <Divider />
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <Box sx={flexBetweenSx}>
                 <Typography variant="subtitle2">Tax Identifiers</Typography>
                 <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
               </Box>

--- a/apps/nap-client/src/pages/Settings/CompanyInfoPage.jsx
+++ b/apps/nap-client/src/pages/Settings/CompanyInfoPage.jsx
@@ -38,7 +38,7 @@ import {
   useArchiveTaxIdentifier,
 } from '../../hooks/useCompanyInfo.js';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
-import { pageContainerSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, flexBetweenSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useToast } from '../../hooks/useToast.js';
 import { cap, errMsg } from '../../utils/format.js';
 
@@ -114,7 +114,7 @@ function SetupCompanyForm({ tenantCode, tenantName, tenantId, onComplete, onErro
 
       {/* ── Company Name ───────────────────────────────────────── */}
       <Card variant="outlined">
-        <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <CardContent sx={flexColumnSx}>
           <Typography variant="subtitle2" fontWeight={600}>
             Company
           </Typography>
@@ -131,7 +131,7 @@ function SetupCompanyForm({ tenantCode, tenantName, tenantId, onComplete, onErro
 
       {/* ── Billing Address ────────────────────────────────────── */}
       <Card variant="outlined">
-        <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <CardContent sx={flexColumnSx}>
           <Typography variant="subtitle2" fontWeight={600}>
             Billing Address
           </Typography>
@@ -170,8 +170,8 @@ function SetupCompanyForm({ tenantCode, tenantName, tenantId, onComplete, onErro
 
       {/* ── Tax Identifiers ────────────────────────────────────── */}
       <Card variant="outlined">
-        <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <CardContent sx={flexColumnSx}>
+          <Box sx={flexBetweenSx}>
             <Typography variant="subtitle2" fontWeight={600}>
               Tax Identifiers
             </Typography>
@@ -284,8 +284,8 @@ function AddressCard({ address, isNew, sourceId, onSaved, onDeleted, onError }) 
 
   return (
     <Card variant="outlined">
-      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <CardContent sx={flexColumnSx}>
+        <Box sx={flexBetweenSx}>
           <Typography variant="subtitle2" fontWeight={600}>
             {isNew ? 'New Address' : `${cap(form.label)} Address`}
           </Typography>
@@ -481,8 +481,8 @@ export default function CompanyInfoPage() {
           </Card>
 
           {/* ── Addresses ────────────────────────────────────────── */}
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Box sx={flexColumnSx}>
+            <Box sx={flexBetweenSx}>
               <Typography variant="overline" color="text.secondary">
                 Addresses
               </Typography>
@@ -524,8 +524,8 @@ export default function CompanyInfoPage() {
           <Divider />
 
           {/* ── Tax Identifiers ──────────────────────────────────── */}
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Box sx={flexColumnSx}>
+            <Box sx={flexBetweenSx}>
               <Typography variant="overline" color="text.secondary">
                 Tax Identifiers
               </Typography>

--- a/apps/nap-client/src/pages/Settings/NumberingConfigPage.jsx
+++ b/apps/nap-client/src/pages/Settings/NumberingConfigPage.jsx
@@ -24,7 +24,7 @@ import Divider from '@mui/material/Divider';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
 import { useNumberingConfig, useUpdateNumberingConfig } from '../../hooks/useNumberingConfig.js';
-import { pageContainerSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, flexBetweenSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useToast } from '../../hooks/useToast.js';
 
 /* ── Constants ─────────────────────────────────────────────────── */
@@ -130,9 +130,9 @@ function NumberingCard({ config, onSave, saving }) {
 
   return (
     <Card variant="outlined" sx={{ opacity: form.is_enabled ? 1 : 0.7 }}>
-      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <CardContent sx={flexColumnSx}>
         {/* Header row */}
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Box sx={flexBetweenSx}>
           <Typography variant="subtitle1" fontWeight={600}>
             {label} Numbering
           </Typography>
@@ -316,13 +316,13 @@ export default function NumberingConfigPage() {
       </Typography>
 
       {isLoading ? (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box sx={flexColumnSx}>
           {[1, 2, 3].map((i) => (
             <Skeleton key={i} variant="rounded" height={80} />
           ))}
         </Box>
       ) : (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box sx={flexColumnSx}>
           {sorted.map((cfg) => (
             <NumberingCard key={cfg.id} config={cfg} onSave={handleSave} saving={savingId === cfg.id} />
           ))}

--- a/apps/nap-client/src/pages/Settings/PreferencesPage.jsx
+++ b/apps/nap-client/src/pages/Settings/PreferencesPage.jsx
@@ -21,7 +21,7 @@ import Skeleton from '@mui/material/Skeleton';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
 import { useTenantPreferences, useUpdateTenantPreferences } from '../../hooks/useTenantPreferences.js';
-import { pageContainerSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useToast } from '../../hooks/useToast.js';
 
 /* ── Constants ─────────────────────────────────────────────────── */
@@ -84,7 +84,7 @@ export default function PreferencesPage() {
         <Skeleton variant="rounded" height={120} />
       ) : (
         <Card variant="outlined" sx={{ maxWidth: 480 }}>
-          <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <CardContent sx={flexColumnSx}>
             <Typography variant="subtitle1" fontWeight={600}>
               Data Grid Display
             </Typography>

--- a/apps/nap-client/src/pages/Tenant/CreateTenantWizard.jsx
+++ b/apps/nap-client/src/pages/Tenant/CreateTenantWizard.jsx
@@ -27,6 +27,7 @@ import StepperFormDialog from '../../components/shared/StepperFormDialog.jsx';
 import PasswordField from '../../components/shared/PasswordField.jsx';
 import { useCreateTenant } from '../../hooks/useTenants.js';
 import { cap } from '../../utils/format.js';
+import { flexBetweenSx } from '../../config/layoutTokens.js';
 
 /* ── Constants ──────────────────────────────────────────────────── */
 
@@ -214,7 +215,7 @@ export default function CreateTenantWizard({ open, onClose, onSuccess }) {
           />
 
           <Divider sx={{ mt: 1 }} />
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Box sx={flexBetweenSx}>
             <Typography variant="overline" color="text.secondary">
               Tax Identifiers (optional)
             </Typography>

--- a/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageRolesPage.jsx
@@ -37,7 +37,7 @@ import FormDialog from '../../components/shared/FormDialog.jsx';
 import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
 import { useRoles, useCreateRole, useUpdateRole } from '../../hooks/useRoles.js';
-import { masterDetailSx, masterPanelSx, detailPanelSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
+import { masterDetailSx, masterPanelSx, detailPanelSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useToast } from '../../hooks/useToast.js';
 import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
@@ -257,7 +257,7 @@ export default function ManageRolesPage() {
         </DialogTitle>
         <DialogContent dividers>
           {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={flexColumnSx}>
               <Box sx={detailGridSx}>
                 <FieldRow label="Code" value={viewDialog.data.code} />
                 <FieldRow label="Name" value={viewDialog.data.name} />

--- a/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageUsersPage.jsx
@@ -32,7 +32,7 @@ import FormDialog from '../../components/shared/FormDialog.jsx';
 import PasswordField from '../../components/shared/PasswordField.jsx';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
 import { useUsers, useUpdateUser } from '../../hooks/useUsers.js';
-import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useToast } from '../../hooks/useToast.js';
 import { capSnake, fmtDate, errMsg } from '../../utils/format.js';
@@ -186,7 +186,7 @@ export default function ManageUsersPage() {
         </DialogTitle>
         <DialogContent dividers>
           {viewDialog.data && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={flexColumnSx}>
               <Box sx={detailGridSx}>
                 <FieldRow label="Email" value={viewDialog.data.email} />
                 <FieldRow label="Entity Type" value={capSnake(viewDialog.data.entity_type) || '\u2014'} />


### PR DESCRIPTION
## Summary
- Add `flexColumnSx` token to `layoutTokens.js` for the repeated `{ display: 'flex', flexDirection: 'column', gap: 2 }` pattern
- Apply `flexColumnSx` across 20 files (26 occurrences)
- Apply existing `flexBetweenSx` across 9 files (21 occurrences)
- 47 total inline sx patterns replaced with named tokens across 27 files

## Test plan
- [ ] Visual spot-check: open any dialog (view, edit, create) and confirm layout unchanged
- [ ] Check sub-collection section headers (Emails / Phones / Addresses / Tax IDs) still have Title + Add button side-by-side
- [ ] Check dialog content areas still stack vertically with consistent spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)