### PR TITLE
refactor: extract shared dialog, collection, and report page components

### DIFF
--- a/apps/nap-client/src/components/shared/CollectionSectionHeader.jsx
+++ b/apps/nap-client/src/components/shared/CollectionSectionHeader.jsx
@@ -1,0 +1,24 @@
+/**
+ * @file Shared editable collection section header with add action
+ * @module nap-client/components/shared/CollectionSectionHeader
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+
+import { flexBetweenSx } from '../../config/layoutTokens.js';
+
+export default function CollectionSectionHeader({ title, addLabel, onAdd }) {
+  return (
+    <Box sx={flexBetweenSx}>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Button size="small" startIcon={<AddIcon />} onClick={onAdd}>
+        {addLabel}
+      </Button>
+    </Box>
+  );
+}

--- a/apps/nap-client/src/components/shared/DetailDialog.jsx
+++ b/apps/nap-client/src/components/shared/DetailDialog.jsx
@@ -1,0 +1,45 @@
+/**
+ * @file Shared read-only detail dialog shell
+ * @module nap-client/components/shared/DetailDialog
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+
+import { dialogHeaderSx, dialogActionBoxSx } from '../../config/layoutTokens.js';
+
+export default function DetailDialog({
+  open,
+  onClose,
+  title,
+  subtitle,
+  maxWidth = 'sm',
+  children,
+}) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth={maxWidth} fullWidth>
+      <DialogTitle sx={dialogHeaderSx}>
+        <Box>
+          <span>{title}</span>
+          {subtitle && (
+            <Typography variant="body2" color="text.secondary">
+              {subtitle}
+            </Typography>
+          )}
+        </Box>
+        <Box sx={dialogActionBoxSx}>
+          <Button size="small" color="inherit" onClick={onClose}>
+            Close
+          </Button>
+        </Box>
+      </DialogTitle>
+      <DialogContent dividers>{children}</DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/nap-client/src/components/shared/EditableAddressesSection.jsx
+++ b/apps/nap-client/src/components/shared/EditableAddressesSection.jsx
@@ -1,0 +1,102 @@
+/**
+ * @file Shared editable addresses section for entity edit dialogs
+ * @module nap-client/components/shared/EditableAddressesSection
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import CollectionSectionHeader from './CollectionSectionHeader.jsx';
+import { formGridSx, formGroupCardSx, formFullSpanSx } from '../../config/layoutTokens.js';
+
+const addressHeaderSx = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  mb: 1,
+};
+
+const addressLabelFieldSx = { width: 200 };
+
+export default function EditableAddressesSection({
+  collection,
+  emptyMessage = 'No addresses',
+  addLabel = 'Add Address',
+}) {
+  return (
+    <>
+      <Divider />
+      <CollectionSectionHeader title="Addresses" addLabel={addLabel} onAdd={collection.add} />
+      {collection.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          {emptyMessage}
+        </Typography>
+      )}
+      {collection.indexedItems.map(({ item, index }) => (
+        <Box key={item.id || index} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+          <Box sx={addressHeaderSx}>
+            <TextField
+              label="Label"
+              value={item.label}
+              onChange={(e) => collection.update(index, 'label', e.target.value)}
+              size="small"
+              sx={addressLabelFieldSx}
+            />
+            <IconButton size="small" onClick={() => collection.remove(index)} color="error">
+              <DeleteOutlineIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <Box sx={formGridSx}>
+            <TextField
+              label="Address Line 1"
+              value={item.address_line_1}
+              onChange={(e) => collection.update(index, 'address_line_1', e.target.value)}
+              size="small"
+              sx={formFullSpanSx}
+            />
+            <TextField
+              label="Address Line 2"
+              value={item.address_line_2}
+              onChange={(e) => collection.update(index, 'address_line_2', e.target.value)}
+              size="small"
+              sx={formFullSpanSx}
+            />
+            <TextField
+              label="Address Line 3"
+              value={item.address_line_3 || ''}
+              onChange={(e) => collection.update(index, 'address_line_3', e.target.value)}
+              size="small"
+              sx={formFullSpanSx}
+            />
+            <TextField label="City" value={item.city} onChange={(e) => collection.update(index, 'city', e.target.value)} size="small" />
+            <TextField
+              label="State / Province"
+              value={item.state_province}
+              onChange={(e) => collection.update(index, 'state_province', e.target.value)}
+              size="small"
+            />
+            <TextField
+              label="Postal Code"
+              value={item.postal_code}
+              onChange={(e) => collection.update(index, 'postal_code', e.target.value)}
+              size="small"
+            />
+            <TextField
+              label="Country Code"
+              value={item.country_code}
+              onChange={(e) => collection.update(index, 'country_code', e.target.value)}
+              size="small"
+              inputProps={{ maxLength: 2 }}
+            />
+          </Box>
+        </Box>
+      ))}
+    </>
+  );
+}

--- a/apps/nap-client/src/components/shared/EditableEmailsSection.jsx
+++ b/apps/nap-client/src/components/shared/EditableEmailsSection.jsx
@@ -1,0 +1,43 @@
+/**
+ * @file Shared editable emails section for entity edit dialogs
+ * @module nap-client/components/shared/EditableEmailsSection
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+
+import CollectionSectionHeader from './CollectionSectionHeader.jsx';
+import EmailRow from './EmailRow.jsx';
+
+export default function EditableEmailsSection({
+  collection,
+  emptyMessage = 'No emails',
+  addLabel = 'Add Email',
+  showLogin = false,
+  loginDisabled = false,
+}) {
+  return (
+    <>
+      <Divider />
+      <CollectionSectionHeader title="Emails" addLabel={addLabel} onAdd={collection.add} />
+      {collection.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          {emptyMessage}
+        </Typography>
+      )}
+      {collection.indexedItems.map(({ item, index }) => (
+        <EmailRow
+          key={item.id || index}
+          item={item}
+          index={index}
+          onUpdate={collection.update}
+          onRemove={collection.remove}
+          showLogin={showLogin}
+          loginDisabled={loginDisabled}
+        />
+      ))}
+    </>
+  );
+}

--- a/apps/nap-client/src/components/shared/EditablePhoneNumbersSection.jsx
+++ b/apps/nap-client/src/components/shared/EditablePhoneNumbersSection.jsx
@@ -1,0 +1,33 @@
+/**
+ * @file Shared editable phone numbers section for entity edit dialogs
+ * @module nap-client/components/shared/EditablePhoneNumbersSection
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+
+import CollectionSectionHeader from './CollectionSectionHeader.jsx';
+import PhoneRow from './PhoneRow.jsx';
+
+export default function EditablePhoneNumbersSection({
+  collection,
+  emptyMessage = 'No phone numbers',
+  addLabel = 'Add Phone',
+}) {
+  return (
+    <>
+      <Divider />
+      <CollectionSectionHeader title="Phone Numbers" addLabel={addLabel} onAdd={collection.add} />
+      {collection.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          {emptyMessage}
+        </Typography>
+      )}
+      {collection.indexedItems.map(({ item, index }) => (
+        <PhoneRow key={item.id || index} item={item} index={index} onUpdate={collection.update} onRemove={collection.remove} />
+      ))}
+    </>
+  );
+}

--- a/apps/nap-client/src/components/shared/EditableTaxIdentifiersSection.jsx
+++ b/apps/nap-client/src/components/shared/EditableTaxIdentifiersSection.jsx
@@ -1,0 +1,102 @@
+/**
+ * @file Shared editable tax identifier section for entity edit dialogs
+ * @module nap-client/components/shared/EditableTaxIdentifiersSection
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import PatternTextField from './PatternTextField.jsx';
+import CollectionSectionHeader from './CollectionSectionHeader.jsx';
+import { formGroupCardSx } from '../../config/layoutTokens.js';
+import { TAX_TYPES, COUNTRIES } from '@nap/shared';
+
+const taxRowSx = {
+  display: 'flex',
+  gap: 1,
+  alignItems: 'center',
+  flexWrap: 'wrap',
+};
+
+const shortSelectSx = { minWidth: 80 };
+const taxValueSx = { flex: 1, minWidth: 160 };
+
+export default function EditableTaxIdentifiersSection({
+  collection,
+  emptyMessage = 'No tax identifiers',
+  addLabel = 'Add Tax ID',
+}) {
+  return (
+    <>
+      <Divider />
+      <CollectionSectionHeader title="Tax Identifiers" addLabel={addLabel} onAdd={collection.add} />
+      {collection.indexedItems.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          {emptyMessage}
+        </Typography>
+      )}
+      {collection.indexedItems.map(({ item, index }) => {
+        const countryCode = item.country_code?.trim() || '';
+        const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
+        return (
+          <Box key={item.id || index} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
+            <Box sx={taxRowSx}>
+              <TextField
+                select
+                label="Country"
+                value={countryCode}
+                onChange={(e) => {
+                  collection.update(index, 'country_code', e.target.value);
+                  const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
+                  collection.update(index, 'tax_type', newTypes[0]?.code || 'TIN');
+                }}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small"
+                sx={shortSelectSx}
+              >
+                {COUNTRIES.map((country) => (
+                  <MenuItem key={country.code} value={country.code}>
+                    {country.code} - {country.name}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                select
+                label="Type"
+                value={item.tax_type}
+                onChange={(e) => collection.update(index, 'tax_type', e.target.value)}
+                SelectProps={{ renderValue: (val) => val }}
+                size="small"
+                sx={shortSelectSx}
+              >
+                {taxTypes.map((taxType) => (
+                  <MenuItem key={taxType.code} value={taxType.code}>
+                    {taxType.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <PatternTextField
+                label="Tax ID Value"
+                value={item.tax_value}
+                onChange={(raw) => collection.update(index, 'tax_value', raw)}
+                pattern={taxTypes.find((taxType) => taxType.code === item.tax_type)?.placeholder}
+                size="small"
+                sx={taxValueSx}
+              />
+              <IconButton size="small" onClick={() => collection.remove(index)} color="error">
+                <DeleteOutlineIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          </Box>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/nap-client/src/components/shared/ReadOnlyDataTable.jsx
+++ b/apps/nap-client/src/components/shared/ReadOnlyDataTable.jsx
@@ -1,0 +1,23 @@
+/**
+ * @file Shared read-only DataGrid wrapper for detail views
+ * @module nap-client/components/shared/ReadOnlyDataTable
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import { DataGrid } from '@mui/x-data-grid';
+
+export default function ReadOnlyDataTable({ rows, columns, getRowId, dataGridProps = {} }) {
+  return (
+    <DataGrid
+      rows={rows}
+      columns={columns}
+      getRowId={getRowId}
+      autoHeight
+      hideFooter
+      disableColumnMenu
+      disableRowSelectionOnClick
+      {...dataGridProps}
+    />
+  );
+}

--- a/apps/nap-client/src/components/shared/ReportTablePage.jsx
+++ b/apps/nap-client/src/components/shared/ReportTablePage.jsx
@@ -1,0 +1,45 @@
+/**
+ * @file Shared report page shell with standard title and DataGrid
+ * @module nap-client/components/shared/ReportTablePage
+ *
+ * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
+ */
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { DataGrid } from '@mui/x-data-grid';
+
+import { pageContainerSx } from '../../config/layoutTokens.js';
+
+const reportHeaderSx = { p: 2 };
+
+export default function ReportTablePage({
+  title,
+  rows,
+  columns,
+  getRowId,
+  loading,
+  headerContent = null,
+  dataGridProps = {},
+}) {
+  return (
+    <Box sx={pageContainerSx}>
+      <Box sx={reportHeaderSx}>
+        <Typography variant="h6" gutterBottom>
+          {title}
+        </Typography>
+        {headerContent}
+      </Box>
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        getRowId={getRowId}
+        loading={loading}
+        pageSizeOptions={[25, 50, 100]}
+        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
+        disableRowSelectionOnClick
+        {...dataGridProps}
+      />
+    </Box>
+  );
+}

