### PR TITLE
feat(server): export child UUID columns for round-trip dedup

### DIFF
--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -91,7 +91,7 @@ export async function buildChildSheet(wb, sheetName, model, sourceIds, parentIdB
 
   if (!sourceIds.length) {
     if (defaultHeaders.length) {
-      sheet.setHeaders([linkColName, ...defaultHeaders]);
+      sheet.setHeaders([linkColName, 'id', ...defaultHeaders]);
     } else {
       sheet.addRow(['No data']);
     }

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -99,21 +99,23 @@ export async function buildChildSheet(wb, sheetName, model, sourceIds, parentIdB
   }
 
   const rows = await model.findWhere([{ source_id: { $in: sourceIds } }]);
-  // Drop id from child rows — children are replaced wholesale on import
-  const curated = curateRows(rows, ['id']);
+  // Keep child `id` so re-import can match on UUID (round-trip dedup guarantee)
+  const curated = curateRows(rows);
 
   if (!curated.length) {
     if (defaultHeaders.length) {
-      sheet.setHeaders([linkColName, ...defaultHeaders]);
+      sheet.setHeaders([linkColName, 'id', ...defaultHeaders]);
     } else {
       sheet.addRow(['No data']);
     }
     return;
   }
 
-  // Prepend linkage column (parent id/ref) and format phone/tax values for display
+  // Prepend linkage column (parent id/ref) followed by the child UUID, then the rest.
+  // Order: <linkColName>, id, <other columns>
   const linked = curated.map((row, i) => {
-    const out = { [linkColName]: parentIdBySourceId.get(rows[i].source_id) || '', ...row };
+    const { id, ...restCols } = row;
+    const out = { [linkColName]: parentIdBySourceId.get(rows[i].source_id) || '', id, ...restCols };
     formatExportRow(out, 'phone_number', 'country_code', 'tax_value', 'country_code', 'tax_type');
     return out;
   });
@@ -523,7 +525,7 @@ export async function buildExportWorkbook(model, where, joinType, options, confi
     mainSheet.setHeaders([...schemaHeaders, ...extraHeaders]);
     for (const child of config.childSheets) {
       const childSheet = wb.sheet(child.sheetName);
-      childSheet.setHeaders([config.linkColName, ...child.headers]);
+      childSheet.setHeaders([config.linkColName, 'id', ...child.headers]);
     }
     return { wb, rows, sourceIds: [], idBySourceId: new Map(), writeXlsx };
   }

--- a/apps/server/tests/unit/spreadsheetHelpers.test.js
+++ b/apps/server/tests/unit/spreadsheetHelpers.test.js
@@ -258,4 +258,16 @@ describe('buildChildSheet (UUID round-trip)', () => {
     const headers = sheet.getRow(0).map((c) => c.value);
     expect(headers).toEqual(['employee_id', 'id', 'email', 'label']);
   });
+
+  it('emits an `id` column header when sourceIds is empty', async () => {
+    const model = makeStubModel([]);
+    const wb = WorkbookBuilder.create();
+    await buildChildSheet(wb, 'Emails', model, [], new Map(), 'employee_id', ['email', 'label']);
+
+    const reader = WorkbookReader.fromBuffer(writeXlsx(wb.build()));
+    const sheetIdx = reader.sheetNames.indexOf('Emails');
+    const sheet = reader.sheet(sheetIdx);
+    const headers = sheet.getRow(0).map((c) => c.value);
+    expect(headers).toEqual(['employee_id', 'id', 'email', 'label']);
+  });
 });

