### PR TITLE
chore: document Option 4 git workflow + sync scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - **Never add `Co-Authored-By` lines** to commit messages — suppress the default trailer entirely
 - Husky pre-commit rejects mixed commits touching both `apps/client/` and `apps/server/` — split into separate commits
-- Working branch: `dev`; PRs target `dev` (PRs to `main` only for releases)
+- Working branch: `dev`. PRs are required for both `dev` and `main`. Feature branches PR into `dev`; releases use `bash scripts/git/release-to-main.sh <version>` then `bash scripts/git/sync-main-to-dev.sh`. Full workflow: [docs/workflow.md](docs/workflow.md).
 
 ## Project Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - **Never add `Co-Authored-By` lines** to commit messages — suppress the default trailer entirely
 - Husky pre-commit rejects mixed commits touching both `apps/client/` and `apps/server/` — split into separate commits
-- Working branch: `dev`. PRs are required for both `dev` and `main`. Feature branches PR into `dev`; releases use `bash scripts/git/release-to-main.sh <version>` then `bash scripts/git/sync-main-to-dev.sh`. Full workflow: [docs/workflow.md](docs/workflow.md).
+- Working branch: `dev`. PRs are required for both `dev` and `main`. Feature branches PR into `dev`; releases use `bash scripts/git/release-to-main.sh v<version>` (e.g. `v0.2.0` — `v` prefix required) then `bash scripts/git/sync-main-to-dev.sh`. Full workflow: [docs/workflow.md](docs/workflow.md).
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **Never add `Co-Authored-By` lines** to commit messages — suppress the default trailer entirely
 - Husky pre-commit rejects mixed commits touching both `apps/client/` and `apps/server/` — split into separate commits
-- Working branch: `dev`; PRs target `dev` (PRs to `main` only for releases)
+- Working branch: `dev`. PRs are required for both `dev` and `main`. Feature branches PR into `dev`; releases use `bash scripts/git/release-to-main.sh <version>` then `bash scripts/git/sync-main-to-dev.sh`. Full workflow: [docs/workflow.md](docs/workflow.md).
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **Never add `Co-Authored-By` lines** to commit messages — suppress the default trailer entirely
 - Husky pre-commit rejects mixed commits touching both `apps/client/` and `apps/server/` — split into separate commits
