### PR TITLE
fix: address Copilot review on PR #36

### DIFF
--- a/apps/client/src/components/shared/DataTable.jsx
+++ b/apps/client/src/components/shared/DataTable.jsx
@@ -79,7 +79,8 @@ export default function DataTable({
       cellClassName: 'row-actions-cell',
       renderCell: (params) => {
         const extra = isRowActionsFn ? rowActions(params.row) : rowActions;
-        const actions = [...baseActions, ...extra];
+        const extraArr = Array.isArray(extra) ? extra : [];
+        const actions = [...baseActions, ...extraArr];
         return <RowActionsMenu row={params.row} actions={actions} />;
       },
     };

--- a/apps/client/src/hooks/useCompanyInfo.js
+++ b/apps/client/src/hooks/useCompanyInfo.js
@@ -37,8 +37,8 @@ export function useSelfCompany(tenantCode) {
   });
 }
 
-/** Fetch addresses for a given source_id. */
-export function useAddresses(sourceId) {
+/** Fetch addresses for a given source_id (Settings → Company Info scope). */
+export function useCompanyInfoAddresses(sourceId) {
   return useQuery({
     queryKey: [...COMPANY_INFO_KEY, 'addresses', sourceId],
     queryFn: () => addressApi.list({ source_id: sourceId }),
@@ -50,8 +50,8 @@ export function useAddresses(sourceId) {
   });
 }
 
-/** Fetch tax identifiers for a given source_id. */
-export function useTaxIdentifiers(sourceId) {
+/** Fetch tax identifiers for a given source_id (Settings → Company Info scope). */
+export function useCompanyInfoTaxIdentifiers(sourceId) {
   return useQuery({
     queryKey: [...COMPANY_INFO_KEY, 'tax-identifiers', sourceId],
     queryFn: () => taxIdentifierApi.list({ source_id: sourceId }),

--- a/apps/client/src/hooks/useImportExport.js
+++ b/apps/client/src/hooks/useImportExport.js
@@ -44,7 +44,9 @@ export function useExportXls(exportFn, filePrefix) {
       document.body.appendChild(a);
       a.click();
       a.remove();
-      URL.revokeObjectURL(url);
+      // Defer revoke so Safari/older browsers have time to initiate the
+      // download before the blob URL is invalidated.
+      window.setTimeout(() => URL.revokeObjectURL(url), 0);
     },
   });
 }

--- a/apps/client/src/hooks/useListSelection.js
+++ b/apps/client/src/hooks/useListSelection.js
@@ -9,7 +9,7 @@
  */
 
 import { useState, useRef, useCallback, useMemo } from 'react';
-import { deriveSelectionState, buildMutualExclusionHandler } from '../utils/selectionUtils.js';
+import { deriveSelectionState, buildMutualExclusionHandler, applyMutualExclusion } from '../utils/selectionUtils.js';
 
 /**
  * @param {Array}  rows - visible DataGrid rows (must have `id` field)
@@ -35,6 +35,10 @@ export function useListSelection(rows, entityType) {
    * Handle row body clicks with modifier key awareness.
    * Bound to DataGrid onRowClick. Checkboxes and action cells are skipped —
    * those paths are handled by onRowSelectionModelChange and RowActionsMenu.
+   *
+   * When `entityType` is set, the resolved next selection is gated through the
+   * same mutual-exclusion rule applied by handleSelectionModelChange so that
+   * Ctrl/Shift-Click cannot bypass root-entity invariants.
    */
   const handleRowClick = useCallback(
     (params, event) => {
@@ -47,6 +51,7 @@ export function useListSelection(rows, entityType) {
       if (target.closest?.('.row-actions-cell')) return;
 
       const id = params.id;
+      const gate = (prev, next) => (entityType ? applyMutualExclusion(prev, next, rows, entityType) : next);
 
       if (event.shiftKey && lastClickedId.current != null) {
         // Shift+Click: range selection
@@ -55,7 +60,7 @@ export function useListSelection(rows, entityType) {
 
         if (anchorIdx === -1) {
           // Anchor not in current view — treat as plain click
-          setSelectionModel([id]);
+          setSelectionModel((prev) => gate(prev, [id]));
           lastClickedId.current = id;
           return;
         }
@@ -68,7 +73,7 @@ export function useListSelection(rows, entityType) {
         setSelectionModel((prev) => {
           const merged = new Set(prev);
           for (const rid of rangeIds) merged.add(rid);
-          return Array.from(merged);
+          return gate(prev, Array.from(merged));
         });
         // Do NOT update lastClickedId for shift-click
         return;
@@ -83,17 +88,17 @@ export function useListSelection(rows, entityType) {
           } else {
             set.add(id);
           }
-          return Array.from(set);
+          return gate(prev, Array.from(set));
         });
         lastClickedId.current = id;
         return;
       }
 
       // Plain click: select only this record
-      setSelectionModel([id]);
+      setSelectionModel((prev) => gate(prev, [id]));
       lastClickedId.current = id;
     },
-    [rows],
+    [rows, entityType],
   );
 
   /**

--- a/apps/client/src/pages/Settings/CompanyInfoPage.jsx
+++ b/apps/client/src/pages/Settings/CompanyInfoPage.jsx
@@ -30,8 +30,8 @@ import { useAuth } from '../../contexts/AuthContext.jsx';
 import {
   useSelfCompany,
   useCreateCompany,
-  useAddresses,
-  useTaxIdentifiers,
+  useCompanyInfoAddresses,
+  useCompanyInfoTaxIdentifiers,
   useCreateAddress,
   useUpdateAddress,
   useArchiveAddress,
@@ -425,8 +425,8 @@ export default function CompanyInfoPage() {
 
   const { data: company, isLoading: companyLoading } = useSelfCompany(tenantCode);
   const sourceId = company?.source_id;
-  const { data: addresses = [], isLoading: addrLoading } = useAddresses(sourceId);
-  const { data: taxIds = [], isLoading: taxLoading } = useTaxIdentifiers(sourceId);
+  const { data: addresses = [], isLoading: addrLoading } = useCompanyInfoAddresses(sourceId);
+  const { data: taxIds = [], isLoading: taxLoading } = useCompanyInfoTaxIdentifiers(sourceId);
 
   const [newAddresses, setNewAddresses] = useState([]);
   const [newTaxIds, setNewTaxIds] = useState([]);

--- a/apps/client/src/utils/selectionUtils.js
+++ b/apps/client/src/utils/selectionUtils.js
@@ -44,23 +44,16 @@ export function applyMutualExclusion(prevModel, newModel, rows, entityType) {
 
   if (added.length === 0) return newModel;
 
-  const rowById = (id) => rows.find((r) => r.id === id);
-  const addedHasRoot = added.some((id) => {
-    const r = rowById(id);
-    return r && isRootEntity(r, entityType);
-  });
+  // O(1) id → row lookups; avoids the prior O(rows × selectionSize) cost
+  // when this runs on every modifier-key click and large-selection updates.
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  const isRoot = (id) => {
+    const r = byId.get(id);
+    return !!r && isRootEntity(r, entityType);
+  };
 
-  if (addedHasRoot) {
-    return added.filter((id) => {
-      const r = rowById(id);
-      return r && isRootEntity(r, entityType);
-    });
-  }
-
-  return newModel.filter((id) => {
-    const r = rowById(id);
-    return !r || !isRootEntity(r, entityType);
-  });
+  if (added.some(isRoot)) return added.filter(isRoot);
+  return newModel.filter((id) => !isRoot(id));
 }
 
 /**

--- a/apps/client/src/utils/selectionUtils.js
+++ b/apps/client/src/utils/selectionUtils.js
@@ -24,10 +24,48 @@ export function isRootEntity(row, entityType) {
 }
 
 /**
- * Build an onRowSelectionModelChange handler that enforces mutual exclusion
- * for root entities:
+ * Pure transform that enforces root-entity mutual exclusion on a proposed
+ * selection model:
  *   - Selecting a root entity deselects everything else.
  *   - Selecting a non-root entity while root is selected deselects root.
+ *
+ * Used by both checkbox/keyboard paths (via buildMutualExclusionHandler) and
+ * row-click paths (useListSelection.handleRowClick) to keep behavior identical.
+ *
+ * @param {Array} prevModel  – previous selectionModel
+ * @param {Array} newModel   – proposed next selectionModel
+ * @param {Array} rows       – visible DataGrid rows
+ * @param {'tenant'|'user'} entityType
+ * @returns {Array} the resolved selectionModel
+ */
+export function applyMutualExclusion(prevModel, newModel, rows, entityType) {
+  const prevSet = new Set(prevModel);
+  const added = newModel.filter((id) => !prevSet.has(id));
+
+  if (added.length === 0) return newModel;
+
+  const rowById = (id) => rows.find((r) => r.id === id);
+  const addedHasRoot = added.some((id) => {
+    const r = rowById(id);
+    return r && isRootEntity(r, entityType);
+  });
+
+  if (addedHasRoot) {
+    return added.filter((id) => {
+      const r = rowById(id);
+      return r && isRootEntity(r, entityType);
+    });
+  }
+
+  return newModel.filter((id) => {
+    const r = rowById(id);
+    return !r || !isRootEntity(r, entityType);
+  });
+}
+
+/**
+ * Build an onRowSelectionModelChange handler that enforces mutual exclusion
+ * for root entities. Thin wrapper around {@link applyMutualExclusion}.
  *
  * @param {Object}   opts
  * @param {Array}    opts.rows        – visible DataGrid rows
@@ -38,38 +76,7 @@ export function isRootEntity(row, entityType) {
  */
 export function buildMutualExclusionHandler({ rows, prevModel, setModel, entityType }) {
   return (newModel) => {
-    const prevSet = new Set(prevModel);
-    const added = newModel.filter((id) => !prevSet.has(id));
-
-    if (added.length === 0) {
-      setModel(newModel);
-      return;
-    }
-
-    const rowById = (id) => rows.find((r) => r.id === id);
-    const addedHasRoot = added.some((id) => {
-      const r = rowById(id);
-      return r && isRootEntity(r, entityType);
-    });
-
-    if (addedHasRoot) {
-      // Root was just selected → keep only root IDs from the added set
-      setModel(
-        added.filter((id) => {
-          const r = rowById(id);
-          return r && isRootEntity(r, entityType);
-        }),
-      );
-      return;
-    }
-
-    // Non-root added → strip any root entities that were already selected
-    setModel(
-      newModel.filter((id) => {
-        const r = rowById(id);
-        return !r || !isRootEntity(r, entityType);
-      }),
-    );
+    setModel(applyMutualExclusion(prevModel, newModel, rows, entityType));
   };
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the Copilot review on [#36](https://github.com/silverstone-i/axerra/pull/36). Addresses 4 of the 6 comments. The 5th is tracked in [#35](https://github.com/silverstone-i/axerra/issues/35) (deferred — design decision). The 6th (PreferencesPage empty state) is intentionally skipped — production tenants are seeded via [tenantPreferencesSeeder.js](apps/server/src/system/core/services/tenantPreferencesSeeder.js).

### Fixes

- **`useListSelection`** — Ctrl/Shift+Click on root-tenant entity pages bypassed the mutual-exclusion rule the checkbox path enforced. Extracted a pure `applyMutualExclusion(prevModel, newModel, rows, entityType)` helper from `buildMutualExclusionHandler` and apply it in `handleRowClick` when `entityType` is set.
- **`useImportExport`** — `URL.revokeObjectURL` ran synchronously after `a.click()`, intermittently breaking downloads in Safari. Now deferred via `window.setTimeout(…, 0)`.
- **`useCompanyInfo`** — Renamed `useAddresses` / `useTaxIdentifiers` to `useCompanyInfoAddresses` / `useCompanyInfoTaxIdentifiers` to remove the name collision with the general-purpose hooks in `useAddresses.js` / `useTaxIdentifiers.js`. Updated `CompanyInfoPage` imports and call sites.
- **`DataTable`** — Defensive normalization: when `rowActions` is a function and a caller returns `null`/`undefined` for a row, `[...extra]` no longer throws. Coerced to `[]` first.

## Test plan

- [x] `npm run lint` clean
- [x] `npm -w apps/server` test suites green (verified via pre-push hook)
- [ ] CI: 2 required status checks pass