### PR TITLE
fix(server): sync login email for client and vendor_contact

### DIFF
--- a/apps/server/src/system/core/controllers/emailsController.js
+++ b/apps/server/src/system/core/controllers/emailsController.js
@@ -19,7 +19,6 @@ const ENTITY_TABLE_BY_SOURCE_TYPE = {
   client: 'clients',
   vendor_contact: 'vendor_contacts',
 };
-const LOGIN_SOURCE_TYPES = new Set(Object.keys(ENTITY_TABLE_BY_SOURCE_TYPE));
 
 class EmailsController extends BaseController {
   constructor() {
@@ -153,7 +152,7 @@ class EmailsController extends BaseController {
         [sourceId],
       );
       if (!source) return;
-      if (!LOGIN_SOURCE_TYPES.has(source.source_type)) return;
+      if (!ENTITY_TABLE_BY_SOURCE_TYPE[source.source_type]) return;
 
       await db.none(
         `UPDATE admin.portal_users SET email = $1, updated_by = $2

--- a/apps/server/src/system/core/controllers/emailsController.js
+++ b/apps/server/src/system/core/controllers/emailsController.js
@@ -14,6 +14,13 @@ import { clearOtherPrimary } from '../../../lib/clearOtherPrimary.js';
 import db, { pgp } from '../../../db/db.js';
 import logger from '../../../lib/logger.js';
 
+const ENTITY_TABLE_BY_SOURCE_TYPE = {
+  employee: 'employees',
+  client: 'clients',
+  vendor_contact: 'vendor_contacts',
+};
+const LOGIN_SOURCE_TYPES = new Set(Object.keys(ENTITY_TABLE_BY_SOURCE_TYPE));
+
 class EmailsController extends BaseController {
   constructor() {
     super('emails');
@@ -141,20 +148,17 @@ class EmailsController extends BaseController {
   async #syncLoginEmail(schema, sourceId, email, req) {
     const s = pgp.as.name(schema);
     try {
-      // Find the source to get the entity type and id
       const source = await db.oneOrNone(
         `SELECT table_id, source_type FROM ${s}.sources WHERE id = $1 AND deactivated_at IS NULL`,
         [sourceId],
       );
       if (!source) return;
-
-      // Only employees sync to portal_users currently
-      if (source.source_type !== 'employee') return;
+      if (!LOGIN_SOURCE_TYPES.has(source.source_type)) return;
 
       await db.none(
         `UPDATE admin.portal_users SET email = $1, updated_by = $2
-         WHERE entity_type = 'employee' AND entity_id = $3 AND deactivated_at IS NULL`,
-        [email, req.user?.id || null, source.table_id],
+         WHERE entity_type = $3 AND entity_id = $4 AND deactivated_at IS NULL`,
+        [email, req.user?.id || null, source.source_type, source.table_id],
       );
     } catch (err) {
       logger.error('Failed to sync login email to portal_users', { sourceId, email, error: err.message });
@@ -171,13 +175,15 @@ class EmailsController extends BaseController {
       `SELECT table_id, source_type FROM ${s}.sources WHERE id = $1 AND deactivated_at IS NULL`,
       [sourceId],
     );
-    if (!source || source.source_type !== 'employee') return true;
+    if (!source) return true;
+    const table = ENTITY_TABLE_BY_SOURCE_TYPE[source.source_type];
+    if (!table) return true;
 
-    const employee = await db.oneOrNone(
-      `SELECT is_app_user FROM ${s}.employees WHERE id = $1 AND deactivated_at IS NULL`,
+    const entity = await db.oneOrNone(
+      `SELECT is_app_user FROM ${s}.${table} WHERE id = $1 AND deactivated_at IS NULL`,
       [source.table_id],
     );
-    return !employee?.is_app_user;
+    return !entity?.is_app_user;
   }
 }
 

--- a/apps/server/tests/contract/emails.test.js
+++ b/apps/server/tests/contract/emails.test.js
@@ -231,11 +231,20 @@ describe('Login email sync — client and vendor_contact source types', () => {
   let cookies;
 
   beforeAll(async () => {
-    const loginRes = await request(app)
+    let loginRes = await request(app)
       .post('/api/auth/login')
       .send({ email: 'admin@emtest.com', password: 'EmtestPass123!' });
+
+    if (!loginRes.headers['set-cookie']?.length) {
+      const rootCookies = await loginRoot();
+      await provisionTenant(rootCookies);
+      loginRes = await request(app)
+        .post('/api/auth/login')
+        .send({ email: 'admin@emtest.com', password: 'EmtestPass123!' });
+    }
+
     cookies = loginRes.headers['set-cookie'];
-  }, 15000);
+  }, 30000);
 
   test('client app-user creation syncs login email to admin.portal_users', async () => {
     const res = await request(app)
@@ -263,10 +272,11 @@ describe('Login email sync — client and vendor_contact source types', () => {
     const loginEmail = (emailsList.body.rows ?? emailsList.body).find((e) => e.is_login);
     expect(loginEmail).toBeTruthy();
 
-    await request(app)
+    const updateRes = await request(app)
       .put(`/api/core/v1/emails/update?id=${loginEmail.id}`)
       .set('Cookie', cookies)
       .send({ email: 'client-login-updated@emtest.com' });
+    expect(updateRes.status).toBe(200);
 
     const portalAfter = await DB.db.oneOrNone(
       `SELECT email FROM admin.portal_users WHERE entity_type = 'client' AND entity_id = $1 AND deactivated_at IS NULL`,

--- a/apps/server/tests/contract/emails.test.js
+++ b/apps/server/tests/contract/emails.test.js
@@ -11,7 +11,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import request from 'supertest';
-import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+import { bootstrapAdmin, cleanupTestDb, DB } from '../helpers/testDb.js';
 
 const ROOT_EMAIL = process.env.ROOT_EMAIL;
 const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
@@ -224,5 +224,103 @@ describe('Email CRUD — /api/core/v1/emails', () => {
       .set('Cookie', cookies)
       .send({});
     expect(res.status).toBe(200);
+  });
+});
+
+describe('Login email sync — client and vendor_contact source types', () => {
+  let cookies;
+
+  beforeAll(async () => {
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@emtest.com', password: 'EmtestPass123!' });
+    cookies = loginRes.headers['set-cookie'];
+  }, 15000);
+
+  test('client app-user creation syncs login email to admin.portal_users', async () => {
+    const res = await request(app)
+      .post('/api/core/v1/clients')
+      .set('Cookie', cookies)
+      .send({
+        name: 'Sync Client Co',
+        email: 'client-login@emtest.com',
+        is_app_user: true,
+        roles: ['client'],
+        password: 'ClientPass123!',
+      });
+    expect(res.status).toBe(201);
+
+    const portal = await DB.db.oneOrNone(
+      `SELECT email FROM admin.portal_users WHERE entity_type = 'client' AND entity_id = $1 AND deactivated_at IS NULL`,
+      [res.body.id],
+    );
+    expect(portal?.email).toBe('client-login@emtest.com');
+
+    // Updating the login email should cascade
+    const emailsList = await request(app)
+      .get(`/api/core/v1/emails?source_id=${res.body.source_id}`)
+      .set('Cookie', cookies);
+    const loginEmail = (emailsList.body.rows ?? emailsList.body).find((e) => e.is_login);
+    expect(loginEmail).toBeTruthy();
+
+    await request(app)
+      .put(`/api/core/v1/emails/update?id=${loginEmail.id}`)
+      .set('Cookie', cookies)
+      .send({ email: 'client-login-updated@emtest.com' });
+
+    const portalAfter = await DB.db.oneOrNone(
+      `SELECT email FROM admin.portal_users WHERE entity_type = 'client' AND entity_id = $1 AND deactivated_at IS NULL`,
+      [res.body.id],
+    );
+    expect(portalAfter?.email).toBe('client-login-updated@emtest.com');
+
+    // Unsetting is_login should be blocked while is_app_user
+    const unset = await request(app)
+      .put(`/api/core/v1/emails/update?id=${loginEmail.id}`)
+      .set('Cookie', cookies)
+      .send({ is_login: false });
+    expect(unset.status).toBe(400);
+    expect(unset.body.error).toMatch(/app user/i);
+  });
+
+  test('vendor_contact app-user creation syncs login email to admin.portal_users', async () => {
+    const vendorRes = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookies)
+      .send({ name: 'Sync Vendor Co' });
+    expect(vendorRes.status).toBe(201);
+
+    const res = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookies)
+      .send({
+        vendor_id: vendorRes.body.id,
+        first_name: 'VC',
+        last_name: 'Login',
+        email: 'vc-login@emtest.com',
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'VcPass123!',
+      });
+    expect(res.status).toBe(201);
+
+    const portal = await DB.db.oneOrNone(
+      `SELECT email FROM admin.portal_users WHERE entity_type = 'vendor_contact' AND entity_id = $1 AND deactivated_at IS NULL`,
+      [res.body.id],
+    );
+    expect(portal?.email).toBe('vc-login@emtest.com');
+
+    const emailsList = await request(app)
+      .get(`/api/core/v1/emails?source_id=${res.body.source_id}`)
+      .set('Cookie', cookies);
+    const loginEmail = (emailsList.body.rows ?? emailsList.body).find((e) => e.is_login);
+    expect(loginEmail).toBeTruthy();
+
+    const unset = await request(app)
+      .put(`/api/core/v1/emails/update?id=${loginEmail.id}`)
+      .set('Cookie', cookies)
+      .send({ is_login: false });
+    expect(unset.status).toBe(400);
+    expect(unset.body.error).toMatch(/app user/i);
   });
 });

--- a/apps/server/tests/contract/emails.test.js
+++ b/apps/server/tests/contract/emails.test.js
@@ -3,8 +3,9 @@
  * @module tests/contract/emails
  *
  * Covers: single is_login enforcement, blocking unset/archive of login email
- * while employee is_app_user. (portal_users sync is exercised implicitly but not
- * asserted directly — cross-schema assertions deferred to integration tests.)
+ * while is_app_user, and login-email sync to admin.portal_users for
+ * employee, client, and vendor_contact source types. The sync suite asserts
+ * directly against admin.portal_users via the test DB handle.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */


### PR DESCRIPTION
## Summary

Task 1 of the [Import Dedup & Multi-Tenant Vendor Access plan](../../../../.claude/plans/users-ian-downloads-import-dedup-and-mu-jolly-castle.md).

`emailsController.#syncLoginEmail` and `#canUnsetLogin` previously hard-coded `source_type === 'employee'`, so login email changes on clients and vendor_contacts never propagated to `admin.portal_users` and the unset-login guard didn't fire while `is_app_user` was true.

Drive both helpers off a `source_type → entity table` map covering `employee`, `client`, and `vendor_contact`. The `UPDATE admin.portal_users` clause uses the source's type instead of a literal `'employee'`.

Prerequisite for the `portal_user_tenants` split in Task 4 — the sync target needs to be correct for all three entity types before the join table is introduced.

## Test plan

- [x] `npm -w apps/server test -- tests/contract/emails.test.js` — 11 passed (2 new)
- [x] `npm -w apps/server test` — 486 passed
- [x] `npm run lint`
- [ ] Reviewer: confirm no other callsites assume employee-only sync