-- Working branch: `dev`. PRs are required for both `dev` and `main`. Feature branches PR into `dev`; releases use `bash scripts/git/release-to-main.sh <version>` then `bash scripts/git/sync-main-to-dev.sh`. Full workflow: [docs/workflow.md](docs/workflow.md).
+- Working branch: `dev`. PRs are required for both `dev` and `main`. Feature branches PR into `dev`; releases use `bash scripts/git/release-to-main.sh v<version>` (e.g. `v0.2.0` — `v` prefix required) then `bash scripts/git/sync-main-to-dev.sh`. Full workflow: [docs/workflow.md](docs/workflow.md).
 
 ## Project Overview
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,143 @@
+# Git Workflow
+
+Branch protection on both `main` and `dev` requires PRs to land any change. This
+keeps a structured review surface (CI checks, Copilot review on `dev`) for
+feature work. The two `dev↔main` sync flows are scripted as one-liners so the
+PR ceremony stays out of the way for routine maintenance.
+
+## TL;DR
+
+| Flow | Command |
+|---|---|
+| Feature branch → `dev` | `gh pr create --base dev --head feature/foo` → review → merge in UI |
+| `dev` → `main` (release) | `bash scripts/git/release-to-main.sh v0.2.0` |
+| `main` → `dev` (sync) | `bash scripts/git/sync-main-to-dev.sh` |
+
+## Branch protection (what's enforced)
+
+Both `main` and `dev` enforce:
+
+- **Pull request required** — no direct pushes
+- **Required status checks** — `Lint`, `Architecture Check` must pass
+- **Force-push blocked** (`non_fast_forward`)
+- **Branch deletion blocked**
+
+`dev` additionally enforces **Copilot code review** on every PR.
+
+The helper scripts use `gh pr merge --admin` to bypass the required-review gate
+for `dev↔main` sync PRs, since those are mechanical and have no reviewer.
+
+## 1. Feature branch → dev
+
+Standard PR flow. No script — `gh pr create` is one line and you usually want to
+read Copilot's review before merging.
+
+```bash
+# Branch off the latest dev
+git checkout dev && git pull
+git checkout -b feature/your-feature
+
+# Develop. Husky pre-commit rejects mixed commits touching both
+# apps/client/ and apps/server/ — split into separate commits.
+git add ...
+git commit -m "..."
+
+# Push and open a PR
+git push -u origin feature/your-feature
+gh pr create --base dev --head feature/your-feature \
+  --title "feat: ..." \
+  --body "..."
+
+# Wait for CI (Lint + Architecture Check) and Copilot review.
+# Address any feedback, push more commits to the branch.
+
+# Merge in the GitHub UI (or `gh pr merge --squash`), then clean up:
+git checkout dev && git pull
+git branch -d feature/your-feature
+git push origin --delete feature/your-feature
+```
+
+## 2. dev → main (release) — `--ff-only` equivalent
+
+For releases, use `scripts/git/release-to-main.sh`. The script squash-merges all
+of `dev`'s changes into a single commit on `main`, keeping `main`'s log clean as
+a release ledger, and creates+pushes the version tag.
+
+```bash
+bash scripts/git/release-to-main.sh v0.2.0
+```
+
+The script:
+
+1. Aborts if `dev` and `main` are already in sync (nothing to release).
+2. Asks for confirmation.
+3. Opens a PR `dev → main` titled `Release v0.2.0`.
+4. Squash-merges with `--admin` (bypasses required reviews).
+5. Tags `origin/main`'s new tip as `v0.2.0` and pushes the tag.
+
+> **Why squash, not `--ff-only` literal?** GitHub PR merges can't do strict
+> fast-forward via the API. Squash is the closest equivalent for a release: one
+> commit on `main` representing the release, no merge-commit noise. After the
+> squash, run the sync script (next section) to align `dev` with the new `main`.
+
+## 3. main → dev (sync) — post-release alignment
+
+After a squash release, `main` has a new commit (the squash) that's not on
+`dev`'s history. Run the sync script to bring `dev` up to date so the histories
+align in tools like Git Graph.
+
+```bash
+bash scripts/git/sync-main-to-dev.sh
+```
+
+The script:
+
+1. Aborts if `dev` is already up to date with `main`.
+2. Opens a PR `main → dev` titled `chore: sync main into dev`.
+3. Merge-commits (not squash) with `--admin`. The merge commit ties the histories
+   together — `main`'s commit becomes reachable from `dev`'s tip.
+
+> **Why a merge commit, not `--ff-only`?** `dev` has commits `main` doesn't have
+> any more (the original feature commits, before the release squash). A
+> merge commit is the only way to bridge them without rewriting either side's
+> SHAs.
+
+## 4. Helper scripts — reference
+
+Both scripts live in `scripts/git/`. Run from the repo root.
+
+### `release-to-main.sh <version>`
+
+Squash-merges `dev` into `main` and tags the result.
+
+- **Input:** `<version>` — the tag name (e.g. `v0.2.0`).
+- **Side effects:** opens a PR, merges it, pushes a tag. All on `origin`.
+- **Idempotent?** Yes — exits early if `dev` and `main` are in sync.
+- **Failure modes:** `gh` not authenticated; CI failing on the PR (manual
+  intervention needed — the `--admin` flag overrides reviews but not status
+  check failures, depending on ruleset config).
+
+### `sync-main-to-dev.sh`
+
+Merge-commits `main` into `dev` after a release.
+
+- **Input:** none.
+- **Side effects:** opens a PR, merges it. All on `origin`.
+- **Idempotent?** Yes — exits early if `dev` is in sync with `main`.
+
+## Releasing — full sequence
+
+```bash
+# 1. Make sure dev is green
+git checkout dev && git pull
+
+# 2. Cut the release
+bash scripts/git/release-to-main.sh v0.2.0
+
+# 3. Sync dev with main
+bash scripts/git/sync-main-to-dev.sh
+
+# 4. Pull the merged state locally
+git checkout main && git pull
+git checkout dev && git pull
+```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -10,6 +10,7 @@ PR ceremony stays out of the way for routine maintenance.
 | Flow | Command |
 |---|---|
 | Feature branch → `dev` | `gh pr create --base dev --head feature/foo` → review → merge in UI |
+| Bump version (on `dev`, before release) | `bash scripts/git/bump-version.sh 0.2.0` |
 | `dev` → `main` (release) | `bash scripts/git/release-to-main.sh v0.2.0` |
 | `main` → `dev` (sync) | `bash scripts/git/sync-main-to-dev.sh` |
 