--- a/apps/server/tests/unit/spreadsheetHelpers.test.js
+++ b/apps/server/tests/unit/spreadsheetHelpers.test.js
@@ -6,7 +6,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { getEnumColumns, validateChildEnums } from '../../src/lib/spreadsheetHelpers.js';
+import { WorkbookBuilder, WorkbookReader, writeXlsx } from '@nap-sft/tablsx';
+import { getEnumColumns, validateChildEnums, buildChildSheet, curateRows, parseSheet } from '../../src/lib/spreadsheetHelpers.js';
 
 describe('getEnumColumns', () => {
   it('extracts enum values from a CHECK IN (...) constraint', () => {
@@ -158,5 +159,103 @@ describe('validateChildEnums', () => {
   it('handles groups missing the child key entirely', () => {
     const groups = [{ parent: {}, children: {} }, { parent: {} }];
     expect(validateChildEnums(groups, { sheetName: 'Vendors', childEnums: baseChildEnums })).toEqual([]);
+  });
+});
+
+describe('curateRows', () => {
+  it('keeps `id` by default so exports support UUID round-trip', () => {
+    const rows = [
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        tenant_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        source_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        created_at: '2025-01-01',
+        created_by: 'x',
+        updated_at: '2025-01-02',
+        updated_by: 'y',
+        deactivated_at: null,
+        email: 'a@b.com',
+      },
+    ];
+    const out = curateRows(rows);
+    expect(out).toEqual([{ id: '11111111-1111-1111-1111-111111111111', email: 'a@b.com' }]);
+  });
+});
+
+describe('buildChildSheet (UUID round-trip)', () => {
+  const PARENT_ID = '22222222-2222-2222-2222-222222222222';
+  const SOURCE_ID = '33333333-3333-3333-3333-333333333333';
+  const CHILD_ID_1 = '44444444-4444-4444-4444-444444444444';
+  const CHILD_ID_2 = '55555555-5555-5555-5555-555555555555';
+
+  function makeStubModel(rows) {
+    return {
+      findWhere: async () => rows,
+    };
+  }
+
+  it('exports the child UUID column so re-import can match on id', async () => {
+    const model = makeStubModel([
+      {
+        id: CHILD_ID_1,
+        tenant_id: 'tid',
+        source_id: SOURCE_ID,
+        email: 'a@b.com',
+        label: 'work',
+        is_primary: true,
+        is_login: false,
+        created_at: 'x',
+        created_by: 'x',
+        updated_at: 'x',
+        updated_by: 'x',
+        deactivated_at: null,
+      },
+      {
+        id: CHILD_ID_2,
+        tenant_id: 'tid',
+        source_id: SOURCE_ID,
+        email: 'c@d.com',
+        label: 'home',
+        is_primary: false,
+        is_login: false,
+      },
+    ]);
+
+    const wb = WorkbookBuilder.create();
+    const idBySource = new Map([[SOURCE_ID, PARENT_ID]]);
+    await buildChildSheet(wb, 'Emails', model, [SOURCE_ID], idBySource, 'employee_id', ['email', 'label', 'is_primary', 'is_login']);
+
+    const reader = WorkbookReader.fromBuffer(writeXlsx(wb.build()));
+    const sheetIdx = reader.sheetNames.indexOf('Emails');
+    const parsed = parseSheet(reader, sheetIdx);
+
+    expect(parsed.length).toBe(2);
+    expect(Object.keys(parsed[0])).toContain('id');
+    expect(Object.keys(parsed[0])).toContain('employee_id');
+    // Round-trip preserves the child UUID
+    const ids = parsed.map((r) => r.id).sort();
+    expect(ids).toEqual([CHILD_ID_1, CHILD_ID_2].sort());
+    // Linkage column is the parent UUID
+    expect(parsed[0].employee_id).toBe(PARENT_ID);
+    // Internal columns stripped
+    for (const r of parsed) {
+      expect(r.tenant_id).toBeUndefined();
+      expect(r.source_id).toBeUndefined();
+      expect(r.created_at).toBeUndefined();
+      expect(r.updated_by).toBeUndefined();
+      expect(r.deactivated_at).toBeUndefined();
+    }
+  });
+
+  it('emits an `id` column header even when no rows exist', async () => {
+    const model = makeStubModel([]);
+    const wb = WorkbookBuilder.create();
+    await buildChildSheet(wb, 'Emails', model, [SOURCE_ID], new Map(), 'employee_id', ['email', 'label']);
+
+    const reader = WorkbookReader.fromBuffer(writeXlsx(wb.build()));
+    const sheetIdx = reader.sheetNames.indexOf('Emails');
+    const sheet = reader.sheet(sheetIdx);
+    const headers = sheet.getRow(0).map((c) => c.value);
+    expect(headers).toEqual(['employee_id', 'id', 'email', 'label']);
   });
 });


### PR DESCRIPTION
## Summary

Task 11 of the [Import Dedup & Multi-Tenant Vendor Access plan](../../../../.claude/plans/users-ian-downloads-import-dedup-and-mu-jolly-castle.md). Excel exports now emit child-entity UUIDs alongside the parent UUID so round-trip imports can match on UUID and the dedup logic in Task 10 has something to anchor against.

`buildChildSheet` in `spreadsheetHelpers.js` previously stripped `id` via `curateRows(rows, ['id'])`. It now keeps `id` and places it as the second column after the parent linkage column. The empty-sheet header path in `buildExportWorkbook` was updated to match so populated and empty exports have identical column shape.

Documented behavior (per spec):
- Clearing a UUID forces a new-entity insert.
- Collision on a unique field after clearing UUID → import is rejected (the rejection logic lands in Task 10).

## User-visible change

Every child sheet (Phone Numbers, Addresses, Tax Identifiers, Emails, etc.) now contains an extra `id` column between the parent linkage column (e.g. `employee_id`) and the existing data columns. Anyone consuming or hand-editing exported xlsx files will see the new column.

## Out of scope

- Import-side `id` handling — `importChildSheet` still does `delete row.id` and replaces children wholesale. Task 10 (cross-tenant collision check) will read `id` before the delete.
- Flat (single-sheet) exports unchanged — child rows are fragments without their own UUIDs by design; only the parent UUID needs to round-trip there, which already works.

## Test plan

- [x] `npm run lint` clean
- [x] `vitest run tests/unit/spreadsheetHelpers.test.js` — 16/16 (3 new)
- [x] Full server suite passes locally
- [ ] Reviewer: confirm the new column header is acceptable in exports