### PR TITLE
feat(client): add orphan-source cleanup UI

### DIFF
--- a/apps/client/src/App.jsx
+++ b/apps/client/src/App.jsx
@@ -21,6 +21,7 @@ import ClientsPage from './pages/Core/ClientsPage.jsx';
 import EmployeesPage from './pages/Core/EmployeesPage.jsx';
 import ContactsPage from './pages/Core/ContactsPage.jsx';
 import CompaniesPage from './pages/Core/CompaniesPage.jsx';
+import DataMaintenancePage from './pages/Core/DataMaintenancePage.jsx';
 import ProjectsPage from './pages/Projects/ProjectsPage.jsx';
 import ProjectDetailPage from './pages/Projects/ProjectDetailPage.jsx';
 import ChangeOrdersPage from './pages/Projects/ChangeOrdersPage.jsx';
@@ -73,6 +74,7 @@ export default function App() {
           <Route path="/core/employees" element={<EmployeesPage />} />
           <Route path="/core/contacts" element={<ContactsPage />} />
           <Route path="/core/companies" element={<CompaniesPage />} />
+          <Route path="/core/data-maintenance" element={<DataMaintenancePage />} />
 
           {/* Project routes */}
           <Route path="/projects" element={<ProjectsPage />} />

--- a/apps/client/src/config/navigationConfig.js
+++ b/apps/client/src/config/navigationConfig.js
@@ -147,6 +147,7 @@ export const NAV_ITEMS = [
       { label: 'Contacts', path: '/core/contacts', capability: 'core::contacts' },
       { label: 'Companies', path: '/core/companies', capability: 'core::companies' },
       { label: 'Roles', path: '/tenant/manage-roles', capability: 'core::roles' },
+      { label: 'Data Maintenance', path: '/core/data-maintenance', capability: 'core::sources' },
     ],
   },
   {

--- a/apps/client/src/pages/Core/DataMaintenancePage.jsx
+++ b/apps/client/src/pages/Core/DataMaintenancePage.jsx
@@ -59,6 +59,9 @@ export default function DataMaintenancePage() {
       await previewQuery.refetch();
     },
     onError: (err) => toast(errMsg(err), 'error'),
+    // Dialog close lives in onSettled so we don't depend on the click handler
+    // awaiting mutateAsync(), which would surface an unhandled rejection on error.
+    onSettled: () => setConfirmOpen(false),
   });
 
   /* ── Derived data ─────────────────────────────────────────────── */
@@ -89,13 +92,7 @@ export default function DataMaintenancePage() {
     previewQuery.refetch().catch((err) => toast(errMsg(err), 'error'));
   };
 
-  const handleCleanupConfirm = async () => {
-    try {
-      await cleanupMut.mutateAsync();
-    } finally {
-      setConfirmOpen(false);
-    }
-  };
+  const handleCleanupConfirm = () => cleanupMut.mutate();
 
   /* ── Toolbar (empty — no module-level actions) ────────────────── */
 