@@ -57,7 +58,43 @@ git branch -d feature/your-feature
 git push origin --delete feature/your-feature
 ```
 
-## 2. dev → main (release) — `--ff-only` equivalent
+## 2. Bump version (on `dev`, before the release)
+
+The release script tags `main` but does **not** bump `package.json` versions —
+those have to be updated separately on `dev` so the squash captures them. Use
+`scripts/git/bump-version.sh`:
+
+```bash
+bash scripts/git/bump-version.sh 0.2.0   # no 'v' prefix — npm versions are bare SemVer
+git add -A
+git commit -m "chore: bump version to 0.2.0"
+git push origin dev
+```
+
+The script:
+
+1. Validates the argument looks like SemVer (e.g. `0.2.0`, `0.2.0-rc.1`).
+2. Refuses to run unless you're on `dev` with a clean working tree.
+3. Runs `npm version <version> --workspaces --include-workspace-root --no-git-tag-version`,
+   updating `package.json` in the repo root, `apps/client`, `apps/server`, and `packages/shared`.
+4. Leaves the changes unstaged for you to review and commit.
+
+### Choosing the bump
+
+Use SemVer (https://semver.org). For axerra at v0.x:
+
+| Bump | Example | When |
+|---|---|---|
+| Patch | `0.1.1` | Bug fixes only, no behavior change |
+| Minor | `0.2.0` | New features, backward-compatible |
+| Pre-release | `0.2.0-rc.1`, `0.2.0-beta.1` | Not yet final |
+| Major | `1.0.0` | Breaking changes — typically reserved for the first stable release |
+
+> **Format note.** The bump script takes the bare SemVer (`0.2.0`); the release
+> script takes the `v`-prefixed git-tag form (`v0.2.0`). Same number, different
+> conventions: `package.json` is bare, git tags are conventionally prefixed.
+
+## 3. dev → main (release) — `--ff-only` equivalent
 
 For releases, use `scripts/git/release-to-main.sh`. The script squash-merges all
 of `dev`'s changes into a single commit on `main`, keeping `main`'s log clean as
@@ -80,7 +117,7 @@ The script:
 > commit on `main` representing the release, no merge-commit noise. After the
 > squash, run the sync script (next section) to align `dev` with the new `main`.
 
-## 3. main → dev (sync) — post-release alignment
+## 4. main → dev (sync) — post-release alignment
 
 After a squash release, `main` has a new commit (the squash) that's not on
 `dev`'s history. Run the sync script to bring `dev` up to date so the histories
@@ -104,20 +141,33 @@ The script:
 > merge commit is the only way to bridge them without rewriting either side's
 > SHAs.
 
-## 4. Helper scripts — reference
+## 5. Helper scripts — reference
 
-Both scripts live in `scripts/git/`. Run from the repo root.
+All scripts live in `scripts/git/`. Run from the repo root.
+
+### `bump-version.sh <version>`
+
+Bumps all workspace `package.json` versions in lockstep before a release.
+
+- **Input:** `<version>` — bare SemVer (e.g. `0.2.0`, `0.2.0-rc.1`). No `v` prefix.
+- **Side effects:** modifies `package.json` in repo root, `apps/client`, `apps/server`,
+  and `packages/shared`. Leaves changes unstaged for review.
+- **Guards:** must be on `dev` with a clean working tree; rejects bare `v…`
+  arguments and non-SemVer strings.
+- **Does not commit, push, tag, or open a PR** — that's intentional. Review the
+  diff, then commit and push manually before running `release-to-main.sh`.
 
 ### `release-to-main.sh <version>`
 
 Squash-merges `dev` into `main` and tags the result.
 
-- **Input:** `<version>` — the tag name (e.g. `v0.2.0`).
+- **Input:** `<version>` — the tag name with `v` prefix (e.g. `v0.2.0`).
 - **Side effects:** opens a PR, merges it, pushes a tag. All on `origin`.
 - **Skips early when there's nothing to do** — exits as a no-op if the version
   tag already exists on `origin`. If the tag exists locally but not on `origin`
   (recovery from a previous run that merged but failed to push the tag), the
-  script pushes the tag and exits.
+  script verifies the local tag points at `origin/main` and pushes it; on a SHA
+  mismatch it aborts rather than publishing a stray tag.
 - **Failure modes / rerun caveats:**
   - `gh` not authenticated.
   - An open PR with the same `dev → main` head/base from a prior run will block
@@ -147,13 +197,18 @@ Merge-commits `main` into `dev` after a release.
 # 1. Make sure dev is green
 git checkout dev && git pull
 
-# 2. Cut the release
+# 2. Bump workspace package.json versions on dev
+bash scripts/git/bump-version.sh 0.2.0
+git add -A && git commit -m "chore: bump version to 0.2.0"
+git push origin dev
+
+# 3. Cut the release (note the v prefix)
 bash scripts/git/release-to-main.sh v0.2.0
 
-# 3. Sync dev with main
+# 4. Sync dev with main
 bash scripts/git/sync-main-to-dev.sh
 
-# 4. Pull the merged state locally
+# 5. Pull the merged state locally
 git checkout main && git pull
 git checkout dev && git pull
 ```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -92,7 +92,9 @@ bash scripts/git/sync-main-to-dev.sh
 
 The script:
 
