### PR TITLE
feat(server): partial unique indexes for emails, tax_ids, cell phones

### DIFF
--- a/apps/server/src/system/core/schemas/emailsSchema.js
+++ b/apps/server/src/system/core/schemas/emailsSchema.js
@@ -39,7 +39,7 @@ const emailsSchema = {
     indexes: [
       { type: 'Index', columns: ['tenant_id'] },
       { type: 'Index', columns: ['source_id'] },
-      { type: 'Index', columns: ['source_id', 'email'], unique: true, where: 'deactivated_at IS NULL' },
+      { type: 'Index', columns: ['email'], unique: true, where: 'deactivated_at IS NULL' },
       { type: 'Index', columns: ['source_id'], unique: true, where: 'is_login = true AND deactivated_at IS NULL' },
       { type: 'Index', columns: ['source_id'], unique: true, where: 'is_primary = true AND deactivated_at IS NULL' },
     ],

--- a/apps/server/src/system/core/schemas/phoneNumbersSchema.js
+++ b/apps/server/src/system/core/schemas/phoneNumbersSchema.js
@@ -19,7 +19,7 @@ const phoneNumbersSchema = {
     { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
     { name: 'tenant_id', type: 'uuid', notNull: true, immutable: true },
     { name: 'source_id', type: 'uuid', notNull: true },
-    { name: 'country_code', type: 'char(2)', default: 'US' },
+    { name: 'country_code', type: 'char(2)', notNull: true, default: 'US' },
     { name: 'phone_type', type: 'varchar(16)', notNull: true, default: 'cell' },
     { name: 'phone_number', type: 'varchar(32)', notNull: true },
     { name: 'is_primary', type: 'boolean', notNull: true, default: false },

--- a/apps/server/src/system/core/schemas/phoneNumbersSchema.js
+++ b/apps/server/src/system/core/schemas/phoneNumbersSchema.js
@@ -41,6 +41,12 @@ const phoneNumbersSchema = {
       { type: 'Index', columns: ['tenant_id'] },
       { type: 'Index', columns: ['source_id'] },
       { type: 'Index', columns: ['source_id'], unique: true, where: 'is_primary = true AND deactivated_at IS NULL' },
+      {
+        type: 'Index',
+        columns: ['country_code', 'phone_number'],
+        unique: true,
+        where: "deactivated_at IS NULL AND phone_type = 'cell'",
+      },
     ],
   },
 };

--- a/apps/server/src/system/core/schemas/taxIdentifiersSchema.js
+++ b/apps/server/src/system/core/schemas/taxIdentifiersSchema.js
@@ -38,6 +38,12 @@ const taxIdentifiersSchema = {
         unique: true,
         where: 'deactivated_at IS NULL',
       },
+      {
+        type: 'Index',
+        columns: ['country_code', 'tax_type', 'tax_value'],
+        unique: true,
+        where: 'deactivated_at IS NULL',
+      },
     ],
   },
 };