--- a/apps/nap-client/src/pages/Core/clients/ClientEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/clients/ClientEditDialog.jsx
@@ -8,23 +8,17 @@
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
-import Divider from '@mui/material/Divider';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import IconButton from '@mui/material/IconButton';
-import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
 import Autocomplete from '@mui/material/Autocomplete';
-import AddIcon from '@mui/icons-material/Add';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import LockResetIcon from '@mui/icons-material/LockReset';
 
 import FormDialog from '../../../components/shared/FormDialog.jsx';
-import PatternTextField from '../../../components/shared/PatternTextField.jsx';
-import EmailRow from '../../../components/shared/EmailRow.jsx';
-import PhoneRow from '../../../components/shared/PhoneRow.jsx';
-import { TAX_TYPES, COUNTRIES } from '@nap/shared';
-import { formGridSx, formGroupCardSx, formFullSpanSx, flexBetweenSx } from '../../../config/layoutTokens.js';
+import EditableAddressesSection from '../../../components/shared/EditableAddressesSection.jsx';
+import EditableEmailsSection from '../../../components/shared/EditableEmailsSection.jsx';
+import EditablePhoneNumbersSection from '../../../components/shared/EditablePhoneNumbersSection.jsx';
+import EditableTaxIdentifiersSection from '../../../components/shared/EditableTaxIdentifiersSection.jsx';
+import { formGridSx, formFullSpanSx } from '../../../config/layoutTokens.js';
 
 export default function ClientEditDialog({
   open,
@@ -79,114 +73,10 @@ export default function ClientEditDialog({
           sx={formFullSpanSx}
         />
       </Box>
-
-      {/* ── Emails ────────────────────────────────────────────── */}
-      <Divider />
-      <Box sx={flexBetweenSx}>
-        <Typography variant="subtitle2">Emails</Typography>
-        <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
-      </Box>
-      {emails.indexedItems.length === 0 && (
-        <Typography variant="body2" color="text.secondary">No emails</Typography>
-      )}
-      {emails.indexedItems.map(({ item: em, index: idx }) => (
-        <EmailRow key={em.id || idx} item={em} index={idx} onUpdate={emails.update} onRemove={emails.remove} />
-      ))}
-
-      {/* ── Phone Numbers ──────────────────────────────────── */}
-      <Divider />
-      <Box sx={flexBetweenSx}>
-        <Typography variant="subtitle2">Phone Numbers</Typography>
-        <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
-      </Box>
-      {phones.indexedItems.length === 0 && (
-        <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
-      )}
-      {phones.indexedItems.map(({ item: phone, index: idx }) => (
-        <PhoneRow key={phone.id || idx} item={phone} index={idx} onUpdate={phones.update} onRemove={phones.remove} />
-      ))}
-
-      {/* ── Addresses ──────────────────────────────────────── */}
-      <Divider />
-      <Box sx={flexBetweenSx}>
-        <Typography variant="subtitle2">Addresses</Typography>
-        <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
-      </Box>
-      {addresses.indexedItems.length === 0 && (
-        <Typography variant="body2" color="text.secondary">No addresses</Typography>
-      )}
-      {addresses.indexedItems.map(({ item: addr, index: idx }) => (
-        <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-            <TextField label="Label" value={addr.label} onChange={(e) => addresses.update(idx, 'label', e.target.value)} size="small" sx={{ width: 200 }} />
-            <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
-              <DeleteOutlineIcon fontSize="small" />
-            </IconButton>
-          </Box>
-          <Box sx={formGridSx}>
-            <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-            <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-            <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-            <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
-            <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
-            <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
-            <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
-          </Box>
-        </Box>
-      ))}
-
-      {/* ── Tax Identifiers ──────────────────────────────────── */}
-      <Divider />
-      <Box sx={flexBetweenSx}>
-        <Typography variant="subtitle2">Tax Identifiers</Typography>
-        <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
-      </Box>
-      {taxIds.indexedItems.length === 0 && (
-        <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
-      )}
-      {taxIds.indexedItems.map(({ item: taxId, index: idx }) => {
-        const countryCode = taxId.country_code?.trim() || '';
-        const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
-        return (
-          <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-              <TextField
-                select label="Country" value={countryCode}
-                onChange={(e) => {
-                  taxIds.update(idx, 'country_code', e.target.value);
-                  const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                  taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
-                }}
-                SelectProps={{ renderValue: (val) => val }}
-                size="small" sx={{ minWidth: 80 }}
-              >
-                {COUNTRIES.map((c) => (
-                  <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
-                ))}
-              </TextField>
-              <TextField
-                select label="Type" value={taxId.tax_type}
-                onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
-                SelectProps={{ renderValue: (val) => val }}
-                size="small" sx={{ minWidth: 80 }}
-              >
-                {taxTypes.map((t) => (
-                  <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
-                ))}
-              </TextField>
-              <PatternTextField
-                label="Tax ID Value" value={taxId.tax_value}
-                onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
-                pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
-                size="small" sx={{ flex: 1, minWidth: 160 }}
-              />
-              <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
-                <DeleteOutlineIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          </Box>
-        );
-      })}
+      <EditableEmailsSection collection={emails} />
+      <EditablePhoneNumbersSection collection={phones} />
+      <EditableAddressesSection collection={addresses} />
+      <EditableTaxIdentifiersSection collection={taxIds} />
     </FormDialog>
   );
 }

--- a/apps/nap-client/src/pages/Core/clients/ClientViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/clients/ClientViewDialog.jsx
@@ -6,12 +6,8 @@
  */
 
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import Typography from '@mui/material/Typography';
 
+import DetailDialog from '../../../components/shared/DetailDialog.jsx';
 import FieldRow from '../../../components/shared/FieldRow.jsx';
 import StatusBadge from '../../../components/shared/StatusBadge.jsx';
 import EmailsSection from '../../../components/shared/EmailsSection.jsx';
@@ -19,7 +15,7 @@ import PhoneNumbersSection from '../../../components/shared/PhoneNumbersSection.
 import AddressesSection from '../../../components/shared/AddressesSection.jsx';
 import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
 import { fmtDate } from '../../../utils/format.js';
-import { dialogHeaderSx, dialogActionBoxSx, detailGridSx, flexColumnSx } from '../../../config/layoutTokens.js';
+import { detailGridSx, flexColumnSx } from '../../../config/layoutTokens.js';
 
 export default function ClientViewDialog({
   open,
@@ -31,45 +27,28 @@ export default function ClientViewDialog({
   viewTaxIds,
 }) {
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle sx={dialogHeaderSx}>
-        <Box>
-          <span>Client Details</span>
-          {client && (
-            <Typography variant="body2" color="text.secondary">
-              {client.name}
-            </Typography>
-          )}
-        </Box>
-        <Box sx={dialogActionBoxSx}>
-          <Button size="small" color="inherit" onClick={onClose}>
-            Close
-          </Button>
-        </Box>
-      </DialogTitle>
-      <DialogContent dividers>
-        {client && (
-          <Box sx={flexColumnSx}>
-            <Box sx={detailGridSx}>
-              <FieldRow label="Code" value={client.code || '\u2014'} />
-              <FieldRow label="Name" value={client.name} />
-              <FieldRow label="Active" value={client.is_active ? 'Yes' : 'No'} />
-              <FieldRow label="App User" value={client.is_app_user ? 'Yes' : 'No'} />
-              <FieldRow label="Roles" value={client.roles?.length ? client.roles.join(', ') : '\u2014'} />
-              <FieldRow label="Status">
-                <StatusBadge status={client.deactivated_at ? 'archived' : 'active'} />
-              </FieldRow>
-              <FieldRow label="Created" value={fmtDate(client.created_at)} />
-              <FieldRow label="Updated" value={fmtDate(client.updated_at)} />
-            </Box>
-
-            <EmailsSection emails={viewEmails} />
-            <PhoneNumbersSection phones={viewPhones} />
-            <AddressesSection addresses={viewAddresses} />
-            <TaxIdentifiersSection taxIds={viewTaxIds} />
+    <DetailDialog open={open} onClose={onClose} title="Client Details" subtitle={client?.name}>
+      {client && (
+        <Box sx={flexColumnSx}>
+          <Box sx={detailGridSx}>
+            <FieldRow label="Code" value={client.code || '\u2014'} />
+            <FieldRow label="Name" value={client.name} />
+            <FieldRow label="Active" value={client.is_active ? 'Yes' : 'No'} />
+            <FieldRow label="App User" value={client.is_app_user ? 'Yes' : 'No'} />
+            <FieldRow label="Roles" value={client.roles?.length ? client.roles.join(', ') : '\u2014'} />
+            <FieldRow label="Status">
+              <StatusBadge status={client.deactivated_at ? 'archived' : 'active'} />
+            </FieldRow>
+            <FieldRow label="Created" value={fmtDate(client.created_at)} />
+            <FieldRow label="Updated" value={fmtDate(client.updated_at)} />
           </Box>
-        )}
-      </DialogContent>
-    </Dialog>
+
+          <EmailsSection emails={viewEmails} />
+          <PhoneNumbersSection phones={viewPhones} />
+          <AddressesSection addresses={viewAddresses} />
+          <TaxIdentifiersSection taxIds={viewTaxIds} />
+        </Box>
+      )}
+    </DetailDialog>
   );
 }

--- a/apps/nap-client/src/pages/Core/vendors/VendorEditDialog.jsx
+++ b/apps/nap-client/src/pages/Core/vendors/VendorEditDialog.jsx
@@ -13,24 +13,20 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
-import Divider from '@mui/material/Divider';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
 import ConfirmDialog from '../../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../../components/shared/DataTable.jsx';
-import PatternTextField from '../../../components/shared/PatternTextField.jsx';
-import EmailRow from '../../../components/shared/EmailRow.jsx';
-import PhoneRow from '../../../components/shared/PhoneRow.jsx';
-import { formGridSx, formGroupCardSx, formFullSpanSx, flexBetweenSx, flexColumnSx } from '../../../config/layoutTokens.js';
-import { TAX_TYPES, COUNTRIES } from '@nap/shared';
+import EditableAddressesSection from '../../../components/shared/EditableAddressesSection.jsx';
+import EditableEmailsSection from '../../../components/shared/EditableEmailsSection.jsx';
+import EditablePhoneNumbersSection from '../../../components/shared/EditablePhoneNumbersSection.jsx';
+import EditableTaxIdentifiersSection from '../../../components/shared/EditableTaxIdentifiersSection.jsx';
+import { formGridSx, flexColumnSx } from '../../../config/layoutTokens.js';
 
 const dialogSx = { '& .MuiDialogTitle-root + .MuiDialogContent-root': { paddingTop: '16px' } };
 
@@ -124,128 +120,10 @@ export default function VendorEditDialog({
                   label="Active"
                 />
               </Box>
-
-              {/* ── Emails ──────────────────────────────────────────── */}
-              <Divider />
-              <Box sx={flexBetweenSx}>
-                <Typography variant="subtitle2">Emails</Typography>
-                <Button size="small" startIcon={<AddIcon />} onClick={emails.add}>Add Email</Button>
-              </Box>
-              {emails.indexedItems.length === 0 && (
-                <Typography variant="body2" color="text.secondary">No emails</Typography>
-              )}
-              {emails.indexedItems.map(({ item: em, index: idx }) => (
-                <EmailRow key={em.id || idx} item={em} index={idx} onUpdate={emails.update} onRemove={emails.remove} />
-              ))}
-
-              {/* ── Phone Numbers ──────────────────────────────────── */}
-              <Divider />
-              <Box sx={flexBetweenSx}>
-                <Typography variant="subtitle2">Phone Numbers</Typography>
-                <Button size="small" startIcon={<AddIcon />} onClick={phones.add}>Add Phone</Button>
-              </Box>
-              {phones.indexedItems.length === 0 && (
-                <Typography variant="body2" color="text.secondary">No phone numbers</Typography>
-              )}
-              {phones.indexedItems.map(({ item: phone, index: idx }) => (
-                <PhoneRow key={phone.id || idx} item={phone} index={idx} onUpdate={phones.update} onRemove={phones.remove} />
-              ))}
-
-              {/* ── Addresses ──────────────────────────────────────── */}
-              <Divider />
-              <Box sx={flexBetweenSx}>
-                <Typography variant="subtitle2">Addresses</Typography>
-                <Button size="small" startIcon={<AddIcon />} onClick={addresses.add}>Add Address</Button>
-              </Box>
-              {addresses.indexedItems.length === 0 && (
-                <Typography variant="body2" color="text.secondary">No addresses</Typography>
-              )}
-              {addresses.indexedItems.map(({ item: addr, index: idx }) => (
-                <Box key={addr.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                    <TextField
-                      label="Label"
-                      value={addr.label}
-                      onChange={(e) => addresses.update(idx, 'label', e.target.value)}
-                      size="small"
-                      sx={{ width: 200 }}
-                    />
-                    <IconButton size="small" onClick={() => addresses.remove(idx)} color="error">
-                      <DeleteOutlineIcon fontSize="small" />
-                    </IconButton>
-                  </Box>
-                  <Box sx={formGridSx}>
-                    <TextField label="Address Line 1" value={addr.address_line_1} onChange={(e) => addresses.update(idx, 'address_line_1', e.target.value)} size="small" sx={formFullSpanSx} />
-                    <TextField label="Address Line 2" value={addr.address_line_2} onChange={(e) => addresses.update(idx, 'address_line_2', e.target.value)} size="small" sx={formFullSpanSx} />
-                    <TextField label="Address Line 3" value={addr.address_line_3 || ''} onChange={(e) => addresses.update(idx, 'address_line_3', e.target.value)} size="small" sx={formFullSpanSx} />
-                    <TextField label="City" value={addr.city} onChange={(e) => addresses.update(idx, 'city', e.target.value)} size="small" />
-                    <TextField label="State / Province" value={addr.state_province} onChange={(e) => addresses.update(idx, 'state_province', e.target.value)} size="small" />
-                    <TextField label="Postal Code" value={addr.postal_code} onChange={(e) => addresses.update(idx, 'postal_code', e.target.value)} size="small" />
-                    <TextField label="Country Code" value={addr.country_code} onChange={(e) => addresses.update(idx, 'country_code', e.target.value)} size="small" inputProps={{ maxLength: 2 }} />
-                  </Box>
-                </Box>
-              ))}
-
-              {/* ── Tax Identifiers ──────────────────────────────────── */}
-              <Divider />
-              <Box sx={flexBetweenSx}>
-                <Typography variant="subtitle2">Tax Identifiers</Typography>
-                <Button size="small" startIcon={<AddIcon />} onClick={taxIds.add}>Add Tax ID</Button>
-              </Box>
-              {taxIds.indexedItems.length === 0 && (
-                <Typography variant="body2" color="text.secondary">No tax identifiers</Typography>
-              )}
-              {taxIds.indexedItems.map(({ item: taxId, index: idx }) => {
-                const countryCode = taxId.country_code?.trim() || '';
-                const taxTypes = TAX_TYPES[countryCode] || TAX_TYPES._OTHER;
-                return (
-                  <Box key={taxId.id || idx} sx={{ ...formGroupCardSx, gridColumn: undefined }}>
-                    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-                      <TextField
-                        select
-                        label="Country"
-                        value={countryCode}
-                        onChange={(e) => {
-                          taxIds.update(idx, 'country_code', e.target.value);
-                          const newTypes = TAX_TYPES[e.target.value] || TAX_TYPES._OTHER;
-                          taxIds.update(idx, 'tax_type', newTypes[0]?.code || 'TIN');
-                        }}
-                        SelectProps={{ renderValue: (val) => val }}
-                        size="small"
-                        sx={{ minWidth: 80 }}
-                      >
-                        {COUNTRIES.map((c) => (
-                          <MenuItem key={c.code} value={c.code}>{c.code} - {c.name}</MenuItem>
-                        ))}
-                      </TextField>
-                      <TextField
-                        select
-                        label="Type"
-                        value={taxId.tax_type}
-                        onChange={(e) => taxIds.update(idx, 'tax_type', e.target.value)}
-                        SelectProps={{ renderValue: (val) => val }}
-                        size="small"
-                        sx={{ minWidth: 80 }}
-                      >
-                        {taxTypes.map((t) => (
-                          <MenuItem key={t.code} value={t.code}>{t.label}</MenuItem>
-                        ))}
-                      </TextField>
-                      <PatternTextField
-                        label="Tax ID Value"
-                        value={taxId.tax_value}
-                        onChange={(raw) => taxIds.update(idx, 'tax_value', raw)}
-                        pattern={taxTypes.find((t) => t.code === taxId.tax_type)?.placeholder}
-                        size="small"
-                        sx={{ flex: 1, minWidth: 160 }}
-                      />
-                      <IconButton size="small" onClick={() => taxIds.remove(idx)} color="error">
-                        <DeleteOutlineIcon fontSize="small" />
-                      </IconButton>
-                    </Box>
-                  </Box>
-                );
-              })}
+              <EditableEmailsSection collection={emails} />
+              <EditablePhoneNumbersSection collection={phones} />
+              <EditableAddressesSection collection={addresses} />
+              <EditableTaxIdentifiersSection collection={taxIds} />
             </Box>
           )}
 

--- a/apps/nap-client/src/pages/Core/vendors/VendorViewDialog.jsx
+++ b/apps/nap-client/src/pages/Core/vendors/VendorViewDialog.jsx
@@ -7,15 +7,11 @@
 
 import { useState } from 'react';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
 import Divider from '@mui/material/Divider';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-import Typography from '@mui/material/Typography';
 
+import DetailDialog from '../../../components/shared/DetailDialog.jsx';
 import StatusBadge from '../../../components/shared/StatusBadge.jsx';
 import FieldRow from '../../../components/shared/FieldRow.jsx';
 import DataTable from '../../../components/shared/DataTable.jsx';
@@ -23,7 +19,7 @@ import EmailsSection from '../../../components/shared/EmailsSection.jsx';
 import PhoneNumbersSection from '../../../components/shared/PhoneNumbersSection.jsx';
 import AddressesSection from '../../../components/shared/AddressesSection.jsx';
 import TaxIdentifiersSection from '../../../components/shared/TaxIdentifiersSection.jsx';
-import { dialogHeaderSx, dialogActionBoxSx, detailGridSx } from '../../../config/layoutTokens.js';
+import { detailGridSx } from '../../../config/layoutTokens.js';
 import { fmtDate } from '../../../utils/format.js';
 
 export default function VendorViewDialog({
@@ -48,71 +44,54 @@ export default function VendorViewDialog({
   };
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle sx={dialogHeaderSx}>
-        <Box>
-          <span>Vendor Details</span>
-          {vendor && (
-            <Typography variant="body2" color="text.secondary">
-              {vendor.name}
-            </Typography>
+    <DetailDialog open={open} onClose={handleClose} title="Vendor Details" subtitle={vendor?.name}>
+      {vendor && (
+        <>
+          <Tabs value={viewTab} onChange={(_, v) => setViewTab(v)} sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <Tab label="Vendor" />
+            <Tab label="Contacts" />
+          </Tabs>
+
+          {viewTab === 0 && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 2 }}>
+              <Box sx={detailGridSx}>
+                <FieldRow label="Code" value={vendor.code || '\u2014'} />
+                <FieldRow label="Vendor Name" value={vendor.name} />
+                <FieldRow label="Payment Terms" value={ptMap.get(vendor.payment_term_id) || '\u2014'} />
+                <FieldRow label="Active" value={vendor.is_active ? 'Yes' : 'No'} />
+                <FieldRow label="Status">
+                  <StatusBadge status={vendor.deactivated_at ? 'archived' : 'active'} />
+                </FieldRow>
+                <FieldRow label="Created" value={fmtDate(vendor.created_at)} />
+                <FieldRow label="Updated" value={fmtDate(vendor.updated_at)} />
+              </Box>
+              {vendor.notes && (
+                <>
+                  <Divider />
+                  <FieldRow label="Notes" value={vendor.notes} />
+                </>
+              )}
+
+              <EmailsSection emails={viewEmails} />
+              <PhoneNumbersSection phones={viewPhones} />
+              <AddressesSection addresses={viewAddresses} />
+              <TaxIdentifiersSection taxIds={viewTaxIds} />
+            </Box>
           )}
-        </Box>
-        <Box sx={dialogActionBoxSx}>
-          <Button size="small" color="inherit" onClick={handleClose}>
-            Close
-          </Button>
-        </Box>
-      </DialogTitle>
-      <DialogContent dividers>
-        {vendor && (
-          <>
-            <Tabs value={viewTab} onChange={(_, v) => setViewTab(v)} sx={{ borderBottom: 1, borderColor: 'divider' }}>
-              <Tab label="Vendor" />
-              <Tab label="Contacts" />
-            </Tabs>
 
-            {viewTab === 0 && (
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 2 }}>
-                <Box sx={detailGridSx}>
-                  <FieldRow label="Code" value={vendor.code || '\u2014'} />
-                  <FieldRow label="Vendor Name" value={vendor.name} />
-                  <FieldRow label="Payment Terms" value={ptMap.get(vendor.payment_term_id) || '\u2014'} />
-                  <FieldRow label="Active" value={vendor.is_active ? 'Yes' : 'No'} />
-                  <FieldRow label="Status">
-                    <StatusBadge status={vendor.deactivated_at ? 'archived' : 'active'} />
-                  </FieldRow>
-                  <FieldRow label="Created" value={fmtDate(vendor.created_at)} />
-                  <FieldRow label="Updated" value={fmtDate(vendor.updated_at)} />
-                </Box>
-                {vendor.notes && (
-                  <>
-                    <Divider />
-                    <FieldRow label="Notes" value={vendor.notes} />
-                  </>
-                )}
-
-                <EmailsSection emails={viewEmails} />
-                <PhoneNumbersSection phones={viewPhones} />
-                <AddressesSection addresses={viewAddresses} />
-                <TaxIdentifiersSection taxIds={viewTaxIds} />
-              </Box>
-            )}
-
-            {viewTab === 1 && (
-              <Box sx={{ pt: 2 }}>
-                <DataTable
-                  rows={viewContacts}
-                  columns={contactColumns}
-                  selection={contactSelection}
-                  onView={onViewContact}
-                  dataGridProps={{ autoHeight: true, checkboxSelection: false, pageSizeOptions: [10, 25] }}
-                />
-              </Box>
-            )}
-          </>
-        )}
-      </DialogContent>
-    </Dialog>
+          {viewTab === 1 && (
+            <Box sx={{ pt: 2 }}>
+              <DataTable
+                rows={viewContacts}
+                columns={contactColumns}
+                selection={contactSelection}
+                onView={onViewContact}
+                dataGridProps={{ autoHeight: true, checkboxSelection: false, pageSizeOptions: [10, 25] }}
+              />
+            </Box>
+          )}
+        </>
+      )}
+    </DetailDialog>
   );
 }

--- a/apps/nap-client/src/pages/Reports/ApAgingPage.jsx
+++ b/apps/nap-client/src/pages/Reports/ApAgingPage.jsx
@@ -7,13 +7,9 @@
  * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
  */
 
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import { DataGrid } from '@mui/x-data-grid';
-
 import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
+import ReportTablePage from '../../components/shared/ReportTablePage.jsx';
 import { useApAging } from '../../hooks/useReports.js';
-import { pageContainerSx } from '../../config/layoutTokens.js';
 
 const columns = [
   { field: 'vendor_code', headerName: 'Code', width: 100 },
@@ -31,21 +27,6 @@ export default function ApAgingPage() {
   const { data: rows = [], isLoading } = useApAging();
 
   return (
-    <Box sx={pageContainerSx}>
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6" gutterBottom>
-          AP Aging
-        </Typography>
-      </Box>
-      <DataGrid
-        rows={rows}
-        columns={columns}
-        getRowId={(r) => r.vendor_id || r.vendor_code}
-        loading={isLoading}
-        pageSizeOptions={[25, 50, 100]}
-        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
-        disableRowSelectionOnClick
-      />
-    </Box>
+    <ReportTablePage title="AP Aging" rows={rows} columns={columns} getRowId={(r) => r.vendor_id || r.vendor_code} loading={isLoading} />
   );
 }

--- a/apps/nap-client/src/pages/Reports/ArAgingPage.jsx
+++ b/apps/nap-client/src/pages/Reports/ArAgingPage.jsx
@@ -7,13 +7,9 @@
  * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
  */
 
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import { DataGrid } from '@mui/x-data-grid';
-
 import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
+import ReportTablePage from '../../components/shared/ReportTablePage.jsx';
 import { useArAging } from '../../hooks/useReports.js';
-import { pageContainerSx } from '../../config/layoutTokens.js';
 
 const columns = [
   { field: 'client_code', headerName: 'Code', width: 100 },
@@ -31,21 +27,6 @@ export default function ArAgingPage() {
   const { data: rows = [], isLoading } = useArAging();
 
   return (
-    <Box sx={pageContainerSx}>
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6" gutterBottom>
-          AR Aging
-        </Typography>
-      </Box>
-      <DataGrid
-        rows={rows}
-        columns={columns}
-        getRowId={(r) => r.client_id || r.client_code}
-        loading={isLoading}
-        pageSizeOptions={[25, 50, 100]}
-        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
-        disableRowSelectionOnClick
-      />
-    </Box>
+    <ReportTablePage title="AR Aging" rows={rows} columns={columns} getRowId={(r) => r.client_id || r.client_code} loading={isLoading} />
   );
 }

--- a/apps/nap-client/src/pages/Reports/CostBreakdownPage.jsx
+++ b/apps/nap-client/src/pages/Reports/CostBreakdownPage.jsx
@@ -11,14 +11,13 @@ import { useState, useMemo } from 'react';
 import Box from '@mui/material/Box';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
-import { DataGrid } from '@mui/x-data-grid';
 import { BarChart } from '@mui/x-charts/BarChart';
 
 import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
+import ReportTablePage from '../../components/shared/ReportTablePage.jsx';
 import { useProjects } from '../../hooks/useProjects.js';
 import { useCostBreakdown } from '../../hooks/useReports.js';
-import { pageContainerSx, chartContainerSx } from '../../config/layoutTokens.js';
+import { chartContainerSx } from '../../config/layoutTokens.js';
 
 const columns = [
   { field: 'category_code', headerName: 'Code', width: 100 },
@@ -40,50 +39,48 @@ export default function CostBreakdownPage() {
   const budgetData = useMemo(() => rows.map((r) => Number(r.budgeted_amount || 0)), [rows]);
   const actualData = useMemo(() => rows.map((r) => Number(r.actual_amount || 0)), [rows]);
 
-  return (
-    <Box sx={pageContainerSx}>
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6" gutterBottom>
-          Budget vs Actual
-        </Typography>
-        <TextField
-          select
-          label="Select Project"
-          value={projectId}
-          onChange={(e) => setProjectId(e.target.value)}
-          sx={{ minWidth: 300, mb: 2 }}
-          size="small"
-        >
-          <MenuItem value="">— Select —</MenuItem>
-          {projects.map((p) => (
-            <MenuItem key={p.id} value={p.id}>
-              {p.project_code} — {p.project_name || p.name}
-            </MenuItem>
-          ))}
-        </TextField>
+  const headerContent = (
+    <>
+      <TextField
+        select
+        label="Select Project"
+        value={projectId}
+        onChange={(e) => setProjectId(e.target.value)}
+        sx={{ minWidth: 300, mb: 2 }}
+        size="small"
+      >
+        <MenuItem value="">— Select —</MenuItem>
+        {projects.map((p) => (
+          <MenuItem key={p.id} value={p.id}>
+            {p.project_code} — {p.project_name || p.name}
+          </MenuItem>
+        ))}
+      </TextField>
 
-        {rows.length > 0 && (
-          <Box sx={chartContainerSx}>
-            <BarChart
-              xAxis={[{ data: chartLabels, scaleType: 'band' }]}
-              series={[
-                { data: budgetData, label: 'Budgeted', color: '#2196f3' },
-                { data: actualData, label: 'Actual', color: '#ff9800' },
-              ]}
-              height={280}
-            />
-          </Box>
-        )}
-      </Box>
-      <DataGrid
-        rows={rows}
-        columns={columns}
-        getRowId={(r) => r.category_code || Math.random()}
-        loading={isLoading}
-        pageSizeOptions={[25, 50]}
-        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
-        disableRowSelectionOnClick
-      />
-    </Box>
+      {rows.length > 0 && (
+        <Box sx={chartContainerSx}>
+          <BarChart
+            xAxis={[{ data: chartLabels, scaleType: 'band' }]}
+            series={[
+              { data: budgetData, label: 'Budgeted', color: '#2196f3' },
+              { data: actualData, label: 'Actual', color: '#ff9800' },
+            ]}
+            height={280}
+          />
+        </Box>
+      )}
+    </>
+  );
+
+  return (
+    <ReportTablePage
+      title="Budget vs Actual"
+      rows={rows}
+      columns={columns}
+      getRowId={(r) => r.category_code || `${r.category_name}-${r.category_type}`}
+      loading={isLoading}
+      headerContent={headerContent}
+      dataGridProps={{ pageSizeOptions: [25, 50] }}
+    />
   );
 }

--- a/apps/nap-client/src/pages/Reports/MarginAnalysisPage.jsx
+++ b/apps/nap-client/src/pages/Reports/MarginAnalysisPage.jsx
@@ -8,13 +8,10 @@
  */
 
 import { useState } from 'react';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import { DataGrid } from '@mui/x-data-grid';
 
 import PercentCell from '../../components/shared/PercentCell.jsx';
+import ReportTablePage from '../../components/shared/ReportTablePage.jsx';
 import { useMarginAnalysis } from '../../hooks/useReports.js';
-import { pageContainerSx } from '../../config/layoutTokens.js';
 import { statusColumn, currencyColumn } from '../../utils/columnHelpers.jsx';
 
 const SORT_FIELDS = new Set([
@@ -50,24 +47,17 @@ export default function MarginAnalysisPage() {
   const { data: rows = [], isLoading } = useMarginAnalysis(apiParams);
 
   return (
-    <Box sx={pageContainerSx}>
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6" gutterBottom>
-          Margin Analysis
-        </Typography>
-      </Box>
-      <DataGrid
-        rows={rows}
-        columns={columns}
-        getRowId={(r) => r.project_id || r.project_code}
-        loading={isLoading}
-        sortingMode="server"
-        sortModel={sortModel}
-        onSortModelChange={setSortModel}
-        pageSizeOptions={[25, 50, 100]}
-        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
-        disableRowSelectionOnClick
-      />
-    </Box>
+    <ReportTablePage
+      title="Margin Analysis"
+      rows={rows}
+      columns={columns}
+      getRowId={(r) => r.project_id || r.project_code}
+      loading={isLoading}
+      dataGridProps={{
+        sortingMode: 'server',
+        sortModel,
+        onSortModelChange: setSortModel,
+      }}
+    />
   );
 }

--- a/apps/nap-client/src/pages/Reports/ProjectCashflowPage.jsx
+++ b/apps/nap-client/src/pages/Reports/ProjectCashflowPage.jsx
@@ -11,14 +11,13 @@ import { useState, useMemo } from 'react';
 import Box from '@mui/material/Box';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
-import { DataGrid } from '@mui/x-data-grid';
 import { LineChart } from '@mui/x-charts/LineChart';
 
 import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
+import ReportTablePage from '../../components/shared/ReportTablePage.jsx';
 import { useProjects } from '../../hooks/useProjects.js';
 import { useProjectCashflow } from '../../hooks/useReports.js';
-import { pageContainerSx, chartContainerSx } from '../../config/layoutTokens.js';
+import { chartContainerSx } from '../../config/layoutTokens.js';
 
 const columns = [
   {
@@ -49,51 +48,49 @@ export default function ProjectCashflowPage() {
   const outflowData = useMemo(() => rows.map((r) => Number(r.outflow || 0)), [rows]);
   const netData = useMemo(() => rows.map((r) => Number(r.cumulative_net || 0)), [rows]);
 
-  return (
-    <Box sx={pageContainerSx}>
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6" gutterBottom>
-          Project Cashflow
-        </Typography>
-        <TextField
-          select
-          label="Select Project"
-          value={projectId}
-          onChange={(e) => setProjectId(e.target.value)}
-          sx={{ minWidth: 300, mb: 2 }}
-          size="small"
-        >
-          <MenuItem value="">— Select —</MenuItem>
-          {projects.map((p) => (
-            <MenuItem key={p.id} value={p.id}>
-              {p.project_code} — {p.project_name || p.name}
-            </MenuItem>
-          ))}
-        </TextField>
+  const headerContent = (
+    <>
+      <TextField
+        select
+        label="Select Project"
+        value={projectId}
+        onChange={(e) => setProjectId(e.target.value)}
+        sx={{ minWidth: 300, mb: 2 }}
+        size="small"
+      >
+        <MenuItem value="">— Select —</MenuItem>
+        {projects.map((p) => (
+          <MenuItem key={p.id} value={p.id}>
+            {p.project_code} — {p.project_name || p.name}
+          </MenuItem>
+        ))}
+      </TextField>
 
-        {rows.length > 0 && (
-          <Box sx={chartContainerSx}>
-            <LineChart
-              xAxis={[{ data: chartLabels, scaleType: 'band' }]}
-              series={[
-                { data: inflowData, label: 'Inflow', color: '#4caf50' },
-                { data: outflowData, label: 'Outflow', color: '#f44336' },
-                { data: netData, label: 'Cumulative Net', color: '#2196f3' },
-              ]}
-              height={280}
-            />
-          </Box>
-        )}
-      </Box>
-      <DataGrid
-        rows={rows}
-        columns={columns}
-        getRowId={(r) => r.month || Math.random()}
-        loading={isLoading}
-        pageSizeOptions={[25, 50]}
-        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
-        disableRowSelectionOnClick
-      />
-    </Box>
+      {rows.length > 0 && (
+        <Box sx={chartContainerSx}>
+          <LineChart
+            xAxis={[{ data: chartLabels, scaleType: 'band' }]}
+            series={[
+              { data: inflowData, label: 'Inflow', color: '#4caf50' },
+              { data: outflowData, label: 'Outflow', color: '#f44336' },
+              { data: netData, label: 'Cumulative Net', color: '#2196f3' },
+            ]}
+            height={280}
+          />
+        </Box>
+      )}
+    </>
+  );
+
+  return (
+    <ReportTablePage
+      title="Project Cashflow"
+      rows={rows}
+      columns={columns}
+      getRowId={(r) => r.month}
+      loading={isLoading}
+      headerContent={headerContent}
+      dataGridProps={{ pageSizeOptions: [25, 50] }}
+    />
   );
 }

--- a/apps/nap-client/src/pages/Reports/ProjectProfitabilityPage.jsx
+++ b/apps/nap-client/src/pages/Reports/ProjectProfitabilityPage.jsx
@@ -7,15 +7,11 @@
  * Copyright (c) 2025 – present NapSoft LLC. All rights reserved.
  */
 
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import { DataGrid } from '@mui/x-data-grid';
-
+import ReportTablePage from '../../components/shared/ReportTablePage.jsx';
 import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import CurrencyCell from '../../components/shared/CurrencyCell.jsx';
 import PercentCell from '../../components/shared/PercentCell.jsx';
 import { useProjectProfitability } from '../../hooks/useReports.js';
-import { pageContainerSx } from '../../config/layoutTokens.js';
 
 const columns = [
   { field: 'project_code', headerName: 'Code', width: 120 },
@@ -39,21 +35,12 @@ export default function ProjectProfitabilityPage() {
   const { data: rows = [], isLoading } = useProjectProfitability();
 
   return (
-    <Box sx={pageContainerSx}>
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6" gutterBottom>
-          Project Profitability
-        </Typography>
-      </Box>
-      <DataGrid
-        rows={rows}
-        columns={columns}
-        getRowId={(r) => r.project_id || r.project_code}
-        loading={isLoading}
-        pageSizeOptions={[25, 50, 100]}
-        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
-        disableRowSelectionOnClick
-      />
-    </Box>
+    <ReportTablePage
+      title="Project Profitability"
+      rows={rows}
+      columns={columns}
+      getRowId={(r) => r.project_id || r.project_code}
+      loading={isLoading}
+    />
   );
 }

--- a/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
+++ b/apps/nap-client/src/pages/Tenant/ManageTenantsPage.jsx
@@ -18,24 +18,21 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useFormState } from '../../hooks/useFormState.js';
 import { useDialogState } from '../../hooks/useDialogState.js';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
 import Divider from '@mui/material/Divider';
 import Link from '@mui/material/Link';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { DataGrid } from '@mui/x-data-grid';
 import StatusBadge from '../../components/shared/StatusBadge.jsx';
 import FieldRow from '../../components/shared/FieldRow.jsx';
 import TaxIdentifiersSection from '../../components/shared/TaxIdentifiersSection.jsx';
 import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
 import DataTable from '../../components/shared/DataTable.jsx';
+import DetailDialog from '../../components/shared/DetailDialog.jsx';
 import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
 import FormDialog from '../../components/shared/FormDialog.jsx';
 import ImportDialog from '../../components/shared/ImportDialog.jsx';
+import ReadOnlyDataTable from '../../components/shared/ReadOnlyDataTable.jsx';
 import CreateTenantWizard from './CreateTenantWizard.jsx';
 import { COUNTRIES, formatByPattern } from '@nap/shared';
 import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
@@ -51,7 +48,7 @@ import {
   TENANTS_KEY,
   TENANT_SCHEMAS_KEY,
 } from '../../hooks/useTenants.js';
-import { pageContainerSx, dialogHeaderSx, dialogActionBoxSx, formFullSpanSx, detailGridSx } from '../../config/layoutTokens.js';
+import { pageContainerSx, formFullSpanSx, detailGridSx } from '../../config/layoutTokens.js';
 import { useListSelection } from '../../hooks/useListSelection.js';
 import { useToast } from '../../hooks/useToast.js';
 import { cap, fmtDate, errMsg } from '../../utils/format.js';
@@ -338,123 +335,98 @@ export default function ManageTenantsPage() {
       />
 
       {/* ── View Details ───────────────────────────────────── */}
-      <Dialog open={detailDialog.isOpen} onClose={detailDialog.close} maxWidth="md" fullWidth>
-        <DialogTitle sx={dialogHeaderSx}>
-          <Box>
-            <span>Tenant Details</span>
-            {detailTenant && (
-              <Typography variant="body2" color="text.secondary">
-                {detailTenant.company}
-              </Typography>
-            )}
-          </Box>
-          <Box sx={dialogActionBoxSx}>
-            <Button size="small" color="inherit" onClick={detailDialog.close}>
-              Close
-            </Button>
-          </Box>
-        </DialogTitle>
-        <DialogContent dividers>
-          {detailTenant && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-              {/* ── Tenant fields ─────────────────────────────── */}
-              <Box sx={detailGridSx}>
-                <FieldRow label="Code" value={detailTenant.tenant_code} />
-                <FieldRow label="Tier" value={cap(detailTenant.tier)} />
-                <FieldRow label="Region" value={detailTenant.region || '\u2014'} />
-                <FieldRow label="Status">
-                  <StatusBadge status={detailTenant.status} />
-                </FieldRow>
-                <FieldRow label="Max Users" value={detailTenant.max_users ?? '\u2014'} />
-                <FieldRow label="Schema">
-                  <Typography variant="body2" fontFamily="monospace">
-                    {detailTenant.schema_name || '\u2014'}
-                  </Typography>
-                </FieldRow>
-                <FieldRow label="Created" value={fmtDate(detailTenant.created_at)} />
-                <FieldRow label="Updated" value={fmtDate(detailTenant.updated_at)} />
-                <FieldRow label="Notes" value={detailTenant.notes || '\u2014'} sx={formFullSpanSx} />
-              </Box>
-
-              {/* ── Company Address & Tax IDs ─────────────────── */}
-              {companyData?.company && (
-                <>
-                  <Divider />
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                    <Typography variant="overline" color="text.secondary">
-                      Company Billing Address
-                    </Typography>
-                    {companyData.addresses?.length ? (
-                      <Box sx={detailGridSx}>
-                        {companyData.addresses.map((a) => (
-                            <Box key={a.id} sx={{ gridColumn: '1 / -1' }}>
-                              <Typography variant="body2">
-                                {[a.address_line_1, a.address_line_2, a.address_line_3].filter(Boolean).join(', ')}
-                              </Typography>
-                              <Typography variant="body2">
-                                {[a.city, a.state_province, a.postal_code, a.country_code].filter(Boolean).join(', ')}
-                              </Typography>
-                            </Box>
-                          ))}
-                      </Box>
-                    ) : (
-                      <Typography variant="body2" color="text.secondary">
-                        No address on file
-                      </Typography>
-                    )}
-                  </Box>
-                  <TaxIdentifiersSection taxIds={companyData.tax_identifiers} />
-                </>
-              )}
-
-              {/* ── Contacts ──────────────────────────────────── */}
-              <Divider />
-
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                <Typography variant="overline" color="text.secondary">
-                  Primary Contacts
+      <DetailDialog open={detailDialog.isOpen} onClose={detailDialog.close} maxWidth="md" title="Tenant Details" subtitle={detailTenant?.company}>
+        {detailTenant && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+            {/* ── Tenant fields ─────────────────────────────── */}
+            <Box sx={detailGridSx}>
+              <FieldRow label="Code" value={detailTenant.tenant_code} />
+              <FieldRow label="Tier" value={cap(detailTenant.tier)} />
+              <FieldRow label="Region" value={detailTenant.region || '\u2014'} />
+              <FieldRow label="Status">
+                <StatusBadge status={detailTenant.status} />
+              </FieldRow>
+              <FieldRow label="Max Users" value={detailTenant.max_users ?? '\u2014'} />
+              <FieldRow label="Schema">
+                <Typography variant="body2" fontFamily="monospace">
+                  {detailTenant.schema_name || '\u2014'}
                 </Typography>
-                {contactsData?.primary?.length ? (
-                  <DataGrid
-                    rows={contactsData.primary}
-                    columns={contactColumns}
-                    getRowId={(r) => r.id}
-                    autoHeight
-                    hideFooter
-                    disableColumnMenu
-                    disableRowSelectionOnClick
-                  />
-                ) : (
-                  <Typography variant="body2" color="text.secondary">
-                    No primary contacts
-                  </Typography>
-                )}
-              </Box>
-
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                <Typography variant="overline" color="text.secondary">
-                  Billing Contacts
-                </Typography>
-                {contactsData?.billing?.length ? (
-                  <DataGrid
-                    rows={contactsData.billing}
-                    columns={contactColumns}
-                    getRowId={(r) => r.id}
-                    autoHeight
-                    hideFooter
-                    disableColumnMenu
-                    disableRowSelectionOnClick
-                  />
-                ) : (
-                  <Typography variant="body2" color="text.secondary">
-                    No billing contacts
-                  </Typography>
-                )}
-              </Box>
+              </FieldRow>
+              <FieldRow label="Created" value={fmtDate(detailTenant.created_at)} />
+              <FieldRow label="Updated" value={fmtDate(detailTenant.updated_at)} />
+              <FieldRow label="Notes" value={detailTenant.notes || '\u2014'} sx={formFullSpanSx} />
             </Box>
-          )}
-        </DialogContent>
-      </Dialog>
+
+            {/* ── Company Address & Tax IDs ─────────────────── */}
+            {companyData?.company && (
+              <>
+                <Divider />
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <Typography variant="overline" color="text.secondary">
+                    Company Billing Address
+                  </Typography>
+                  {companyData.addresses?.length ? (
+                    <Box sx={detailGridSx}>
+                      {companyData.addresses.map((a) => (
+                        <Box key={a.id} sx={{ gridColumn: '1 / -1' }}>
+                          <Typography variant="body2">
+                            {[a.address_line_1, a.address_line_2, a.address_line_3].filter(Boolean).join(', ')}
+                          </Typography>
+                          <Typography variant="body2">
+                            {[a.city, a.state_province, a.postal_code, a.country_code].filter(Boolean).join(', ')}
+                          </Typography>
+                        </Box>
+                      ))}
+                    </Box>
+                  ) : (
+                    <Typography variant="body2" color="text.secondary">
+                      No address on file
+                    </Typography>
+                  )}
+                </Box>
+                <TaxIdentifiersSection taxIds={companyData.tax_identifiers} />
+              </>
+            )}
+
+            {/* ── Contacts ──────────────────────────────────── */}
+            <Divider />
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Typography variant="overline" color="text.secondary">
+                Primary Contacts
+              </Typography>
+              {contactsData?.primary?.length ? (
+                <ReadOnlyDataTable
+                  rows={contactsData.primary}
+                  columns={contactColumns}
+                  getRowId={(r) => r.id}
+                />
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  No primary contacts
+                </Typography>
+              )}
+            </Box>
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Typography variant="overline" color="text.secondary">
+                Billing Contacts
+              </Typography>
+              {contactsData?.billing?.length ? (
+                <ReadOnlyDataTable
+                  rows={contactsData.billing}
+                  columns={contactColumns}
+                  getRowId={(r) => r.id}
+                />
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  No billing contacts
+                </Typography>
+              )}
+            </Box>
+          </Box>
+        )}
+      </DetailDialog>
 
       {/* ── Create Wizard ──────────────────────────────────── */}
       <CreateTenantWizard open={createDialog.isOpen} onClose={createDialog.close} onSuccess={toast} />


### PR DESCRIPTION
## Summary
- Extract `DetailDialog`, `CollectionSectionHeader`, and four `Editable*Section` components from duplicated Client/Vendor edit/view dialog markup
- Extract `ReportTablePage` to replace repeated page-shell + DataGrid boilerplate across all 6 report pages
- Add `ReadOnlyDataTable` wrapper for detail-view grids in ManageTenantsPage
- Fix unstable `Math.random()` `getRowId` keys in CostBreakdown and ProjectCashflow pages

## Test plan
- [x] Verify Client and Vendor edit dialogs render emails, phones, addresses, and tax identifiers correctly
- [x] Verify Client and Vendor view dialogs display entity details with correct layout
- [x] Verify all 6 report pages render title, header content, and DataGrid as before
- [x] Verify Tenant detail dialog displays contacts, addresses, and tax IDs
- [x] Confirm no console warnings about missing keys in CostBreakdown/ProjectCashflow grids

🤖 Generated with [Claude Code](https://claude.com/claude-code)