-1. Aborts if `dev` is already up to date with `main`.
+1. Aborts if `main` is already an ancestor of `dev` (history check, not tree
+   check — after a squash release, trees match but histories don't, and that
+   gap is exactly what this script exists to bridge).
 2. Opens a PR `main → dev` titled `chore: sync main into dev`.
 3. Merge-commits (not squash) with `--admin`. The merge commit ties the histories
    together — `main`'s commit becomes reachable from `dev`'s tip.
@@ -112,10 +114,18 @@ Squash-merges `dev` into `main` and tags the result.
 
 - **Input:** `<version>` — the tag name (e.g. `v0.2.0`).
 - **Side effects:** opens a PR, merges it, pushes a tag. All on `origin`.
-- **Idempotent?** Yes — exits early if `dev` and `main` are in sync.
-- **Failure modes:** `gh` not authenticated; CI failing on the PR (manual
-  intervention needed — the `--admin` flag overrides reviews but not status
-  check failures, depending on ruleset config).
+- **Skips early when there's nothing to do** — exits as a no-op if the version
+  tag already exists on `origin`. If the tag exists locally but not on `origin`
+  (recovery from a previous run that merged but failed to push the tag), the
+  script pushes the tag and exits.
+- **Failure modes / rerun caveats:**
+  - `gh` not authenticated.
+  - An open PR with the same `dev → main` head/base from a prior run will block
+    `gh pr create` — close or merge that PR before rerunning.
+  - CI failing on the PR — `--admin` bypasses required reviews, but whether it
+    bypasses required status checks depends on the branch ruleset configuration.
+  - If `main` and `dev` are in sync but the tag doesn't exist anywhere, the
+    script exits non-zero and prints recovery instructions rather than guessing.
 
 ### `sync-main-to-dev.sh`
 
@@ -123,7 +133,13 @@ Merge-commits `main` into `dev` after a release.
 
 - **Input:** none.
 - **Side effects:** opens a PR, merges it. All on `origin`.
-- **Idempotent?** Yes — exits early if `dev` is in sync with `main`.
+- **Skips early when there's nothing to do** — uses
+  `git merge-base --is-ancestor origin/main origin/dev` to detect that `main`'s
+  history is already reachable from `dev`. Tree equality alone isn't a reliable
+  signal post-squash.
+- **Failure modes / rerun caveats:** an open PR with the same `main → dev`
+  head/base from a prior run will block `gh pr create` — close or merge that PR
+  before rerunning.
 
 ## Releasing — full sequence
 