--- a/apps/server/src/system/core/schemas/taxIdentifiersSchema.js
+++ b/apps/server/src/system/core/schemas/taxIdentifiersSchema.js
@@ -34,12 +34,6 @@ const taxIdentifiersSchema = {
       { type: 'Index', columns: ['source_id'] },
       {
         type: 'Index',
-        columns: ['source_id', 'country_code', 'tax_type'],
-        unique: true,
-        where: 'deactivated_at IS NULL',
-      },
-      {
-        type: 'Index',
         columns: ['country_code', 'tax_type', 'tax_value'],
         unique: true,
         where: 'deactivated_at IS NULL',

--- a/apps/server/tests/contract/partialUniqueIndexes.test.js
+++ b/apps/server/tests/contract/partialUniqueIndexes.test.js
@@ -2,13 +2,17 @@
  * @file Contract tests for partial unique indexes on tenant child entities
  * @module tests/contract/partialUniqueIndexes
  *
- * Verifies the following partial unique indexes exist and reject duplicates:
+ * Exercises the following partial unique indexes and adjacent constraints
+ * via direct inserts through the test DB handle:
  *   - emails:           UNIQUE (email)                                    WHERE deactivated_at IS NULL
  *   - tax_identifiers:  UNIQUE (country_code, tax_type, tax_value)        WHERE deactivated_at IS NULL
  *   - phone_numbers:    UNIQUE (country_code, phone_number)               WHERE deactivated_at IS NULL AND phone_type = 'cell'
+ *   - phone_numbers.country_code is NOT NULL
  *
- * Each case inserts a conflicting row directly via the test DB handle and
- * asserts the database rejects with a unique-violation (Postgres SQLSTATE 23505).
+ * Coverage spans positive duplicate-rejection cases (SQLSTATE 23505), the
+ * NOT NULL violation on country_code (SQLSTATE 23502), and negative cases
+ * that must succeed: soft-deleted email reuse, non-cell phone duplicates,
+ * and multiple tax values for the same source/country/type.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */

--- a/apps/server/tests/contract/partialUniqueIndexes.test.js
+++ b/apps/server/tests/contract/partialUniqueIndexes.test.js
@@ -1,0 +1,180 @@
+/**
+ * @file Contract tests for partial unique indexes on tenant child entities
+ * @module tests/contract/partialUniqueIndexes
+ *
+ * Verifies the following partial unique indexes exist and reject duplicates:
+ *   - emails:           UNIQUE (email)                                    WHERE deactivated_at IS NULL
+ *   - tax_identifiers:  UNIQUE (country_code, tax_type, tax_value)        WHERE deactivated_at IS NULL
+ *   - phone_numbers:    UNIQUE (country_code, phone_number)               WHERE deactivated_at IS NULL AND phone_type = 'cell'
+ *
+ * Each case inserts a conflicting row directly via the test DB handle and
+ * asserts the database rejects with a unique-violation (Postgres SQLSTATE 23505).
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { bootstrapAdmin, cleanupTestDb, DB } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(cookies) {
+  const res = await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', cookies)
+    .send({
+      tenant_code: 'PUITST',
+      company: 'Partial Unique Index Test Corp',
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'Test',
+      admin_last_name: 'Admin',
+      admin_email: 'admin@puitst.com',
+      admin_password: 'PuitstPass123!',
+      billing_address: { address_line_1: '1 Unique Way', country_code: 'US' },
+    });
+  return res.body;
+}
+
+async function makeSource(schema, tenantId, label) {
+  return db.one(
+    `INSERT INTO ${DB.pgp.as.name(schema)}.sources (tenant_id, table_id, source_type, label)
+     VALUES ($1, gen_random_uuid(), 'vendor', $2)
+     RETURNING id`,
+    [tenantId, label],
+  );
+}
+
+describe('Partial unique indexes — emails / tax_identifiers / phone_numbers', () => {
+  let tenantId;
+  const schema = 'puitst';
+
+  beforeAll(async () => {
+    const rootCookies = await loginRoot();
+    const tenantRec = await provisionTenant(rootCookies);
+    tenantId = tenantRec.id;
+  }, 30000);
+
+  test('emails: UNIQUE (email) WHERE deactivated_at IS NULL rejects duplicate email across sources', async () => {
+    const a = await makeSource(schema, tenantId, 'EmailSrcA');
+    const b = await makeSource(schema, tenantId, 'EmailSrcB');
+
+    await db.none(
+      `INSERT INTO ${DB.pgp.as.name(schema)}.emails (tenant_id, source_id, email, label, is_primary)
+       VALUES ($1, $2, 'dup@example.com', 'work', false)`,
+      [tenantId, a.id],
+    );
+
+    await expect(
+      db.none(
+        `INSERT INTO ${DB.pgp.as.name(schema)}.emails (tenant_id, source_id, email, label, is_primary)
+         VALUES ($1, $2, 'dup@example.com', 'work', false)`,
+        [tenantId, b.id],
+      ),
+    ).rejects.toMatchObject({ code: '23505' });
+  });
+
+  test('emails: soft-deleted row does not block reuse of the email', async () => {
+    const a = await makeSource(schema, tenantId, 'EmailSrcSoftA');
+    const b = await makeSource(schema, tenantId, 'EmailSrcSoftB');
+
+    await db.none(
+      `INSERT INTO ${DB.pgp.as.name(schema)}.emails (tenant_id, source_id, email, label, is_primary, deactivated_at)
+       VALUES ($1, $2, 'reuse@example.com', 'work', false, now())`,
+      [tenantId, a.id],
+    );
+
+    await expect(
+      db.none(
+        `INSERT INTO ${DB.pgp.as.name(schema)}.emails (tenant_id, source_id, email, label, is_primary)
+         VALUES ($1, $2, 'reuse@example.com', 'work', false)`,
+        [tenantId, b.id],
+      ),
+    ).resolves.toBeNull();
+  });
+
+  test('tax_identifiers: UNIQUE (country_code, tax_type, tax_value) rejects duplicate global tax identifier', async () => {
+    const a = await makeSource(schema, tenantId, 'TaxSrcA');
+    const b = await makeSource(schema, tenantId, 'TaxSrcB');
+
+    await db.none(
+      `INSERT INTO ${DB.pgp.as.name(schema)}.tax_identifiers (tenant_id, source_id, country_code, tax_type, tax_value)
+       VALUES ($1, $2, 'US', 'EIN', '12-3456789')`,
+      [tenantId, a.id],
+    );
+
+    await expect(
+      db.none(
+        `INSERT INTO ${DB.pgp.as.name(schema)}.tax_identifiers (tenant_id, source_id, country_code, tax_type, tax_value)
+         VALUES ($1, $2, 'US', 'EIN', '12-3456789')`,
+        [tenantId, b.id],
+      ),
+    ).rejects.toMatchObject({ code: '23505' });
+
+    // Different tax_value is fine
+    await expect(
+      db.none(
+        `INSERT INTO ${DB.pgp.as.name(schema)}.tax_identifiers (tenant_id, source_id, country_code, tax_type, tax_value)
+         VALUES ($1, $2, 'US', 'EIN', '98-7654321')`,
+        [tenantId, b.id],
+      ),
+    ).resolves.toBeNull();
+  });
+
+  test('phone_numbers: UNIQUE (country_code, phone_number) WHERE phone_type = cell rejects duplicate cell numbers', async () => {
+    const a = await makeSource(schema, tenantId, 'PhoneSrcA');
+    const b = await makeSource(schema, tenantId, 'PhoneSrcB');
+
+    await db.none(
+      `INSERT INTO ${DB.pgp.as.name(schema)}.phone_numbers (tenant_id, source_id, country_code, phone_type, phone_number, is_primary)
+       VALUES ($1, $2, 'US', 'cell', '+15555550001', false)`,
+      [tenantId, a.id],
+    );
+
+    await expect(
+      db.none(
+        `INSERT INTO ${DB.pgp.as.name(schema)}.phone_numbers (tenant_id, source_id, country_code, phone_type, phone_number, is_primary)
+         VALUES ($1, $2, 'US', 'cell', '+15555550001', false)`,
+        [tenantId, b.id],
+      ),
+    ).rejects.toMatchObject({ code: '23505' });
+  });
+
+  test('phone_numbers: non-cell phone types are NOT subject to the unique index', async () => {
+    const a = await makeSource(schema, tenantId, 'PhoneSrcWorkA');
+    const b = await makeSource(schema, tenantId, 'PhoneSrcWorkB');
+
+    await db.none(
+      `INSERT INTO ${DB.pgp.as.name(schema)}.phone_numbers (tenant_id, source_id, country_code, phone_type, phone_number, is_primary)
+       VALUES ($1, $2, 'US', 'work', '+15555550100', false)`,
+      [tenantId, a.id],
+    );
+
+    await expect(
+      db.none(
+        `INSERT INTO ${DB.pgp.as.name(schema)}.phone_numbers (tenant_id, source_id, country_code, phone_type, phone_number, is_primary)
+         VALUES ($1, $2, 'US', 'work', '+15555550100', false)`,
+        [tenantId, b.id],
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/server/tests/contract/partialUniqueIndexes.test.js
+++ b/apps/server/tests/contract/partialUniqueIndexes.test.js
@@ -177,4 +177,34 @@ describe('Partial unique indexes — emails / tax_identifiers / phone_numbers', 
       ),
     ).resolves.toBeNull();
   });
+
+  test('phone_numbers: country_code is NOT NULL — rejects inserts that omit a value', async () => {
+    const src = await makeSource(schema, tenantId, 'PhoneSrcNullCC');
+
+    await expect(
+      db.none(
+        `INSERT INTO ${DB.pgp.as.name(schema)}.phone_numbers (tenant_id, source_id, country_code, phone_type, phone_number, is_primary)
+         VALUES ($1, $2, NULL, 'cell', '+15555559999', false)`,
+        [tenantId, src.id],
+      ),
+    ).rejects.toMatchObject({ code: '23502' });
+  });
+
+  test('tax_identifiers: same source may hold multiple values for the same country/type', async () => {
+    const src = await makeSource(schema, tenantId, 'TaxSrcMultiVAT');
+
+    await db.none(
+      `INSERT INTO ${DB.pgp.as.name(schema)}.tax_identifiers (tenant_id, source_id, country_code, tax_type, tax_value)
+       VALUES ($1, $2, 'GB', 'VAT', 'GB123456789')`,
+      [tenantId, src.id],
+    );
+
+    await expect(
+      db.none(
+        `INSERT INTO ${DB.pgp.as.name(schema)}.tax_identifiers (tenant_id, source_id, country_code, tax_type, tax_value)
+         VALUES ($1, $2, 'GB', 'VAT', 'GB987654321')`,
+        [tenantId, src.id],
+      ),
+    ).resolves.toBeNull();
+  });
 });

--- a/apps/server/tests/contract/partialUniqueIndexes.test.js
+++ b/apps/server/tests/contract/partialUniqueIndexes.test.js
@@ -178,7 +178,7 @@ describe('Partial unique indexes — emails / tax_identifiers / phone_numbers', 
     ).resolves.toBeNull();
   });
 
-  test('phone_numbers: country_code is NOT NULL — rejects inserts that omit a value', async () => {
+  test('phone_numbers: country_code is NOT NULL — rejects explicit NULL inserts', async () => {
     const src = await makeSource(schema, tenantId, 'PhoneSrcNullCC');
 
     await expect(


### PR DESCRIPTION
## Summary

Task 3 of the Import Dedup & Multi-Tenant Vendor Access plan. Schema-only change on a fresh DB — no migration files (see [architecture review reply](https://github.com/silverstone-i/axerra/pull/48#issuecomment-4361470015) for the fresh-DB rationale).

| Schema | Change |
|---|---|
| `emailsSchema.js` | Replace `(source_id, email) WHERE deactivated_at IS NULL` with `(email) WHERE deactivated_at IS NULL` |
| `taxIdentifiersSchema.js` | **Drop** existing `(source_id, country_code, tax_type) WHERE deactivated_at IS NULL`. **Add** `(country_code, tax_type, tax_value) WHERE deactivated_at IS NULL` |
| `phoneNumbersSchema.js` | Tighten `country_code` to `notNull: true` (default `'US'` retained). **Add** `(country_code, phone_number) WHERE deactivated_at IS NULL AND phone_type = 'cell'` |

`addresses` and non-cell `phone_numbers` keep no DB-level uniqueness, per spec.

Contract test `partialUniqueIndexes.test.js` (7 cases) covers each new index plus negative cases: soft-deleted email rows can be reused; non-cell phones are unconstrained; explicit NULL `country_code` is rejected (SQLSTATE 23502); same source can hold multiple VAT values for the same country/type.

## Resolved review feedback

- Tax-identifiers per-source unique dropped (Copilot + Task 2 ADR concern).
- `phone_numbers.country_code` tightened to `notNull` (Copilot + Task 2 ADR concern).
- Regression tests added for both.
- Architecture-review migration concern: addressed in PR comment — fresh-DB deployment model.

## Test plan

- [x] `npm run lint` clean
- [x] Full server suite passes locally
- [x] `partialUniqueIndexes.test.js` — 7/7