--- a/apps/client/src/pages/Core/DataMaintenancePage.jsx
+++ b/apps/client/src/pages/Core/DataMaintenancePage.jsx
@@ -1,0 +1,197 @@
+/**
+ * @file Data maintenance page — tenant-level data hygiene operations
+ * @module client/pages/Core/DataMaintenancePage
+ *
+ * Currently exposes one operation: orphan-source preview + cleanup. Future
+ * maintenance ops (audit-log review, bulk archival, etc.) land as additional
+ * sections on this same page. See issue #43.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { useMemo, useState } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { DataGrid } from '@mui/x-data-grid';
+
+import PrimaryButton from '../../components/shared/PrimaryButton.jsx';
+import SecondaryButton from '../../components/shared/SecondaryButton.jsx';
+import ConfirmDialog from '../../components/shared/ConfirmDialog.jsx';
+import ToastSnackbar from '../../components/shared/ToastSnackbar.jsx';
+import { useToast } from '../../hooks/useToast.js';
+import { useModuleToolbarRegistration } from '../../contexts/ModuleActionsContext.jsx';
+import { sourcesApi } from '../../services/sourcesApi.js';
+import { pageContainerSx, flexColumnSx } from '../../config/layoutTokens.js';
+
+/* ── Helpers ───────────────────────────────────────────────────── */
+
+const formatDateTime = (value) => {
+  if (!value) return '';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? String(value) : d.toLocaleString();
+};
+
+const errMsg = (err) => err?.payload?.error || err?.message || 'Request failed';
+
+/* ── Component ─────────────────────────────────────────────────── */
+
+export default function DataMaintenancePage() {
+  const { toast, snackProps } = useToast();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // Preview is opt-in (manual click) so the page renders fast and we don't
+  // surprise users with a query the first time they navigate here.
+  const previewQuery = useQuery({
+    queryKey: ['sources', 'orphans', 'preview'],
+    queryFn: () => sourcesApi.previewOrphans(),
+    enabled: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const cleanupMut = useMutation({
+    mutationFn: () => sourcesApi.cleanupOrphans(),
+    onSuccess: async (result) => {
+      toast(`Cleaned up ${result.count} orphan${result.count === 1 ? '' : 's'}`);
+      await previewQuery.refetch();
+    },
+    onError: (err) => toast(errMsg(err), 'error'),
+  });
+
+  /* ── Derived data ─────────────────────────────────────────────── */
+
+  const data = previewQuery.data;
+  const orphans = data?.orphans ?? [];
+  const orphanCount = data?.count ?? 0;
+  const hasPreviewed = !!data;
+
+  const columns = useMemo(
+    () => [
+      { field: 'source_type', headerName: 'Type', width: 140 },
+      { field: 'label', headerName: 'Label', flex: 1, minWidth: 200 },
+      {
+        field: 'created_at',
+        headerName: 'Created',
+        width: 200,
+        valueGetter: (params) => formatDateTime(params.row.created_at),
+      },
+      { field: 'table_id', headerName: 'Original entity ID', width: 320 },
+    ],
+    [],
+  );
+
+  /* ── Handlers ─────────────────────────────────────────────────── */
+
+  const handlePreview = () => {
+    previewQuery.refetch().catch((err) => toast(errMsg(err), 'error'));
+  };
+
+  const handleCleanupConfirm = async () => {
+    try {
+      await cleanupMut.mutateAsync();
+    } finally {
+      setConfirmOpen(false);
+    }
+  };
+
+  /* ── Toolbar (empty — no module-level actions) ────────────────── */
+
+  const toolbar = useMemo(() => ({ tabs: [], filters: [], primaryActions: [] }), []);
+  useModuleToolbarRegistration(toolbar);
+
+  /* ── Render ───────────────────────────────────────────────────── */
+
+  const cleanupLabel =
+    orphanCount > 0 ? `Clean up ${orphanCount} orphan${orphanCount === 1 ? '' : 's'}` : 'Clean up';
+
+  const cleanupDisabled = !hasPreviewed || orphanCount === 0 || cleanupMut.isPending;
+
+  return (
+    <Box sx={{ ...pageContainerSx, overflow: 'auto', p: 2 }}>
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        Data Maintenance
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Tenant-level data hygiene operations. All actions affect this tenant only.
+      </Typography>
+
+      <Card variant="outlined">
+        <CardContent sx={flexColumnSx}>
+          <Box>
+            <Typography variant="subtitle1" fontWeight={600}>
+              Orphan sources
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              Sources rows whose owning entity (vendor, client, employee, contact, company,
+              vendor contact) was hard-deleted. Cleaning up cascades through child tables — emails,
+              phone numbers, addresses, and tax identifiers attached to the orphan source.
+            </Typography>
+          </Box>
+
+          <Stack direction="row" spacing={1} alignItems="center">
+            <SecondaryButton size="small" onClick={handlePreview} disabled={previewQuery.isFetching}>
+              {previewQuery.isFetching ? 'Loading…' : hasPreviewed ? 'Refresh preview' : 'Preview'}
+            </SecondaryButton>
+            <PrimaryButton
+              size="small"
+              onClick={() => setConfirmOpen(true)}
+              disabled={cleanupDisabled}
+            >
+              {cleanupMut.isPending ? 'Cleaning up…' : cleanupLabel}
+            </PrimaryButton>
+            {hasPreviewed && (
+              <Typography variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+                {orphanCount === 0
+                  ? 'No orphans found.'
+                  : `${orphanCount} orphan${orphanCount === 1 ? '' : 's'} found.`}
+              </Typography>
+            )}
+          </Stack>
+
+          {hasPreviewed && orphanCount > 0 && (
+            <Box sx={{ height: 360, width: '100%' }}>
+              <DataGrid
+                rows={orphans}
+                columns={columns}
+                getRowId={(row) => row.source_id}
+                density="compact"
+                disableRowSelectionOnClick
+                hideFooterSelectedRowCount
+                pageSizeOptions={[25, 50, 100]}
+                initialState={{ pagination: { paginationModel: { pageSize: 25, page: 0 } } }}
+              />
+            </Box>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Clean up orphan sources"
+        message={
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {orphanCount === 1
+                ? 'This will permanently delete 1 orphan source row.'
+                : `This will permanently delete ${orphanCount} orphan source rows.`}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Linked emails, phone numbers, addresses, and tax identifiers will be cascade-deleted in
+              the same transaction. This cannot be undone.
+            </Typography>
+          </Box>
+        }
+        confirmLabel="Clean up"
+        cancelLabel="Cancel"
+        loading={cleanupMut.isPending}
+        onConfirm={handleCleanupConfirm}
+        onCancel={() => setConfirmOpen(false)}
+      />
+
+      <ToastSnackbar {...snackProps} />
+    </Box>
+  );
+}

--- a/apps/client/src/services/sourcesApi.js
+++ b/apps/client/src/services/sourcesApi.js
@@ -1,0 +1,19 @@
+/**
+ * @file Sources API methods — orphan-source maintenance helpers
+ * @module client/services/sourcesApi
+ *
+ * Base path: /core/v1/sources
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { client } from './client.js';
+
+const BASE = '/core/v1/sources';
+
+export const sourcesApi = {
+  previewOrphans: () => client.get(`${BASE}/orphans/preview`),
+  cleanupOrphans: () => client.post(`${BASE}/orphans/cleanup`, {}),
+};
+
+export default sourcesApi;


### PR DESCRIPTION
## Summary

Surfaces the tenant-side orphan-source cleanup endpoints (landed in da0a950 / PR #44) inside the app. New \`Data Maintenance\` page under the Admin sidebar group, designed to host future maintenance operations as additional cards.

- New page: \`apps/client/src/pages/Core/DataMaintenancePage.jsx\` at \`/core/data-maintenance\`
- New service: \`apps/client/src/services/sourcesApi.js\` (\`previewOrphans\`, \`cleanupOrphans\`)
- Nav entry: added to the Admin group with capability \`'core::sources'\` (matches sibling entries like \`'core::vendors'\`); existing Sidebar cap-prefix fallback handles RBAC visibility
- Route registered in \`App.jsx\` alongside the other Core entity routes

### UX

- **Preview** (secondary) calls \`GET /sources/orphans/preview\`; results render in a compact MUI X DataGrid (\`source_type\`, \`label\`, \`created_at\`, \`table_id\`).
- **Clean up N orphans** (primary) is count-aware and disabled until a preview has been run and orphans exist.
- ConfirmDialog before the destructive action with explicit cascade warning (linked emails / phone numbers / addresses / tax IDs are removed in the same transaction).
- On success, preview auto-re-runs so the user sees the empty state without an extra click.

### Reused patterns

- \`PreferencesPage\` for the page-shell layout (Card + CardContent inside \`pageContainerSx\`).
- \`ConfirmDialog\` for the confirm-before-destructive flow (no red — BRAND.md §"Destructive actions").
- \`useToast\` / \`ToastSnackbar\` for success/error feedback.
- TanStack Query \`useQuery\` (with \`enabled: false\` so preview is opt-in) and \`useMutation\` for the cleanup call.

### Out of scope

- Audit log persistence — deferred to #43. The cleanup controller still emits its Winston \`logger.info\` placeholder; this UI doesn't need changes when that retrofit lands.
- Client-side tests — axerra has no client test infrastructure today.

## Test plan

- [x] \`npm run lint\` clean
- [x] End-to-end browser smoke test against dev DB:
  - Login as a tenant admin (\`joe@srh.com\` for SRH).
  - Navigate to \`/core/data-maintenance\` → page renders, "No orphans found." after first Preview.
  - \`INSERT INTO srh.sources (..., label='UI Smoke Test')\` directly via psql.
  - Refresh preview → DataGrid shows the orphan; button label flips to "Clean up 1 orphan".
  - Confirm dialog → orphan removed; preview auto-re-runs; \`SELECT count(*) ... WHERE label='UI Smoke Test'\` returns 0.
- [x] Verify in any reviewer environment that the entry appears in the Admin sidebar group for tenant admins with \`core::sources\` (full); does not appear for users without that cap.

Closes the UI follow-up to #20 / #21 (server fix + cleanup endpoints already merged via #44). Audit-log retrofit tracked in #43.