--- a/scripts/git/bump-version.sh
+++ b/scripts/git/bump-version.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Bump all workspace package.json versions in lockstep.
+#
+# Usage:  bash scripts/git/bump-version.sh <version>
+# Example: bash scripts/git/bump-version.sh 0.2.0
+#
+# Behavior:
+#   1. Validates the argument looks like SemVer (e.g. 0.2.0, 0.2.0-rc.1).
+#   2. Checks the current branch is `dev` and the working tree is clean.
+#   3. Runs `npm version <version> --workspaces --include-workspace-root
+#      --no-git-tag-version`, which updates root, apps/client, apps/server,
+#      and packages/shared package.json files.
+#   4. Leaves the changes unstaged for the user to review and commit.
+#
+# Run this on `dev` before scripts/git/release-to-main.sh. The npm version
+# uses the bare number (0.2.0); the git tag in release-to-main.sh uses the
+# `v` prefix (v0.2.0). Don't include `v` here — the script rejects it.
+#
+# Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>  (e.g. 0.2.0 — no 'v' prefix)" >&2
+  exit 1
+fi
+
+if [[ "$VERSION" =~ ^v ]]; then
+  echo "✗ Drop the leading 'v' — package.json versions are bare SemVer (e.g. 0.2.0)." >&2
+  exit 1
+fi
+
+# SemVer-ish: <num>.<num>.<num> with optional pre-release suffix
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+  echo "✗ '$VERSION' doesn't look like SemVer (e.g. 0.2.0, 0.2.0-rc.1, 1.0.0-beta.3)." >&2
+  exit 1
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "dev" ]]; then
+  echo "✗ Not on dev (current: $BRANCH). Version bumps land on dev before the release." >&2
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "✗ Working tree is not clean. Commit or stash changes before bumping." >&2
+  exit 1
+fi
+
+echo "Bumping all workspace package.json versions to $VERSION…"
+npm version "$VERSION" --workspaces --include-workspace-root --no-git-tag-version
+
+echo
+echo "✓ Bumped to $VERSION. Files changed:"
+git diff --name-only
+echo
+echo "Review the diff, then:"
+echo "  git add -A"
+echo "  git commit -m 'chore: bump version to $VERSION'"
+echo "  git push origin dev"
+echo "  bash scripts/git/release-to-main.sh v$VERSION"

--- a/scripts/git/bump-version.sh
+++ b/scripts/git/bump-version.sh
@@ -43,8 +43,9 @@ if [[ "$BRANCH" != "dev" ]]; then
   exit 1
 fi
 
-if ! git diff --quiet || ! git diff --cached --quiet; then
-  echo "✗ Working tree is not clean. Commit or stash changes before bumping." >&2
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "✗ Working tree is not clean (modified, staged, or untracked files present)." >&2
+  echo "  Commit, stash, or remove changes before bumping." >&2
   exit 1
 fi
 

--- a/scripts/git/release-to-main.sh
+++ b/scripts/git/release-to-main.sh
@@ -20,9 +20,21 @@
 
 set -euo pipefail
 
+usage() {
+  echo "Usage: $0 <version>" >&2
+  echo "  <version> must look like v<major>.<minor>.<patch>[-prerelease]" >&2
+  echo "  Examples: v0.2.0, v0.2.0-rc.1, v1.0.0-beta.3" >&2
+}
+
 VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then
-  echo "Usage: $0 <version>  (e.g. v0.2.0)" >&2
+  usage
+  exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "✗ Invalid version tag: $VERSION" >&2
+  usage
   exit 1
 fi
 
@@ -55,6 +67,17 @@ if [[ -n "$LOCAL_TAG" ]]; then
   git push origin "$VERSION"
   echo "✓ Tag $VERSION pushed."
   exit 0
+fi
+
+# Guard against the "forgot to sync after the previous release" trap.
+# If origin/main isn't already in origin/dev's history, a squash merge would
+# re-apply previously-released content on top of main — broken release.
+if ! git merge-base --is-ancestor origin/main origin/dev; then
+  echo "✗ origin/main is not contained in origin/dev's history." >&2
+  echo "  This usually means the previous release wasn't synced back to dev." >&2
+  echo "  Run: bash scripts/git/sync-main-to-dev.sh" >&2
+  echo "  Then retry this release." >&2
+  exit 1
 fi
 
 if git diff --quiet origin/main..origin/dev; then

--- a/scripts/git/release-to-main.sh
+++ b/scripts/git/release-to-main.sh
@@ -7,10 +7,14 @@
 # Behavior:
 #   1. Verifies dev is ahead of main (otherwise nothing to release).
 #   2. Opens a PR with title "Release <version>".
-#   3. Squash-merges with --admin (bypasses required reviews; CI must still pass
-#      unless --admin also overrides it, which it does for branch ruleset checks).
+#   3. Squash-merges with --admin (bypasses required reviews; whether CI/status
+#      checks must pass depends on the branch ruleset configuration).
 #   4. Fetches the new main tip and creates an annotated tag <version> on it.
 #   5. Pushes the tag.
+#
+# Recovers from a partial previous run: if the version tag exists locally
+# but not on origin (merge succeeded, tag push failed), pushes the tag and
+# exits. If the tag is on origin already, exits as a no-op.
 #
 # Copyright (c) 2025 – present Axerra LLC. All rights reserved.
 
@@ -22,11 +26,30 @@ if [[ -z "$VERSION" ]]; then
   exit 1
 fi
 
-git fetch origin --quiet
+git fetch origin --quiet --tags
+
+# Recover from a previous partial run before deciding whether to release.
+LOCAL_TAG=$(git tag -l "$VERSION")
+REMOTE_TAG=$(git ls-remote --tags origin "refs/tags/$VERSION" 2>/dev/null | head -n 1)
+
+if [[ -n "$REMOTE_TAG" ]]; then
+  echo "✓ Tag $VERSION already exists on origin — nothing to release."
+  exit 0
+fi
+
+if [[ -n "$LOCAL_TAG" ]]; then
+  echo "Tag $VERSION exists locally but not on origin. Pushing tag…"
+  git push origin "$VERSION"
+  echo "✓ Tag $VERSION pushed."
+  exit 0
+fi
 
 if git diff --quiet origin/main..origin/dev; then
-  echo "✓ main is already up to date with dev — nothing to release."
-  exit 0
+  echo "✗ main and dev are already in sync, but tag $VERSION doesn't exist." >&2
+  echo "  Either a previous run merged but failed to tag (recover with:" >&2
+  echo "    git tag -a $VERSION origin/main -m 'Release $VERSION' && git push origin $VERSION" >&2
+  echo "  ) or there's nothing to release." >&2
+  exit 1
 fi
 
 echo "About to release $VERSION (squash-merge dev → main)."

--- a/scripts/git/release-to-main.sh
+++ b/scripts/git/release-to-main.sh
@@ -38,7 +38,20 @@ if [[ -n "$REMOTE_TAG" ]]; then
 fi
 
 if [[ -n "$LOCAL_TAG" ]]; then
-  echo "Tag $VERSION exists locally but not on origin. Pushing tag…"
+  # Verify the local tag points at origin/main before publishing it.
+  # A stray local tag (manually created, or from a different release attempt)
+  # should not be pushed without explicit human review.
+  TAG_COMMIT=$(git rev-parse "$VERSION^{commit}")
+  MAIN_TIP=$(git rev-parse origin/main)
+  if [[ "$TAG_COMMIT" != "$MAIN_TIP" ]]; then
+    echo "✗ Local tag $VERSION points at $TAG_COMMIT," >&2
+    echo "  but origin/main is at $MAIN_TIP." >&2
+    echo "  Refusing to push a tag that doesn't match the expected release tip." >&2
+    echo "  Investigate manually (e.g. \`git log $VERSION\`, \`git log origin/main\`)" >&2
+    echo "  and either delete the local tag or move it before retrying." >&2
+    exit 1
+  fi
+  echo "Tag $VERSION exists locally and matches origin/main. Pushing tag…"
   git push origin "$VERSION"
   echo "✓ Tag $VERSION pushed."
   exit 0

--- a/scripts/git/release-to-main.sh
+++ b/scripts/git/release-to-main.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Open and squash-merge a release PR from dev → main, then tag the release.
+#
+# Usage:  bash scripts/git/release-to-main.sh <version>
+# Example: bash scripts/git/release-to-main.sh v0.2.0
+#
+# Behavior:
+#   1. Verifies dev is ahead of main (otherwise nothing to release).
+#   2. Opens a PR with title "Release <version>".
+#   3. Squash-merges with --admin (bypasses required reviews; CI must still pass
+#      unless --admin also overrides it, which it does for branch ruleset checks).
+#   4. Fetches the new main tip and creates an annotated tag <version> on it.
+#   5. Pushes the tag.
+#
+# Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>  (e.g. v0.2.0)" >&2
+  exit 1
+fi
+
+git fetch origin --quiet
+
+if git diff --quiet origin/main..origin/dev; then
+  echo "✓ main is already up to date with dev — nothing to release."
+  exit 0
+fi
+
+echo "About to release $VERSION (squash-merge dev → main)."
+read -r -p "Continue? [y/N] " REPLY
+[[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
+
+URL=$(gh pr create \
+  --base main --head dev \
+  --title "Release $VERSION" \
+  --body "Release PR. Squash-merging dev into main as $VERSION.")
+PR_NUM="${URL##*/}"
+echo "Opened PR #$PR_NUM: $URL"
+
+gh pr merge "$PR_NUM" --squash --admin --delete-branch=false
+echo "Squash-merged."
+
+git fetch origin --quiet
+TIP=$(git rev-parse origin/main)
+git tag -a "$VERSION" "$TIP" -m "Release $VERSION"
+git push origin "$VERSION"
+echo "✓ Released $VERSION (tag pushed)."
+echo
+echo "Run scripts/git/sync-main-to-dev.sh next to align dev with main."

--- a/scripts/git/sync-main-to-dev.sh
+++ b/scripts/git/sync-main-to-dev.sh
@@ -5,7 +5,8 @@
 # Usage:  bash scripts/git/sync-main-to-dev.sh
 #
 # Behavior:
-#   1. Verifies main is ahead of dev (otherwise dev is already in sync).
+#   1. Skips when origin/main is already merged into origin/dev (i.e., main is
+#      reachable from dev's history). Otherwise opens the sync PR.
 #   2. Opens a PR with title "chore: sync main into dev".
 #   3. Merge-commits with --admin (preserves graph alignment without rewriting
 #      dev's history).

--- a/scripts/git/sync-main-to-dev.sh
+++ b/scripts/git/sync-main-to-dev.sh
@@ -16,7 +16,10 @@ set -euo pipefail
 
 git fetch origin --quiet
 
-if git diff --quiet origin/dev..origin/main; then
+# Use ancestry, not tree-diff: after a squash release, dev and main have
+# identical trees but divergent histories — that's exactly the case this
+# script exists to fix. Tree-diff would say "in sync" and skip the merge.
+if git merge-base --is-ancestor origin/main origin/dev; then
   echo "✓ dev is already up to date with main — nothing to sync."
   exit 0
 fi

--- a/scripts/git/sync-main-to-dev.sh
+++ b/scripts/git/sync-main-to-dev.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Open and merge-commit a sync PR from main → dev, aligning dev with main
+# after a release. Use after release-to-main.sh.
+#
+# Usage:  bash scripts/git/sync-main-to-dev.sh
+#
+# Behavior:
+#   1. Verifies main is ahead of dev (otherwise dev is already in sync).
+#   2. Opens a PR with title "chore: sync main into dev".
+#   3. Merge-commits with --admin (preserves graph alignment without rewriting
+#      dev's history).
+#
+# Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+
+set -euo pipefail
+
+git fetch origin --quiet
+
+if git diff --quiet origin/dev..origin/main; then
+  echo "✓ dev is already up to date with main — nothing to sync."
+  exit 0
+fi
+
+URL=$(gh pr create \
+  --base dev --head main \
+  --title "chore: sync main into dev" \
+  --body "Sync PR. Merging main back into dev to align histories after a release.")
+PR_NUM="${URL##*/}"
+echo "Opened PR #$PR_NUM: $URL"
+
+gh pr merge "$PR_NUM" --merge --admin --delete-branch=false
+echo "✓ dev synced with main."


### PR DESCRIPTION
## Summary

Sets up Option 4 from the workflow design discussion: PRs required on both branches, with helper scripts for mechanical \`dev↔main\` sync flows.

### Changes

- **\`docs/workflow.md\`** — full reference for the three flows (feature → dev, dev → main release, main → dev sync) plus script docs.
- **\`scripts/git/release-to-main.sh <version>\`** — squash-merges dev into main via \`gh pr merge --admin --squash\`, then creates and pushes the version tag.
- **\`scripts/git/sync-main-to-dev.sh\`** — merge-commits main back into dev via \`gh pr merge --admin --merge\` to align histories after a release.
- **\`CLAUDE.md\` / \`AGENTS.md\`** — replaced the stale one-line PR rule with a pointer to \`docs/workflow.md\`.

### Branch protection (already configured)

- Both \`main\` and \`dev\`: \`pull_request\`, \`required_status_checks\` (Lint + Architecture Check), \`non_fast_forward\`, \`deletion\`.
- \`dev\` additionally: \`copilot_code_review\`.

The \`--admin\` flag in the scripts bypasses required reviews for sync PRs (which have no human reviewer); status checks still apply unless the ruleset config exempts admins.

## Test plan

- [ ] CI green
- [ ] Self-review docs/workflow.md
- [ ] On merge: try \`bash scripts/git/sync-main-to-dev.sh\` with no diff (should exit early)