### PR TITLE
refactor(server): split portal_users into auth + portal_user_tenants (Tasks 4 + 5)

### DIFF
--- a/apps/server/scripts/setupAdmin.js
+++ b/apps/server/scripts/setupAdmin.js
@@ -146,14 +146,20 @@ async function main() {
   // ── Link root super user to an employee record ──────────────
   const rootEmail = process.env.ROOT_EMAIL;
   if (rootEmail) {
-    const superUser = await db.oneOrNone('SELECT id, entity_type FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL', [
-      rootEmail,
-    ]);
+    const superUser = await db.oneOrNone(
+      'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+      [rootEmail],
+    );
 
-    if (superUser && !superUser.entity_type) {
-      logger.info('Linking root super user to employee record...');
+    if (superUser && tenant) {
+      const existingBinding = await db.oneOrNone(
+        `SELECT id FROM admin.portal_user_tenants
+         WHERE portal_user_id = $1 AND deactivated_at IS NULL`,
+        [superUser.id],
+      );
 
-      if (tenant) {
+      if (!existingBinding) {
+        logger.info('Linking root super user to employee record...');
         const s = DB.pgp.as.name(tenantSchema);
 
         // 1. Insert employee with super_user role
@@ -185,13 +191,17 @@ async function main() {
           [tenant.id, source.id, rootEmail],
         );
 
-        // 4. Link portal_user to employee
-        await db.none("UPDATE admin.portal_users SET entity_type = 'employee', entity_id = $1 WHERE id = $2", [employee.id, superUser.id]);
+        // 4. Bind portal_user to the employee via portal_user_tenants
+        await db.none(
+          `INSERT INTO admin.portal_user_tenants (portal_user_id, tenant_id, entity_type, entity_id, status)
+           VALUES ($1, $2, 'employee', $3, 'active')`,
+          [superUser.id, tenant.id, employee.id],
+        );
 
-        logger.info(`Root super user linked to employee ${employee.id}`);
+        logger.info(`Root super user bound to employee ${employee.id}`);
+      } else {
+        logger.info('Root super user already bound to a tenant, skipping.');
       }
-    } else if (superUser?.entity_type) {
-      logger.info('Root super user already linked to entity, skipping.');
     }
   }
 

--- a/apps/server/scripts/setupAdmin.js
+++ b/apps/server/scripts/setupAdmin.js
@@ -152,13 +152,16 @@ async function main() {
     );
 
     if (superUser && tenant) {
+      // Look for an existing binding for the root tenant. A bare binding
+      // (no entity_type yet) gets its entity link populated rather than
+      // a second binding being inserted.
       const existingBinding = await db.oneOrNone(
-        `SELECT id FROM admin.portal_user_tenants
-         WHERE portal_user_id = $1 AND deactivated_at IS NULL`,
-        [superUser.id],
+        `SELECT id, entity_type, entity_id FROM admin.portal_user_tenants
+         WHERE portal_user_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
+        [superUser.id, tenant.id],
       );
 
-      if (!existingBinding) {
+      if (!existingBinding || existingBinding.entity_type === null) {
         logger.info('Linking root super user to employee record...');
         const s = DB.pgp.as.name(tenantSchema);
 
@@ -191,16 +194,27 @@ async function main() {
           [tenant.id, source.id, rootEmail],
         );
 
-        // 4. Bind portal_user to the employee via portal_user_tenants
-        await db.none(
-          `INSERT INTO admin.portal_user_tenants (portal_user_id, tenant_id, entity_type, entity_id, status)
-           VALUES ($1, $2, 'employee', $3, 'active')`,
-          [superUser.id, tenant.id, employee.id],
-        );
+        // 4. Populate (or insert) the binding's entity link. A bare
+        // binding from a prior register call is updated in place to
+        // preserve the unique (portal_user_id, tenant_id) row.
+        if (existingBinding) {
+          await db.none(
+            `UPDATE admin.portal_user_tenants
+             SET entity_type = 'employee', entity_id = $1, status = 'active'
+             WHERE id = $2`,
+            [employee.id, existingBinding.id],
+          );
+        } else {
+          await db.none(
+            `INSERT INTO admin.portal_user_tenants (portal_user_id, tenant_id, entity_type, entity_id, status)
+             VALUES ($1, $2, 'employee', $3, 'active')`,
+            [superUser.id, tenant.id, employee.id],
+          );
+        }
 
         logger.info(`Root super user bound to employee ${employee.id}`);
       } else {
-        logger.info('Root super user already bound to a tenant, skipping.');
+        logger.info('Root super user already linked to entity, skipping.');
       }
     }
   }

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -971,19 +971,18 @@ export async function provisionAppUser(entityId, email, password, tenantId, crea
     passwordHash = await bcrypt.default.hash(password, rounds);
   }
 
-  const { db } = await getDb();
-  const portalUsersModel = db('portalUsers', 'admin');
-  portalUsersModel.tx = t;
-
-  await portalUsersModel.insert({
-    tenant_id: tenantId,
-    entity_type: entityType,
-    entity_id: entityId,
-    email,
-    password_hash: passwordHash,
-    status: 'invited',
-    created_by: createdBy,
-  });
+  const inserted = await t.one(
+    `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
+     VALUES ($1, $2, 'invited', $3)
+     RETURNING id`,
+    [email, passwordHash, createdBy],
+  );
+  await t.none(
+    `INSERT INTO admin.portal_user_tenants
+       (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+     VALUES ($1, $2, $3, $4, 'active', $5)`,
+    [inserted.id, tenantId, entityType, entityId, createdBy],
+  );
   return true;
 }
 

--- a/apps/server/src/middleware/authRedis.js
+++ b/apps/server/src/middleware/authRedis.js
@@ -237,9 +237,17 @@ export function authRedis() {
               effectiveUser = { ...targetUser, entity_type: targetBinding.entity_type, entity_id: targetBinding.entity_id };
               // Set effective context from the resolved binding so downstream
               // queries don't operate against a tenant the target lacks a
-              // binding for.
-              effectiveTenantCode = (targetBinding.tenant_code || requestedTargetCode || tenantCode).toLowerCase();
-              effectiveSchemaName = targetSchemaOverride || targetBinding.schema_name;
+              // binding for. The Redis-stored targetSchemaName is only
+              // honored when the resolved binding still matches the
+              // originally-chosen tenant — otherwise the original binding
+              // has been archived and the override is stale, so we use
+              // the resolved binding's current schema_name.
+              const bindingTenantCode = targetBinding.tenant_code?.toLowerCase();
+              const overrideMatches = targetSchemaOverride
+                && requestedTargetCode
+                && bindingTenantCode === requestedTargetCode.toLowerCase();
+              effectiveTenantCode = bindingTenantCode || requestedTargetCode || tenantCode;
+              effectiveSchemaName = overrideMatches ? targetSchemaOverride : targetBinding.schema_name;
 
               if (targetBinding.tenant_id !== effectiveTenantRecord.id) {
                 const targetTenant = await db2('tenants', 'admin').findById(targetBinding.tenant_id);

--- a/apps/server/src/middleware/authRedis.js
+++ b/apps/server/src/middleware/authRedis.js
@@ -169,10 +169,17 @@ export function authRedis() {
       }
 
       // ── RBAC Permission Loading ─────────────────────────────────────────
-      // Permissions are scoped to the active binding's home schema (where
-      // the binding's entity record lives) and cached per-tenant.
-      const schemaName = activeBinding === homeBinding ? homeSchemaName : effectiveTenantRecord.schema_name;
-      let permissions = await getCachedPermissions(uid, tenantCode);
+      // Permissions are scoped to the active binding's schema. Cache key
+      // follows the binding: when a matching per-tenant binding was found
+      // we key on the active tenant_code; when we fell back to the home
+      // binding (e.g. Axerra cross-tenant switch with no binding) the
+      // perms are home-tenant perms, so cache under homeTenantCode. Mixing
+      // these would let stale home perms shadow real per-tenant perms
+      // once the user gains a binding to that tenant.
+      const fellBackToHome = activeBinding === homeBinding;
+      const schemaName = fellBackToHome ? homeSchemaName : effectiveTenantRecord.schema_name;
+      const permCacheKey = fellBackToHome ? homeTenantCode : tenantCode;
+      let permissions = await getCachedPermissions(uid, permCacheKey);
 
       if (!permissions) {
         permissions = await loadPermissions({
@@ -181,7 +188,7 @@ export function authRedis() {
           entityType: activeBinding.entity_type,
           entityId: activeBinding.entity_id,
         });
-        await cachePermissions(uid, tenantCode, permissions);
+        await cachePermissions(uid, permCacheKey, permissions);
       }
 
       // ── Stale Token Detection ───────────────────────────────────────────
@@ -211,25 +218,28 @@ export function authRedis() {
           const db2 = dbMod2.default || dbMod2.db;
           const targetUser = await db2('portalUsers', 'admin').findOneBy([{ id: parsed.targetUserId }]);
           if (targetUser) {
-            // Resolve the impersonated target's binding for the chosen tenant,
-            // falling back to their first active binding.
-            const targetTenantCode = parsed.targetTenantCode || tenantCode;
-            const targetSchemaName = parsed.targetSchemaName;
+            // Resolve the impersonated target's binding: prefer one that
+            // matches the requested target tenant, otherwise fall back
+            // to their earliest active binding.
+            const requestedTargetCode = parsed.targetTenantCode || tenantCode || null;
+            const targetSchemaOverride = parsed.targetSchemaName;
             const targetBinding = await db2.oneOrNone(
               `SELECT b.entity_type, b.entity_id, b.tenant_id, t.schema_name, t.tenant_code
                FROM admin.portal_user_tenants b
                JOIN admin.tenants t ON t.id = b.tenant_id
                WHERE b.portal_user_id = $1 AND b.deactivated_at IS NULL
-                 AND ($2::text IS NULL OR LOWER(t.tenant_code) = LOWER($2))
-               ORDER BY (LOWER(t.tenant_code) = LOWER($2)) DESC NULLS LAST, b.created_at ASC
+               ORDER BY ($2::text IS NOT NULL AND LOWER(t.tenant_code) = LOWER($2)) DESC, b.created_at ASC
                LIMIT 1`,
-              [targetUser.id, targetTenantCode || null],
+              [targetUser.id, requestedTargetCode],
             );
 
             if (targetBinding) {
               effectiveUser = { ...targetUser, entity_type: targetBinding.entity_type, entity_id: targetBinding.entity_id };
-              effectiveTenantCode = targetTenantCode;
-              effectiveSchemaName = targetSchemaName || targetBinding.schema_name;
+              // Set effective context from the resolved binding so downstream
+              // queries don't operate against a tenant the target lacks a
+              // binding for.
+              effectiveTenantCode = (targetBinding.tenant_code || requestedTargetCode || tenantCode).toLowerCase();
+              effectiveSchemaName = targetSchemaOverride || targetBinding.schema_name;
 
               if (targetBinding.tenant_id !== effectiveTenantRecord.id) {
                 const targetTenant = await db2('tenants', 'admin').findById(targetBinding.tenant_id);

--- a/apps/server/src/middleware/authRedis.js
+++ b/apps/server/src/middleware/authRedis.js
@@ -100,33 +100,50 @@ export function authRedis() {
       const dbMod = await import('../db/db.js');
       const db = dbMod.default || dbMod.db;
       let userRecord = null;
-      let tenantRecord = null;
+      let homeBinding = null;
+      let homeTenantRecord = null;
       try {
         userRecord = await db('portalUsers', 'admin').findOneBy([{ id: uid }]);
         if (userRecord) {
-          tenantRecord = await db('tenants', 'admin').findById(userRecord.tenant_id);
+          // Default to the user's earliest active binding as their "home"
+          // tenant. Tasks 5–9 keep employees and clients single-binding;
+          // vendor_contacts may have multiple but the first-by-created_at
+          // is a deterministic default the x-tenant-code header overrides.
+          homeBinding = await db.oneOrNone(
+            `SELECT id, portal_user_id, tenant_id, entity_type, entity_id, status
+             FROM admin.portal_user_tenants
+             WHERE portal_user_id = $1 AND deactivated_at IS NULL
+             ORDER BY created_at ASC
+             LIMIT 1`,
+            [uid],
+          );
+          if (homeBinding) {
+            homeTenantRecord = await db('tenants', 'admin').findById(homeBinding.tenant_id);
+          }
         }
       } catch {
         // DB unavailable — reject
         return res.status(401).json({ error: 'Unauthorized' });
       }
 
-      if (!userRecord || !tenantRecord) {
+      if (!userRecord || !homeBinding || !homeTenantRecord) {
         return res.status(401).json({ error: 'Unauthorized' });
       }
 
-      // Resolve tenant code from header or user's tenant
+      // Resolve tenant code from header or user's home binding
       const headerTenant = req.headers['x-tenant-code'];
-      const homeTenantCode = tenantRecord.tenant_code.toLowerCase();
+      const homeTenantCode = homeTenantRecord.tenant_code.toLowerCase();
       const tenantCode = headerTenant ? headerTenant.toLowerCase() : homeTenantCode;
 
-      // ── Schema resolution ───────────────────────────────────────────────
-      // Permissions always load from the user's home tenant (where their roles live).
-      // Data queries use the assumed tenant's schema when the header is present.
-      // effectiveTenantRecord tracks the tenant whose data the request operates on.
-      const homeSchemaName = tenantRecord.schema_name;
+      // ── Schema + binding resolution ─────────────────────────────────────
+      // Schema/data resolution follows the resolved tenant_code. Entity
+      // context (entity_type/entity_id) follows the matching binding when
+      // one exists — otherwise it falls back to the home binding so
+      // Axerra cross-tenant switching keeps working without a binding.
+      const homeSchemaName = homeTenantRecord.schema_name;
       let dataSchemaName = homeSchemaName;
-      let effectiveTenantRecord = tenantRecord;
+      let effectiveTenantRecord = homeTenantRecord;
+      let activeBinding = homeBinding;
       if (headerTenant && tenantCode !== homeTenantCode) {
         try {
           const row = await db.oneOrNone(
@@ -136,6 +153,15 @@ export function authRedis() {
           if (row) {
             dataSchemaName = row.schema_name;
             effectiveTenantRecord = row;
+            const matchedBinding = await db.oneOrNone(
+              `SELECT id, portal_user_id, tenant_id, entity_type, entity_id, status
+               FROM admin.portal_user_tenants
+               WHERE portal_user_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
+              [uid, row.id],
+            );
+            if (matchedBinding) {
+              activeBinding = matchedBinding;
+            }
           }
         } catch {
           // Fall back to home schema if lookup fails
@@ -143,17 +169,19 @@ export function authRedis() {
       }
 
       // ── RBAC Permission Loading ─────────────────────────────────────────
-      const schemaName = homeSchemaName;
-      let permissions = await getCachedPermissions(uid, homeTenantCode);
+      // Permissions are scoped to the active binding's home schema (where
+      // the binding's entity record lives) and cached per-tenant.
+      const schemaName = activeBinding === homeBinding ? homeSchemaName : effectiveTenantRecord.schema_name;
+      let permissions = await getCachedPermissions(uid, tenantCode);
 
       if (!permissions) {
         permissions = await loadPermissions({
           schemaName,
           userId: uid,
-          entityType: userRecord.entity_type,
-          entityId: userRecord.entity_id,
+          entityType: activeBinding.entity_type,
+          entityId: activeBinding.entity_id,
         });
-        await cachePermissions(uid, homeTenantCode, permissions);
+        await cachePermissions(uid, tenantCode, permissions);
       }
 
       // ── Stale Token Detection ───────────────────────────────────────────
@@ -183,23 +211,38 @@ export function authRedis() {
           const db2 = dbMod2.default || dbMod2.db;
           const targetUser = await db2('portalUsers', 'admin').findOneBy([{ id: parsed.targetUserId }]);
           if (targetUser) {
-            effectiveUser = targetUser;
-            effectiveTenantCode = parsed.targetTenantCode || tenantCode;
-            effectiveSchemaName = parsed.targetSchemaName || schemaName;
+            // Resolve the impersonated target's binding for the chosen tenant,
+            // falling back to their first active binding.
+            const targetTenantCode = parsed.targetTenantCode || tenantCode;
+            const targetSchemaName = parsed.targetSchemaName;
+            const targetBinding = await db2.oneOrNone(
+              `SELECT b.entity_type, b.entity_id, b.tenant_id, t.schema_name, t.tenant_code
+               FROM admin.portal_user_tenants b
+               JOIN admin.tenants t ON t.id = b.tenant_id
+               WHERE b.portal_user_id = $1 AND b.deactivated_at IS NULL
+                 AND ($2::text IS NULL OR LOWER(t.tenant_code) = LOWER($2))
+               ORDER BY (LOWER(t.tenant_code) = LOWER($2)) DESC NULLS LAST, b.created_at ASC
+               LIMIT 1`,
+              [targetUser.id, targetTenantCode || null],
+            );
 
-            // Resolve the impersonated user's tenant record
-            if (targetUser.tenant_id !== tenantRecord.id) {
-              const targetTenant = await db2('tenants', 'admin').findById(targetUser.tenant_id);
-              if (targetTenant) effectiveTenantRecord = targetTenant;
+            if (targetBinding) {
+              effectiveUser = { ...targetUser, entity_type: targetBinding.entity_type, entity_id: targetBinding.entity_id };
+              effectiveTenantCode = targetTenantCode;
+              effectiveSchemaName = targetSchemaName || targetBinding.schema_name;
+
+              if (targetBinding.tenant_id !== effectiveTenantRecord.id) {
+                const targetTenant = await db2('tenants', 'admin').findById(targetBinding.tenant_id);
+                if (targetTenant) effectiveTenantRecord = targetTenant;
+              }
+
+              effectivePermissions = await loadPermissions({
+                schemaName: effectiveSchemaName,
+                userId: targetUser.id,
+                entityType: targetBinding.entity_type,
+                entityId: targetBinding.entity_id,
+              });
             }
-
-            // Re-load permissions for target user
-            effectivePermissions = await loadPermissions({
-              schemaName: effectiveSchemaName,
-              userId: targetUser.id,
-              entityType: targetUser.entity_type,
-              entityId: targetUser.entity_id,
-            });
           }
         }
       } catch {
@@ -207,11 +250,14 @@ export function authRedis() {
       }
 
       // ── Populate req.user ───────────────────────────────────────────────
+      const effectiveEntityType = isImpersonating ? effectiveUser.entity_type : activeBinding.entity_type;
+      const effectiveEntityId = isImpersonating ? effectiveUser.entity_id : activeBinding.entity_id;
+
       req.user = {
         id: isImpersonating ? impersonatedBy : uid,
         email: effectiveUser.email,
-        entity_type: effectiveUser.entity_type,
-        entity_id: effectiveUser.entity_id,
+        entity_type: effectiveEntityType,
+        entity_id: effectiveEntityId,
         status: effectiveUser.status,
         tenant_id: effectiveTenantRecord.id,
         tenant_code: effectiveTenantCode,

--- a/apps/server/src/services/permissionLoader.js
+++ b/apps/server/src/services/permissionLoader.js
@@ -78,8 +78,8 @@ async function resolveEntityRoles(schemaName, entityType, entityId) {
  * @param {object} options
  * @param {string} options.schemaName Tenant schema name
  * @param {string} options.userId User UUID
- * @param {string|null} [options.entityType] From portal_users.entity_type
- * @param {string|null} [options.entityId] From portal_users.entity_id
+ * @param {string|null} [options.entityType] From the active portal_user_tenants binding
+ * @param {string|null} [options.entityId] From the active portal_user_tenants binding
  * @returns {Promise<object>} Permission canon
  */
 export async function loadPermissions({ schemaName, userId, entityType = null, entityId = null }) {

--- a/apps/server/src/services/tenantSetup.js
+++ b/apps/server/src/services/tenantSetup.js
@@ -214,13 +214,19 @@ export async function provisionNewTenant(body, actorId) {
       );
     }
 
-    // 3g. Create portal_users login linked to the employee
+    // 3g. Create portal_users login + portal_user_tenants binding for the employee
     const user = await t.one(
       `INSERT INTO admin.portal_users
-         (tenant_id, entity_type, entity_id, email, password_hash, status, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
+         (email, password_hash, status, created_by)
+       VALUES ($1, $2, $3, $4)
        RETURNING *`,
-      [tenant.id, 'employee', emp.id, admin_email, passwordHash, 'invited', actorId],
+      [admin_email, passwordHash, 'invited', actorId],
+    );
+    await t.none(
+      `INSERT INTO admin.portal_user_tenants
+         (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+       VALUES ($1, $2, 'employee', $3, 'active', $4)`,
+      [user.id, tenant.id, emp.id, actorId],
     );
 
     return { admin_user_id: user.id, company_id: comp.id, source_id: source.id };

--- a/apps/server/src/system/auth/authRepositories.js
+++ b/apps/server/src/system/auth/authRepositories.js
@@ -7,11 +7,13 @@
 
 import Tenants from './models/Tenants.js';
 import PortalUsers from './models/PortalUsers.js';
+import PortalUserTenants from './models/PortalUserTenants.js';
 import ImpersonationLogs from './models/ImpersonationLogs.js';
 import MatchReviewLogs from './models/MatchReviewLogs.js';
 const repositories = {
   tenants: Tenants,
   portalUsers: PortalUsers,
+  portalUserTenants: PortalUserTenants,
   impersonationLogs: ImpersonationLogs,
   matchReviewLogs: MatchReviewLogs,
 };

--- a/apps/server/src/system/auth/models/PortalUserTenants.js
+++ b/apps/server/src/system/auth/models/PortalUserTenants.js
@@ -1,0 +1,15 @@
+/**
+ * @file PortalUserTenants model — extends TableModel for admin.portal_user_tenants
+ * @module auth/models/PortalUserTenants
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { TableModel } from 'pg-schemata';
+import portalUserTenantsSchema from '../schemas/portalUserTenantsSchema.js';
+
+export default class PortalUserTenants extends TableModel {
+  constructor(db, pgp, logger = null) {
+    super(db, pgp, portalUserTenantsSchema, logger);
+  }
+}

--- a/apps/server/src/system/auth/schema/migrations/202502110001_bootstrapAdmin.js
+++ b/apps/server/src/system/auth/schema/migrations/202502110001_bootstrapAdmin.js
@@ -2,10 +2,11 @@
  * @file Migration: bootstrap admin schema tables and seed root tenant + super user
  * @module auth/schema/migrations/202502110001_bootstrapAdmin
  *
- * Creates admin schema tables (tenants, portal_users, impersonation_logs,
- * match_review_logs). Seeds the Axerra root tenant and a bootstrap
- * super user. The entity link (entity_type, entity_id) is set by
- * setupAdmin.js after tenant provisioning creates the employees table.
+ * Creates admin schema tables (tenants, portal_users, portal_user_tenants,
+ * impersonation_logs, match_review_logs). Seeds the Axerra root tenant
+ * and a bootstrap super user. The tenant binding (portal_user_tenants
+ * row) is created by setupAdmin.js after tenant provisioning creates
+ * the employees table.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
@@ -63,27 +64,20 @@ export default defineMigration({
     const rootPassword = process.env.ROOT_PASSWORD;
 
     if (rootEmail && rootPassword) {
-      const tenant = await db.oneOrNone(
-        'SELECT id FROM admin.tenants WHERE tenant_code = $1',
-        [rootTenantCode],
+      const existingUser = await db.oneOrNone(
+        'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+        [rootEmail],
       );
 
-      if (tenant) {
-        const existingUser = await db.oneOrNone(
-          'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
-          [rootEmail],
+      if (!existingUser) {
+        const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
+        const passwordHash = await bcrypt.hash(rootPassword, rounds);
+
+        await db.none(
+          `INSERT INTO admin.portal_users (email, password_hash, status)
+           VALUES ($1, $2, 'active')`,
+          [rootEmail, passwordHash],
         );
-
-        if (!existingUser) {
-          const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
-          const passwordHash = await bcrypt.hash(rootPassword, rounds);
-
-          await db.none(
-            `INSERT INTO admin.portal_users (tenant_id, entity_type, entity_id, email, password_hash, status)
-             VALUES ($1, NULL, NULL, $2, $3, 'active')`,
-            [tenant.id, rootEmail, passwordHash],
-          );
-        }
       }
     }
   },
@@ -92,7 +86,7 @@ export default defineMigration({
     if (schema !== 'admin') return;
 
     // Drop in reverse dependency order
-    const tables = ['match_review_logs', 'impersonation_logs', 'portal_users', 'tenants'];
+    const tables = ['match_review_logs', 'impersonation_logs', 'portal_user_tenants', 'portal_users', 'tenants'];
     for (const table of tables) {
       await db.none(`DROP TABLE IF EXISTS admin.${table} CASCADE`);
     }

--- a/apps/server/src/system/auth/schemas/portalUserTenantsSchema.js
+++ b/apps/server/src/system/auth/schemas/portalUserTenantsSchema.js
@@ -37,6 +37,16 @@ const portalUserTenantsSchema = {
     ],
     indexes: [
       { type: 'Index', columns: ['portal_user_id', 'tenant_id'], unique: true, where: 'deactivated_at IS NULL' },
+      // Preserves the "exactly one active portal_user per tenant-scoped
+      // entity" invariant that previously lived on portal_users. NULL
+      // entity rows (bare registrations) are excluded so multiple of
+      // those can coexist for the same tenant.
+      {
+        type: 'Index',
+        columns: ['tenant_id', 'entity_type', 'entity_id'],
+        unique: true,
+        where: 'deactivated_at IS NULL AND entity_type IS NOT NULL',
+      },
       { type: 'Index', columns: ['portal_user_id'] },
       { type: 'Index', columns: ['tenant_id'] },
       { type: 'Index', columns: ['entity_type', 'entity_id'] },

--- a/apps/server/src/system/auth/schemas/portalUserTenantsSchema.js
+++ b/apps/server/src/system/auth/schemas/portalUserTenantsSchema.js
@@ -1,0 +1,47 @@
+/**
+ * @file Schema definition for admin.portal_user_tenants table
+ * @module auth/schemas/portalUserTenantsSchema
+ *
+ * Per-tenant binding for a portal_users identity. Employees and clients
+ * have exactly one active binding; vendor_contacts may have one binding
+ * per tenant they service. Carries the tenant-scoped entity link
+ * (entity_type, entity_id) and the binding's invite/active status.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+/** @type {import('pg-schemata').TableSchema} */
+const portalUserTenantsSchema = {
+  dbSchema: 'admin',
+  table: 'portal_user_tenants',
+  version: '1.0.0',
+  hasAuditFields: { enabled: true, userFields: { type: 'uuid', nullable: true, default: null } },
+  softDelete: true,
+  columns: [
+    { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
+    { name: 'portal_user_id', type: 'uuid', notNull: true, immutable: true },
+    { name: 'tenant_id', type: 'uuid', notNull: true, immutable: true },
+    { name: 'entity_type', type: 'varchar(16)', default: null },
+    { name: 'entity_id', type: 'uuid', default: null },
+    { name: 'status', type: 'varchar(20)', notNull: true, default: 'active' },
+  ],
+  constraints: {
+    primaryKey: ['id'],
+    foreignKeys: [
+      { columns: ['portal_user_id'], references: { table: 'portal_users', columns: ['id'], schema: 'admin' }, onDelete: 'CASCADE' },
+      { columns: ['tenant_id'], references: { table: 'tenants', columns: ['id'], schema: 'admin' }, onDelete: 'CASCADE' },
+    ],
+    checks: [
+      { type: 'Check', expression: "entity_type IS NULL OR entity_type IN ('employee','vendor_contact','client')" },
+      { type: 'Check', expression: "status IN ('active','invited','locked')" },
+    ],
+    indexes: [
+      { type: 'Index', columns: ['portal_user_id', 'tenant_id'], unique: true, where: 'deactivated_at IS NULL' },
+      { type: 'Index', columns: ['portal_user_id'] },
+      { type: 'Index', columns: ['tenant_id'] },
+      { type: 'Index', columns: ['entity_type', 'entity_id'] },
+    ],
+  },
+};
+
+export default portalUserTenantsSchema;

--- a/apps/server/src/system/auth/schemas/portalUsersSchema.js
+++ b/apps/server/src/system/auth/schemas/portalUsersSchema.js
@@ -2,11 +2,12 @@
  * @file Schema definition for admin.portal_users table
  * @module auth/schemas/portalUsersSchema
  *
- * portal_users is a pure identity/authentication table per PRD §3.2.2.
- * All personal information (name, phone, address) lives on the linked
- * entity record in the tenant schema. The link is polymorphic via
- * entity_type + entity_id. Roles are stored as a text[] on the entity
- * record — there is no role column here.
+ * portal_users is auth-only: identity (id), credentials (email,
+ * password_hash) and account-level status. Tenant linkage and the
+ * polymorphic entity link (entity_type, entity_id) live on the
+ * portal_user_tenants join table — see portalUserTenantsSchema.
+ *
+ * email is globally unique among active rows.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
@@ -20,29 +21,17 @@ const portalUsersSchema = {
   softDelete: true,
   columns: [
     { name: 'id', type: 'uuid', default: 'gen_random_uuid()', notNull: true, immutable: true },
-    { name: 'tenant_id', type: 'uuid', notNull: true, immutable: true },
-    { name: 'entity_type', type: 'varchar(16)', default: null },
-    { name: 'entity_id', type: 'uuid', default: null },
     { name: 'email', type: 'varchar(128)', notNull: true },
     { name: 'password_hash', type: 'text', notNull: true },
     { name: 'status', type: 'varchar(20)', notNull: true, default: 'active' },
   ],
   constraints: {
     primaryKey: ['id'],
-    foreignKeys: [
-      { columns: ['tenant_id'], references: { table: 'tenants', columns: ['id'], schema: 'admin' }, onDelete: 'CASCADE' },
-    ],
     checks: [
       { type: 'Check', expression: "status IN ('active','invited','locked')" },
-      {
-        type: 'Check',
-        expression: "entity_type IS NULL OR entity_type IN ('employee','vendor_contact','client')",
-      },
     ],
     indexes: [
       { type: 'Index', columns: ['email'], unique: true, where: 'deactivated_at IS NULL' },
-      { type: 'Index', columns: ['entity_type', 'entity_id'], unique: true, where: 'deactivated_at IS NULL' },
-      { type: 'Index', columns: ['tenant_id'] },
     ],
   },
 };

--- a/apps/server/src/system/auth/services/index.js
+++ b/apps/server/src/system/auth/services/index.js
@@ -1,0 +1,12 @@
+/**
+ * @file Barrel exports for the auth module's cross-boundary services
+ * @module auth/services/index
+ *
+ * Per ADR-0019, cross-module consumers (e.g. system/core controllers)
+ * must import auth services through this barrel rather than reaching
+ * into individual files.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+export { findActiveBinding, findAnyBinding, findActivePortalUserId } from './portalUserBindings.js';

--- a/apps/server/src/system/auth/services/passportService.js
+++ b/apps/server/src/system/auth/services/passportService.js
@@ -2,9 +2,11 @@
  * @file Passport.js Local Strategy — validates email/password against admin.portal_users
  * @module auth/services/passportService
  *
- * portal_users is a pure identity table per PRD §3.2.2. Tenant info is
- * resolved via join to admin.tenants. Personal info will come from the
- * linked entity once entity tables exist.
+ * portal_users is auth-only identity. Tenant linkage is resolved via
+ * admin.portal_user_tenants. The user's home tenant — used for the
+ * post-login active-tenant verification — is the earliest active
+ * binding (employees and clients have exactly one; vendor_contacts may
+ * have several and the x-tenant-code header overrides at request time).
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
@@ -34,8 +36,16 @@ passport.use(
       const isMatch = await bcrypt.compare(password, user.password_hash);
       if (!isMatch) return done(null, false, { message: 'Incorrect password.' });
 
-      // Verify tenant is active
-      const tenant = await db('tenants', 'admin').findById(user.tenant_id);
+      // Resolve home binding + tenant
+      const tenant = await db.oneOrNone(
+        `SELECT t.*
+         FROM admin.portal_user_tenants b
+         JOIN admin.tenants t ON t.id = b.tenant_id
+         WHERE b.portal_user_id = $1 AND b.deactivated_at IS NULL
+         ORDER BY b.created_at ASC
+         LIMIT 1`,
+        [user.id],
+      );
       if (!tenant || tenant.deactivated_at !== null) {
         return done(null, false, { message: 'Tenant is inactive.' });
       }

--- a/apps/server/src/system/auth/services/portalUserBindings.js
+++ b/apps/server/src/system/auth/services/portalUserBindings.js
@@ -1,0 +1,48 @@
+/**
+ * @file Helpers for resolving portal_user_tenants bindings from controllers
+ * @module auth/services/portalUserBindings
+ *
+ * Centralises the portal_users + portal_user_tenants joins used by entity
+ * provisioning and archive/restore flows so callers don't repeat the
+ * (entity_type, entity_id, tenant_id) lookup pattern.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import db from '../../../db/db.js';
+
+/**
+ * Find an active binding for the given entity in the given tenant.
+ * @returns {Promise<object|null>} { id, portal_user_id, entity_type, entity_id, tenant_id, status } or null
+ */
+export async function findActiveBinding(entityType, entityId, tenantId) {
+  return db.oneOrNone(
+    `SELECT id, portal_user_id, entity_type, entity_id, tenant_id, status
+     FROM admin.portal_user_tenants
+     WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3 AND deactivated_at IS NULL`,
+    [entityType, entityId, tenantId],
+  );
+}
+
+/**
+ * Find any binding (active or archived) for the given entity in the given tenant.
+ */
+export async function findAnyBinding(entityType, entityId, tenantId) {
+  return db.oneOrNone(
+    `SELECT id, portal_user_id, entity_type, entity_id, tenant_id, status, deactivated_at
+     FROM admin.portal_user_tenants
+     WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3
+     ORDER BY deactivated_at IS NULL DESC, created_at DESC
+     LIMIT 1`,
+    [entityType, entityId, tenantId],
+  );
+}
+
+/**
+ * Find the active portal_user_id for a given (entity_type, entity_id, tenant_id) binding.
+ * @returns {Promise<string|null>}
+ */
+export async function findActivePortalUserId(entityType, entityId, tenantId) {
+  const row = await findActiveBinding(entityType, entityId, tenantId);
+  return row?.portal_user_id || null;
+}

--- a/apps/server/src/system/core/controllers/clientsController.js
+++ b/apps/server/src/system/core/controllers/clientsController.js
@@ -15,7 +15,7 @@ import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import { allocateNumber } from '../services/numberingService.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
-import { findActiveBinding, findAnyBinding } from '../../auth/services/portalUserBindings.js';
+import { findActiveBinding, findAnyBinding } from '../../auth/services/index.js';
 import logger from '../../../lib/logger.js';
 
 class ClientsController extends BaseController {

--- a/apps/server/src/system/core/controllers/clientsController.js
+++ b/apps/server/src/system/core/controllers/clientsController.js
@@ -15,6 +15,7 @@ import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import { allocateNumber } from '../services/numberingService.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
+import { findActiveBinding, findAnyBinding } from '../../auth/services/portalUserBindings.js';
 import logger from '../../../lib/logger.js';
 
 class ClientsController extends BaseController {
@@ -174,13 +175,7 @@ class ClientsController extends BaseController {
 
       // Determine if provisioning is needed (fresh toggle or retry after partial failure)
       const needsProvisioning =
-        isNowAppUser &&
-        (!wasAppUser ||
-          !(await db.oneOrNone(
-            `SELECT id FROM admin.portal_users
-           WHERE entity_type = 'client' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-            [before.id, req.user?.tenant_id],
-          )));
+        isNowAppUser && (!wasAppUser || !(await findActiveBinding('client', before.id, req.user?.tenant_id)));
 
       if (needsProvisioning) {
         const roles = req.body.roles || before.roles || [];
@@ -328,14 +323,8 @@ class ClientsController extends BaseController {
     }
 
     try {
-      const tenantId = req.user?.tenant_id;
-      const portalUser = await db.oneOrNone(
-        `SELECT id FROM admin.portal_users
-         WHERE entity_type = 'client' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-        [clientId, tenantId],
-      );
-
-      if (!portalUser) {
+      const binding = await findActiveBinding('client', clientId, req.user?.tenant_id);
+      if (!binding) {
         return res.status(404).json({ error: 'No active app user account found for this client' });
       }
 
@@ -344,10 +333,10 @@ class ClientsController extends BaseController {
       await db.none('UPDATE admin.portal_users SET password_hash = $/hash/, updated_by = $/updatedBy/ WHERE id = $/id/', {
         hash,
         updatedBy: req.user?.id || null,
-        id: portalUser.id,
+        id: binding.portal_user_id,
       });
 
-      logger.info(`Admin reset password for portal_user ${portalUser.id} (client ${clientId})`);
+      logger.info(`Admin reset password for portal_user ${binding.portal_user_id} (client ${clientId})`);
       res.json({ message: 'Password reset successfully' });
     } catch (err) {
       this.handleError(err, res, 'resetting password for', this.errorLabel);
@@ -357,13 +346,13 @@ class ClientsController extends BaseController {
   /* ── Private helpers ──────────────────────────────────── */
 
   /**
-   * Create or restore a portal_users record for a client gaining app access.
+   * Create or restore a portal_users + portal_user_tenants binding for a
+   * client gaining app access. Both rows stay in sync.
    */
   async #provisionAppUser(client, req, suppliedPassword, loginEmail) {
     const tenantId = req.user?.tenant_id;
     if (!tenantId) throw new Error('Tenant context required to provision app user');
 
-    // Validate supplied password strength (if provided)
     if (suppliedPassword) {
       const pwRules = [
         { test: (p) => p.length >= 8, msg: 'at least 8 characters' },
@@ -380,83 +369,106 @@ class ClientsController extends BaseController {
       }
     }
 
-    // Check if an archived portal_user already exists for this client
-    const existing = await db.oneOrNone(
-      `SELECT id, deactivated_at FROM admin.portal_users
-       WHERE entity_type = 'client' AND entity_id = $1 AND tenant_id = $2`,
-      [client.id, tenantId],
-    );
-
     const clearPassword = suppliedPassword || crypto.randomBytes(12).toString('base64url');
     const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
     const passwordHash = await bcrypt.hash(clearPassword, rounds);
+    const updatedBy = req.user?.id || null;
 
-    if (existing) {
-      // Restore the archived record
-      await db.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NULL, status = 'invited',
-             password_hash = $1, email = $2, updated_by = $3
-         WHERE id = $4`,
-        [passwordHash, loginEmail, req.user?.id || null, existing.id],
-      );
-      logger.info(`Restored portal_user ${existing.id} for client ${client.id}`);
-      return existing.id;
+    const priorBinding = await findAnyBinding('client', client.id, tenantId);
+
+    if (priorBinding) {
+      await db.tx(async (t) => {
+        await t.none(
+          `UPDATE admin.portal_users
+           SET deactivated_at = NULL, status = 'invited',
+               password_hash = $1, email = $2, updated_by = $3
+           WHERE id = $4`,
+          [passwordHash, loginEmail, updatedBy, priorBinding.portal_user_id],
+        );
+        await t.none(
+          `UPDATE admin.portal_user_tenants
+           SET deactivated_at = NULL, status = 'active', updated_by = $1
+           WHERE id = $2`,
+          [updatedBy, priorBinding.id],
+        );
+      });
+      logger.info(`Restored portal_user ${priorBinding.portal_user_id} + binding for client ${client.id}`);
+      return priorBinding.portal_user_id;
     }
 
-    // Create a new portal_users record
-    const user = await db('portalUsers', 'admin').insert({
-      tenant_id: tenantId,
-      entity_type: 'client',
-      entity_id: client.id,
-      email: loginEmail,
-      password_hash: passwordHash,
-      status: 'invited',
-      created_by: req.user?.id || null,
+    const portalUserId = await db.tx(async (t) => {
+      const user = await t.one(
+        `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
+         VALUES ($1, $2, 'invited', $3)
+         RETURNING id`,
+        [loginEmail, passwordHash, updatedBy],
+      );
+      await t.none(
+        `INSERT INTO admin.portal_user_tenants
+           (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+         VALUES ($1, $2, 'client', $3, 'active', $4)`,
+        [user.id, tenantId, client.id, updatedBy],
+      );
+      return user.id;
     });
 
-    logger.info(`Provisioned portal_user ${user.id} for client ${client.id}`);
-    return user.id;
+    logger.info(`Provisioned portal_user ${portalUserId} + binding for client ${client.id}`);
+    return portalUserId;
   }
 
   /**
-   * Archive (soft-delete) the portal_users record linked to a client.
+   * Archive (soft-delete) the portal_users + binding linked to a client.
    */
   async #archiveAppUser(clientId, req) {
-    const portalUser = await db.oneOrNone(
-      `SELECT id FROM admin.portal_users
-       WHERE entity_type = 'client' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-      [clientId, req.user?.tenant_id],
-    );
-    if (portalUser) {
-      await db.none(
+    const binding = await findActiveBinding('client', clientId, req.user?.tenant_id);
+    if (!binding) return;
+
+    const updatedBy = req.user?.id || null;
+    await db.tx(async (t) => {
+      await t.none(
+        `UPDATE admin.portal_user_tenants
+         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+         WHERE id = $2`,
+        [updatedBy, binding.id],
+      );
+      await t.none(
         `UPDATE admin.portal_users
          SET deactivated_at = NOW(), status = 'locked', updated_by = $1
          WHERE id = $2`,
-        [req.user?.id || null, portalUser.id],
+        [updatedBy, binding.portal_user_id],
       );
-      logger.info(`Archived portal_user ${portalUser.id} for client ${clientId}`);
-    }
+    });
+    logger.info(`Archived portal_user ${binding.portal_user_id} + binding for client ${clientId}`);
   }
 
   /**
-   * Restore the portal_users record linked to a client.
+   * Restore the portal_users + binding linked to a client.
    */
   async #restoreAppUser(clientId, req) {
-    const portalUser = await db.oneOrNone(
-      `SELECT id FROM admin.portal_users
-       WHERE entity_type = 'client' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NOT NULL`,
+    const binding = await db.oneOrNone(
+      `SELECT id, portal_user_id FROM admin.portal_user_tenants
+       WHERE entity_type = 'client' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NOT NULL
+       ORDER BY deactivated_at DESC LIMIT 1`,
       [clientId, req.user?.tenant_id],
     );
-    if (portalUser) {
-      await db.none(
+    if (!binding) return;
+
+    const updatedBy = req.user?.id || null;
+    await db.tx(async (t) => {
+      await t.none(
         `UPDATE admin.portal_users
          SET deactivated_at = NULL, status = 'active', updated_by = $1
          WHERE id = $2`,
-        [req.user?.id || null, portalUser.id],
+        [updatedBy, binding.portal_user_id],
       );
-      logger.info(`Restored portal_user ${portalUser.id} for client ${clientId}`);
-    }
+      await t.none(
+        `UPDATE admin.portal_user_tenants
+         SET deactivated_at = NULL, status = 'active', updated_by = $1
+         WHERE id = $2`,
+        [updatedBy, binding.id],
+      );
+    });
+    logger.info(`Restored portal_user ${binding.portal_user_id} + binding for client ${clientId}`);
   }
 }
 

--- a/apps/server/src/system/core/controllers/emailsController.js
+++ b/apps/server/src/system/core/controllers/emailsController.js
@@ -143,6 +143,8 @@ class EmailsController extends BaseController {
 
   /**
    * Sync the login email to admin.portal_users for the entity linked to this source.
+   * Resolves the portal_users.id via the portal_user_tenants binding for
+   * the (entity_type, entity_id) pair in the request's tenant.
    */
   async #syncLoginEmail(schema, sourceId, email, req) {
     const s = pgp.as.name(schema);
@@ -154,10 +156,20 @@ class EmailsController extends BaseController {
       if (!source) return;
       if (!ENTITY_TABLE_BY_SOURCE_TYPE[source.source_type]) return;
 
+      const tenantId = req.user?.tenant_id;
+      if (!tenantId) return;
+
+      const binding = await db.oneOrNone(
+        `SELECT portal_user_id FROM admin.portal_user_tenants
+         WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3 AND deactivated_at IS NULL`,
+        [source.source_type, source.table_id, tenantId],
+      );
+      if (!binding) return;
+
       await db.none(
         `UPDATE admin.portal_users SET email = $1, updated_by = $2
-         WHERE entity_type = $3 AND entity_id = $4 AND deactivated_at IS NULL`,
-        [email, req.user?.id || null, source.source_type, source.table_id],
+         WHERE id = $3 AND deactivated_at IS NULL`,
+        [email, req.user?.id || null, binding.portal_user_id],
       );
     } catch (err) {
       logger.error('Failed to sync login email to portal_users', { sourceId, email, error: err.message });

--- a/apps/server/src/system/core/controllers/employeesController.js
+++ b/apps/server/src/system/core/controllers/employeesController.js
@@ -15,7 +15,7 @@ import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import { allocateNumber } from '../services/numberingService.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
-import { findActiveBinding, findAnyBinding } from '../../auth/services/portalUserBindings.js';
+import { findActiveBinding, findAnyBinding } from '../../auth/services/index.js';
 import logger from '../../../lib/logger.js';
 
 class EmployeesController extends BaseController {

--- a/apps/server/src/system/core/controllers/employeesController.js
+++ b/apps/server/src/system/core/controllers/employeesController.js
@@ -15,6 +15,7 @@ import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import { allocateNumber } from '../services/numberingService.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
+import { findActiveBinding, findAnyBinding } from '../../auth/services/portalUserBindings.js';
 import logger from '../../../lib/logger.js';
 
 class EmployeesController extends BaseController {
@@ -175,13 +176,7 @@ class EmployeesController extends BaseController {
 
       // Determine if provisioning is needed (fresh toggle or retry after partial failure)
       const needsProvisioning =
-        isNowAppUser &&
-        (!wasAppUser ||
-          !(await db.oneOrNone(
-            `SELECT id FROM admin.portal_users
-           WHERE entity_type = 'employee' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-            [before.id, req.user?.tenant_id],
-          )));
+        isNowAppUser && (!wasAppUser || !(await findActiveBinding('employee', before.id, req.user?.tenant_id)));
 
       if (needsProvisioning) {
         const roles = req.body.roles || before.roles || [];
@@ -332,14 +327,8 @@ class EmployeesController extends BaseController {
     }
 
     try {
-      const tenantId = req.user?.tenant_id;
-      const portalUser = await db.oneOrNone(
-        `SELECT id FROM admin.portal_users
-         WHERE entity_type = 'employee' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-        [employeeId, tenantId],
-      );
-
-      if (!portalUser) {
+      const binding = await findActiveBinding('employee', employeeId, req.user?.tenant_id);
+      if (!binding) {
         return res.status(404).json({ error: 'No active app user account found for this employee' });
       }
 
@@ -348,10 +337,10 @@ class EmployeesController extends BaseController {
       await db.none('UPDATE admin.portal_users SET password_hash = $/hash/, updated_by = $/updatedBy/ WHERE id = $/id/', {
         hash,
         updatedBy: req.user?.id || null,
-        id: portalUser.id,
+        id: binding.portal_user_id,
       });
 
-      logger.info(`Admin reset password for portal_user ${portalUser.id} (employee ${employeeId})`);
+      logger.info(`Admin reset password for portal_user ${binding.portal_user_id} (employee ${employeeId})`);
       res.json({ message: 'Password reset successfully' });
     } catch (err) {
       this.handleError(err, res, 'resetting password for', this.errorLabel);
@@ -381,10 +370,9 @@ class EmployeesController extends BaseController {
   /* ── Private helpers ──────────────────────────────────── */
 
   /**
-   * Create or restore a portal_users record for an employee gaining app access.
-   *
-   * portal_users is a pure identity table: tenant_id, entity_type, entity_id,
-   * email, password_hash, status. No role/full_name columns.
+   * Create or restore a portal_users + portal_user_tenants binding for an
+   * employee gaining app access. Both rows are kept in sync — archived
+   * bindings restore alongside their portal_users row.
    */
   async #provisionAppUser(employee, req, suppliedPassword, loginEmail) {
     const tenantId = req.user?.tenant_id;
@@ -407,83 +395,109 @@ class EmployeesController extends BaseController {
       }
     }
 
-    // Check if an archived portal_user already exists for this employee
-    const existing = await db.oneOrNone(
-      `SELECT id, deactivated_at FROM admin.portal_users
-       WHERE entity_type = 'employee' AND entity_id = $1 AND tenant_id = $2`,
-      [employee.id, tenantId],
-    );
-
     const clearPassword = suppliedPassword || crypto.randomBytes(12).toString('base64url');
     const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
     const passwordHash = await bcrypt.hash(clearPassword, rounds);
+    const updatedBy = req.user?.id || null;
 
-    if (existing) {
-      // Restore the archived record
-      await db.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NULL, status = 'invited',
-             password_hash = $1, email = $2, updated_by = $3
-         WHERE id = $4`,
-        [passwordHash, loginEmail, req.user?.id || null, existing.id],
-      );
-      logger.info(`Restored portal_user ${existing.id} for employee ${employee.id}`);
-      return existing.id;
+    // Look for any prior binding for this employee in this tenant (active or archived)
+    const priorBinding = await findAnyBinding('employee', employee.id, tenantId);
+
+    if (priorBinding) {
+      // Restore both portal_users and the binding to keep them in sync
+      await db.tx(async (t) => {
+        await t.none(
+          `UPDATE admin.portal_users
+           SET deactivated_at = NULL, status = 'invited',
+               password_hash = $1, email = $2, updated_by = $3
+           WHERE id = $4`,
+          [passwordHash, loginEmail, updatedBy, priorBinding.portal_user_id],
+        );
+        await t.none(
+          `UPDATE admin.portal_user_tenants
+           SET deactivated_at = NULL, status = 'active', updated_by = $1
+           WHERE id = $2`,
+          [updatedBy, priorBinding.id],
+        );
+      });
+      logger.info(`Restored portal_user ${priorBinding.portal_user_id} + binding for employee ${employee.id}`);
+      return priorBinding.portal_user_id;
     }
 
-    // Create a new portal_users record
-    const user = await db('portalUsers', 'admin').insert({
-      tenant_id: tenantId,
-      entity_type: 'employee',
-      entity_id: employee.id,
-      email: loginEmail,
-      password_hash: passwordHash,
-      status: 'invited',
-      created_by: req.user?.id || null,
+    // Create a new portal_users + binding pair
+    const portalUserId = await db.tx(async (t) => {
+      const user = await t.one(
+        `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
+         VALUES ($1, $2, 'invited', $3)
+         RETURNING id`,
+        [loginEmail, passwordHash, updatedBy],
+      );
+      await t.none(
+        `INSERT INTO admin.portal_user_tenants
+           (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+         VALUES ($1, $2, 'employee', $3, 'active', $4)`,
+        [user.id, tenantId, employee.id, updatedBy],
+      );
+      return user.id;
     });
 
-    logger.info(`Provisioned portal_user ${user.id} for employee ${employee.id}`);
-    return user.id;
+    logger.info(`Provisioned portal_user ${portalUserId} + binding for employee ${employee.id}`);
+    return portalUserId;
   }
 
   /**
-   * Archive (soft-delete) the portal_users record linked to an employee.
+   * Archive (soft-delete) the portal_users + binding linked to an employee.
    */
   async #archiveAppUser(employeeId, req) {
-    const portalUser = await db.oneOrNone(
-      `SELECT id FROM admin.portal_users
-       WHERE entity_type = 'employee' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-      [employeeId, req.user?.tenant_id],
-    );
-    if (portalUser) {
-      await db.none(
+    const binding = await findActiveBinding('employee', employeeId, req.user?.tenant_id);
+    if (!binding) return;
+
+    const updatedBy = req.user?.id || null;
+    await db.tx(async (t) => {
+      await t.none(
+        `UPDATE admin.portal_user_tenants
+         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+         WHERE id = $2`,
+        [updatedBy, binding.id],
+      );
+      await t.none(
         `UPDATE admin.portal_users
          SET deactivated_at = NOW(), status = 'locked', updated_by = $1
          WHERE id = $2`,
-        [req.user?.id || null, portalUser.id],
+        [updatedBy, binding.portal_user_id],
       );
-      logger.info(`Archived portal_user ${portalUser.id} for employee ${employeeId}`);
-    }
+    });
+    logger.info(`Archived portal_user ${binding.portal_user_id} + binding for employee ${employeeId}`);
   }
 
   /**
-   * Restore the portal_users record linked to an employee.
+   * Restore the portal_users + binding linked to an employee.
    */
   async #restoreAppUser(employeeId, req) {
-    const portalUser = await db.oneOrNone(
-      `SELECT id FROM admin.portal_users
-       WHERE entity_type = 'employee' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NOT NULL`,
+    const binding = await db.oneOrNone(
+      `SELECT id, portal_user_id FROM admin.portal_user_tenants
+       WHERE entity_type = 'employee' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NOT NULL
+       ORDER BY deactivated_at DESC LIMIT 1`,
       [employeeId, req.user?.tenant_id],
     );
-    if (portalUser) {
-      await db.none(
+    if (!binding) return;
+
+    const updatedBy = req.user?.id || null;
+    await db.tx(async (t) => {
+      await t.none(
         `UPDATE admin.portal_users
          SET deactivated_at = NULL, status = 'active', updated_by = $1
          WHERE id = $2`,
-        [req.user?.id || null, portalUser.id],
+        [updatedBy, binding.portal_user_id],
       );
-      logger.info(`Restored portal_user ${portalUser.id} for employee ${employeeId}`);
-    }
+      await t.none(
+        `UPDATE admin.portal_user_tenants
+         SET deactivated_at = NULL, status = 'active', updated_by = $1
+         WHERE id = $2`,
+        [updatedBy, binding.id],
+      );
+    });
+    logger.info(`Restored portal_user ${binding.portal_user_id} + binding for employee ${employeeId}`);
   }
 }
 

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -17,7 +17,7 @@ import crypto from 'node:crypto';
 import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
-import { findActiveBinding, findAnyBinding } from '../../auth/services/portalUserBindings.js';
+import { findActiveBinding, findAnyBinding } from '../../auth/services/index.js';
 import logger from '../../../lib/logger.js';
 
 class VendorContactsController extends BaseController {

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -17,6 +17,7 @@ import crypto from 'node:crypto';
 import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
+import { findActiveBinding, findAnyBinding } from '../../auth/services/portalUserBindings.js';
 import logger from '../../../lib/logger.js';
 
 class VendorContactsController extends BaseController {
@@ -160,13 +161,7 @@ class VendorContactsController extends BaseController {
 
       // Determine if provisioning is needed (fresh toggle or retry after partial failure)
       const needsProvisioning =
-        isNowAppUser &&
-        (!wasAppUser ||
-          !(await db.oneOrNone(
-            `SELECT id FROM admin.portal_users
-           WHERE entity_type = 'vendor_contact' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-            [before.id, req.user?.tenant_id],
-          )));
+        isNowAppUser && (!wasAppUser || !(await findActiveBinding('vendor_contact', before.id, req.user?.tenant_id)));
 
       if (needsProvisioning) {
         const roles = req.body.roles || before.roles || [];
@@ -314,14 +309,8 @@ class VendorContactsController extends BaseController {
     }
 
     try {
-      const tenantId = req.user?.tenant_id;
-      const portalUser = await db.oneOrNone(
-        `SELECT id FROM admin.portal_users
-         WHERE entity_type = 'vendor_contact' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-        [contactId, tenantId],
-      );
-
-      if (!portalUser) {
+      const binding = await findActiveBinding('vendor_contact', contactId, req.user?.tenant_id);
+      if (!binding) {
         return res.status(404).json({ error: 'No active app user account found for this vendor contact' });
       }
 
@@ -330,10 +319,10 @@ class VendorContactsController extends BaseController {
       await db.none('UPDATE admin.portal_users SET password_hash = $/hash/, updated_by = $/updatedBy/ WHERE id = $/id/', {
         hash,
         updatedBy: req.user?.id || null,
-        id: portalUser.id,
+        id: binding.portal_user_id,
       });
 
-      logger.info(`Admin reset password for portal_user ${portalUser.id} (vendor_contact ${contactId})`);
+      logger.info(`Admin reset password for portal_user ${binding.portal_user_id} (vendor_contact ${contactId})`);
       res.json({ message: 'Password reset successfully' });
     } catch (err) {
       this.handleError(err, res, 'resetting password for', this.errorLabel);
@@ -343,13 +332,15 @@ class VendorContactsController extends BaseController {
   /* ── Private helpers ──────────────────────────────────── */
 
   /**
-   * Create or restore a portal_users record for a vendor contact gaining app access.
+   * Create or restore a portal_users + portal_user_tenants binding for a
+   * vendor_contact gaining app access. Vendors may end up with multiple
+   * bindings across tenants (Task 6 handles existing-email match → bind);
+   * here we just manage the per-tenant binding pair.
    */
   async #provisionAppUser(vendorContact, req, suppliedPassword, loginEmail) {
     const tenantId = req.user?.tenant_id;
     if (!tenantId) throw new Error('Tenant context required to provision app user');
 
-    // Validate supplied password strength (if provided)
     if (suppliedPassword) {
       const pwRules = [
         { test: (p) => p.length >= 8, msg: 'at least 8 characters' },
@@ -366,83 +357,106 @@ class VendorContactsController extends BaseController {
       }
     }
 
-    // Check if an archived portal_user already exists for this vendor contact
-    const existing = await db.oneOrNone(
-      `SELECT id, deactivated_at FROM admin.portal_users
-       WHERE entity_type = 'vendor_contact' AND entity_id = $1 AND tenant_id = $2`,
-      [vendorContact.id, tenantId],
-    );
-
     const clearPassword = suppliedPassword || crypto.randomBytes(12).toString('base64url');
     const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
     const passwordHash = await bcrypt.hash(clearPassword, rounds);
+    const updatedBy = req.user?.id || null;
 
-    if (existing) {
-      // Restore the archived record
-      await db.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NULL, status = 'invited',
-             password_hash = $1, email = $2, updated_by = $3
-         WHERE id = $4`,
-        [passwordHash, loginEmail, req.user?.id || null, existing.id],
-      );
-      logger.info(`Restored portal_user ${existing.id} for vendor_contact ${vendorContact.id}`);
-      return existing.id;
+    const priorBinding = await findAnyBinding('vendor_contact', vendorContact.id, tenantId);
+
+    if (priorBinding) {
+      await db.tx(async (t) => {
+        await t.none(
+          `UPDATE admin.portal_users
+           SET deactivated_at = NULL, status = 'invited',
+               password_hash = $1, email = $2, updated_by = $3
+           WHERE id = $4`,
+          [passwordHash, loginEmail, updatedBy, priorBinding.portal_user_id],
+        );
+        await t.none(
+          `UPDATE admin.portal_user_tenants
+           SET deactivated_at = NULL, status = 'active', updated_by = $1
+           WHERE id = $2`,
+          [updatedBy, priorBinding.id],
+        );
+      });
+      logger.info(`Restored portal_user ${priorBinding.portal_user_id} + binding for vendor_contact ${vendorContact.id}`);
+      return priorBinding.portal_user_id;
     }
 
-    // Create a new portal_users record
-    const user = await db('portalUsers', 'admin').insert({
-      tenant_id: tenantId,
-      entity_type: 'vendor_contact',
-      entity_id: vendorContact.id,
-      email: loginEmail,
-      password_hash: passwordHash,
-      status: 'invited',
-      created_by: req.user?.id || null,
+    const portalUserId = await db.tx(async (t) => {
+      const user = await t.one(
+        `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
+         VALUES ($1, $2, 'invited', $3)
+         RETURNING id`,
+        [loginEmail, passwordHash, updatedBy],
+      );
+      await t.none(
+        `INSERT INTO admin.portal_user_tenants
+           (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+         VALUES ($1, $2, 'vendor_contact', $3, 'active', $4)`,
+        [user.id, tenantId, vendorContact.id, updatedBy],
+      );
+      return user.id;
     });
 
-    logger.info(`Provisioned portal_user ${user.id} for vendor_contact ${vendorContact.id}`);
-    return user.id;
+    logger.info(`Provisioned portal_user ${portalUserId} + binding for vendor_contact ${vendorContact.id}`);
+    return portalUserId;
   }
 
   /**
-   * Archive (soft-delete) the portal_users record linked to a vendor contact.
+   * Archive (soft-delete) the portal_users + binding linked to a vendor contact.
    */
   async #archiveAppUser(vendorContactId, req) {
-    const portalUser = await db.oneOrNone(
-      `SELECT id FROM admin.portal_users
-       WHERE entity_type = 'vendor_contact' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-      [vendorContactId, req.user?.tenant_id],
-    );
-    if (portalUser) {
-      await db.none(
+    const binding = await findActiveBinding('vendor_contact', vendorContactId, req.user?.tenant_id);
+    if (!binding) return;
+
+    const updatedBy = req.user?.id || null;
+    await db.tx(async (t) => {
+      await t.none(
+        `UPDATE admin.portal_user_tenants
+         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+         WHERE id = $2`,
+        [updatedBy, binding.id],
+      );
+      await t.none(
         `UPDATE admin.portal_users
          SET deactivated_at = NOW(), status = 'locked', updated_by = $1
          WHERE id = $2`,
-        [req.user?.id || null, portalUser.id],
+        [updatedBy, binding.portal_user_id],
       );
-      logger.info(`Archived portal_user ${portalUser.id} for vendor_contact ${vendorContactId}`);
-    }
+    });
+    logger.info(`Archived portal_user ${binding.portal_user_id} + binding for vendor_contact ${vendorContactId}`);
   }
 
   /**
-   * Restore the portal_users record linked to a vendor contact.
+   * Restore the portal_users + binding linked to a vendor contact.
    */
   async #restoreAppUser(vendorContactId, req) {
-    const portalUser = await db.oneOrNone(
-      `SELECT id FROM admin.portal_users
-       WHERE entity_type = 'vendor_contact' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NOT NULL`,
+    const binding = await db.oneOrNone(
+      `SELECT id, portal_user_id FROM admin.portal_user_tenants
+       WHERE entity_type = 'vendor_contact' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NOT NULL
+       ORDER BY deactivated_at DESC LIMIT 1`,
       [vendorContactId, req.user?.tenant_id],
     );
-    if (portalUser) {
-      await db.none(
+    if (!binding) return;
+
+    const updatedBy = req.user?.id || null;
+    await db.tx(async (t) => {
+      await t.none(
         `UPDATE admin.portal_users
          SET deactivated_at = NULL, status = 'active', updated_by = $1
          WHERE id = $2`,
-        [req.user?.id || null, portalUser.id],
+        [updatedBy, binding.portal_user_id],
       );
-      logger.info(`Restored portal_user ${portalUser.id} for vendor_contact ${vendorContactId}`);
-    }
+      await t.none(
+        `UPDATE admin.portal_user_tenants
+         SET deactivated_at = NULL, status = 'active', updated_by = $1
+         WHERE id = $2`,
+        [updatedBy, binding.id],
+      );
+    });
+    logger.info(`Restored portal_user ${binding.portal_user_id} + binding for vendor_contact ${vendorContactId}`);
   }
 }
 

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -1103,24 +1103,26 @@ export default class Vendors extends TableModel {
 
           if (toProvision.length) {
             const hashMap = await batchHashPasswords(toProvision.map((p) => ({ index: p.index, password: p.clearPassword })));
+            const entityType = CONTACT_CONFIG.appUserProvisioning.entityType;
 
-            const portalUsersModel = db('portalUsers', 'admin');
-            portalUsersModel.tx = t;
             for (const { index, email } of toProvision) {
               const existing = await t.oneOrNone(
                 'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
                 [email],
               );
               if (existing) continue;
-              await portalUsersModel.insert({
-                tenant_id: tid,
-                entity_type: CONTACT_CONFIG.appUserProvisioning.entityType,
-                entity_id: insertResults[index].id,
-                email,
-                password_hash: hashMap.get(index),
-                status: 'invited',
-                created_by: createdBy,
-              });
+              const inserted = await t.one(
+                `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
+                 VALUES ($1, $2, 'invited', $3)
+                 RETURNING id`,
+                [email, hashMap.get(index), createdBy],
+              );
+              await t.none(
+                `INSERT INTO admin.portal_user_tenants
+                   (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+                 VALUES ($1, $2, $3, $4, 'active', $5)`,
+                [inserted.id, tid, entityType, insertResults[index].id, createdBy],
+              );
             }
           }
         }

--- a/apps/server/src/system/tenants/controllers/adminController.js
+++ b/apps/server/src/system/tenants/controllers/adminController.js
@@ -27,13 +27,18 @@ export async function getAllSchemas(req, res) {
 
 /**
  * POST /impersonate — start impersonating a target user
- * Body: { target_user_id, reason? }
+ * Body: { target_user_id, target_tenant_id?, target_tenant_code?, reason? }
+ *
+ * For multi-binding users (vendor_contacts) the caller should pass
+ * target_tenant_id or target_tenant_code so the session opens in the
+ * tenant the admin selected from the picker. Without it we fall back
+ * to the target's earliest active binding.
  */
 export async function startImpersonation(req, res) {
   const impersonatorId = req.user?.id;
   if (!impersonatorId) return res.status(401).json({ error: 'Unauthorized' });
 
-  const { target_user_id, reason } = req.body || {};
+  const { target_user_id, target_tenant_id, target_tenant_code, reason } = req.body || {};
   if (!target_user_id) return res.status(400).json({ error: 'target_user_id required' });
 
   try {
@@ -41,17 +46,30 @@ export async function startImpersonation(req, res) {
     const targetUser = await db('portalUsers', 'admin').findOneBy([{ id: target_user_id }]);
     if (!targetUser) return res.status(404).json({ error: 'Target user not found' });
 
-    // Resolve the target's earliest active binding for tenant/entity context.
+    // Resolve the target's binding. Prefer the requested tenant when one
+    // was supplied; otherwise fall back to the earliest active binding.
+    const requestedTenantCode = target_tenant_code ? target_tenant_code.toLowerCase() : null;
     const targetBinding = await db.oneOrNone(
       `SELECT b.tenant_id, b.entity_type, b.entity_id, t.tenant_code, t.schema_name
        FROM admin.portal_user_tenants b
        JOIN admin.tenants t ON t.id = b.tenant_id
        WHERE b.portal_user_id = $1 AND b.deactivated_at IS NULL
-       ORDER BY b.created_at ASC
+       ORDER BY
+         ($2::uuid IS NOT NULL AND b.tenant_id = $2) DESC,
+         ($3::text IS NOT NULL AND LOWER(t.tenant_code) = $3) DESC,
+         b.created_at ASC
        LIMIT 1`,
-      [targetUser.id],
+      [targetUser.id, target_tenant_id || null, requestedTenantCode],
     );
     if (!targetBinding) return res.status(400).json({ error: 'Target user has no active tenant binding' });
+
+    // If the caller specified a tenant, refuse if the target has no binding for it
+    if (target_tenant_id && targetBinding.tenant_id !== target_tenant_id) {
+      return res.status(400).json({ error: 'Target user has no active binding for the requested tenant' });
+    }
+    if (requestedTenantCode && targetBinding.tenant_code.toLowerCase() !== requestedTenantCode) {
+      return res.status(400).json({ error: 'Target user has no active binding for the requested tenant' });
+    }
 
     // Check no active session exists for this impersonator
     const redis = await getRedis();

--- a/apps/server/src/system/tenants/controllers/adminController.js
+++ b/apps/server/src/system/tenants/controllers/adminController.js
@@ -41,8 +41,17 @@ export async function startImpersonation(req, res) {
     const targetUser = await db('portalUsers', 'admin').findOneBy([{ id: target_user_id }]);
     if (!targetUser) return res.status(404).json({ error: 'Target user not found' });
 
-    // Look up target user's tenant for schema_name
-    const targetTenant = await db('tenants', 'admin').findById(targetUser.tenant_id);
+    // Resolve the target's earliest active binding for tenant/entity context.
+    const targetBinding = await db.oneOrNone(
+      `SELECT b.tenant_id, b.entity_type, b.entity_id, t.tenant_code, t.schema_name
+       FROM admin.portal_user_tenants b
+       JOIN admin.tenants t ON t.id = b.tenant_id
+       WHERE b.portal_user_id = $1 AND b.deactivated_at IS NULL
+       ORDER BY b.created_at ASC
+       LIMIT 1`,
+      [targetUser.id],
+    );
+    if (!targetBinding) return res.status(400).json({ error: 'Target user has no active tenant binding' });
 
     // Check no active session exists for this impersonator
     const redis = await getRedis();
@@ -55,7 +64,7 @@ export async function startImpersonation(req, res) {
     const log = await db('impersonationLogs', 'admin').insert({
       impersonator_id: impersonatorId,
       target_user_id,
-      target_tenant_code: targetTenant?.tenant_code || null,
+      target_tenant_code: targetBinding.tenant_code || null,
       reason: reason || null,
       created_by: impersonatorId,
     });
@@ -64,15 +73,15 @@ export async function startImpersonation(req, res) {
     const impData = {
       logId: log.id,
       targetUserId: targetUser.id,
-      targetTenantCode: targetTenant?.tenant_code?.toLowerCase(),
-      targetSchemaName: targetTenant?.schema_name,
+      targetTenantCode: targetBinding.tenant_code?.toLowerCase(),
+      targetSchemaName: targetBinding.schema_name,
       targetUser: {
         id: targetUser.id,
         email: targetUser.email,
         status: targetUser.status,
-        tenant_id: targetUser.tenant_id,
-        entity_type: targetUser.entity_type,
-        entity_id: targetUser.entity_id,
+        tenant_id: targetBinding.tenant_id,
+        entity_type: targetBinding.entity_type,
+        entity_id: targetBinding.entity_id,
       },
     };
     await redis.set(`imp:${impersonatorId}`, JSON.stringify(impData));

--- a/apps/server/src/system/tenants/controllers/portalUsersController.js
+++ b/apps/server/src/system/tenants/controllers/portalUsersController.js
@@ -50,6 +50,57 @@ class PortalUsersController extends BaseController {
   }
 
   /**
+   * Hydrate users with their primary active binding so list views can
+   * keep showing entity_type / entity_id / tenant_id. For users with
+   * multiple bindings (vendor_contacts) the earliest active binding
+   * wins — matches the home-binding choice authRedis makes.
+   */
+  async #hydrateBindings(records) {
+    const list = Array.isArray(records) ? records : records?.rows;
+    if (!list || !list.length) return records;
+
+    const ids = list.map((r) => r.id).filter(Boolean);
+    if (!ids.length) return records;
+
+    const bindings = await db.any(
+      `SELECT DISTINCT ON (portal_user_id)
+         portal_user_id, tenant_id, entity_type, entity_id, status AS binding_status
+       FROM admin.portal_user_tenants
+       WHERE portal_user_id = ANY($1::uuid[]) AND deactivated_at IS NULL
+       ORDER BY portal_user_id, created_at ASC`,
+      [ids],
+    );
+    const byUser = new Map(bindings.map((b) => [b.portal_user_id, b]));
+
+    const decorate = (row) => {
+      const b = byUser.get(row.id);
+      if (!b) return { ...row, tenant_id: null, entity_type: null, entity_id: null };
+      return { ...row, tenant_id: b.tenant_id, entity_type: b.entity_type, entity_id: b.entity_id };
+    };
+
+    if (Array.isArray(records)) return records.map(decorate);
+    if (records?.rows) return { ...records, rows: records.rows.map(decorate) };
+    return records;
+  }
+
+  async #hydrateOne(record) {
+    if (!record?.id) return record;
+    const binding = await db.oneOrNone(
+      `SELECT tenant_id, entity_type, entity_id FROM admin.portal_user_tenants
+       WHERE portal_user_id = $1 AND deactivated_at IS NULL
+       ORDER BY created_at ASC
+       LIMIT 1`,
+      [record.id],
+    );
+    return {
+      ...record,
+      tenant_id: binding?.tenant_id ?? null,
+      entity_type: binding?.entity_type ?? null,
+      entity_id: binding?.entity_id ?? null,
+    };
+  }
+
+  /**
    * POST /register — register a new user with password hashing.
    *
    * Body: { tenant_code, email, password }
@@ -111,33 +162,41 @@ class PortalUsersController extends BaseController {
   };
 
   /**
-   * Override GET / to strip password_hash from results
+   * Override GET / to strip password_hash from results and hydrate the
+   * primary active binding (entity_type / entity_id / tenant_id).
    */
   async get(req, res) {
     const origJson = res.json.bind(res);
-    res.json = (data) => origJson(this.#stripPasswords(data));
+    res.json = async (data) => {
+      const hydrated = await this.#hydrateBindings(data);
+      return origJson(this.#stripPasswords(hydrated));
+    };
     return super.get(req, res);
   }
 
   /**
-   * GET /:id — fetch user record, strip password_hash
+   * GET /:id — fetch user record, strip password_hash, hydrate binding.
    */
   async getById(req, res) {
     try {
       const record = await this.model('admin').findById(req.params.id);
       if (!record) return res.status(404).json({ error: `${this.errorLabel} not found` });
-      res.json(this.#stripPassword(record));
+      const hydrated = await this.#hydrateOne(record);
+      res.json(this.#stripPassword(hydrated));
     } catch (err) {
       this.handleError(err, res, 'fetching', this.errorLabel);
     }
   }
 
   /**
-   * Override GET /where to strip password_hash from results
+   * Override GET /where to strip password_hash and hydrate binding.
    */
   async getWhere(req, res) {
     const origJson = res.json.bind(res);
-    res.json = (data) => origJson(this.#stripPasswords(data));
+    res.json = async (data) => {
+      const hydrated = await this.#hydrateBindings(data);
+      return origJson(this.#stripPasswords(hydrated));
+    };
     return super.getWhere(req, res);
   }
 

--- a/apps/server/src/system/tenants/controllers/portalUsersController.js
+++ b/apps/server/src/system/tenants/controllers/portalUsersController.js
@@ -2,9 +2,10 @@
  * @file PortalUsersController — user CRUD with registration, safe archive/restore
  * @module tenants/controllers/portalUsersController
  *
- * portal_users is a pure identity table (id, tenant_id, entity_type, entity_id,
- * email, password_hash, status). No role, user_name, full_name, or tenant_code
- * columns — those live on entity records (Phase 5).
+ * portal_users is auth-only (id, email, password_hash, status). Tenant
+ * linkage and the polymorphic entity link live on the
+ * portal_user_tenants join table; archive/restore cascades resolve the
+ * binding(s) for the affected user.
  *
  * Overrides:
  *   register → validates tenant active, bcrypt hashes password, creates portal_user
@@ -73,13 +74,25 @@ class PortalUsersController extends BaseController {
       const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
       const password_hash = await bcrypt.hash(password, rounds);
 
-      // Create user record (pure identity table)
-      const user = await db('portalUsers', 'admin').insert({
-        tenant_id: tenant.id,
-        email,
-        password_hash,
-        status: 'active',
-        created_by: req.user?.id || null,
+      // Create the auth-only portal_users row + a tenant binding that
+      // carries no entity link yet (entity_type/entity_id are NULL).
+      // Entity provisioning controllers populate the link when an
+      // employee/client/vendor_contact is created or marked is_app_user.
+      const updatedBy = req.user?.id || null;
+      const user = await db.tx(async (t) => {
+        const inserted = await t.one(
+          `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
+           VALUES ($1, $2, 'active', $3)
+           RETURNING *`,
+          [email, password_hash, updatedBy],
+        );
+        await t.none(
+          `INSERT INTO admin.portal_user_tenants
+             (portal_user_id, tenant_id, status, created_by)
+           VALUES ($1, $2, 'active', $3)`,
+          [inserted.id, tenant.id, updatedBy],
+        );
+        return inserted;
       });
 
       // Return user without password_hash
@@ -161,8 +174,7 @@ class PortalUsersController extends BaseController {
         pwUpdated = pwResult.rowCount > 0;
       }
 
-      // Update scalar user columns via raw SQL to avoid ColumnSet resetting
-      // entity_type / entity_id to NULL (their schema defaults).
+      // Update scalar user columns via raw SQL.
       // Only 'status' is an allowed mutable field from the UI.
       const ALLOWED_FIELDS = new Set(['status']);
       const safeChanges = Object.entries(userChanges).filter(([k]) => ALLOWED_FIELDS.has(k));
@@ -206,22 +218,38 @@ class PortalUsersController extends BaseController {
     }
 
     try {
-      // Look up the portal_user to cascade to linked entity
+      // Look up the portal_user to cascade to linked entity bindings
       const filter = targetId ? { id: targetId } : targetEmail ? { email: targetEmail } : { ...req.query };
       const portalUser = await this.model('admin').findOneBy([filter]);
       if (!portalUser) return res.status(404).json({ error: `${this.errorLabel} not found or already inactive` });
 
-      // Archive the portal_user with status='locked'
-      await db.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NOW(), status = 'locked', updated_by = $1, updated_at = NOW()
-         WHERE id = $2`,
-        [req.user?.id || null, portalUser.id],
+      const bindings = await db.any(
+        `SELECT id, tenant_id, entity_type, entity_id FROM admin.portal_user_tenants
+         WHERE portal_user_id = $1 AND deactivated_at IS NULL`,
+        [portalUser.id],
       );
 
-      // Cascade to linked entity in tenant schema
-      if (portalUser.entity_type && portalUser.entity_id) {
-        await this.#archiveLinkedEntity(portalUser, req);
+      const updatedBy = req.user?.id || null;
+      await db.tx(async (t) => {
+        await t.none(
+          `UPDATE admin.portal_users
+           SET deactivated_at = NOW(), status = 'locked', updated_by = $1, updated_at = NOW()
+           WHERE id = $2`,
+          [updatedBy, portalUser.id],
+        );
+        if (bindings.length) {
+          await t.none(
+            `UPDATE admin.portal_user_tenants
+             SET deactivated_at = NOW(), status = 'locked', updated_by = $1, updated_at = NOW()
+             WHERE portal_user_id = $2 AND deactivated_at IS NULL`,
+            [updatedBy, portalUser.id],
+          );
+        }
+      });
+
+      // Cascade to linked entities in their tenant schemas
+      for (const binding of bindings) {
+        await this.#archiveLinkedEntity(binding, req);
       }
 
       res.status(200).json({ message: `${this.errorLabel} marked as inactive` });
@@ -244,23 +272,44 @@ class PortalUsersController extends BaseController {
       const user = await this.model('admin').findOneBy([filter], { includeDeactivated: true });
       if (!user) return res.status(404).json({ error: 'User not found' });
 
-      // Check parent tenant is active
-      const tenant = await db('tenants', 'admin').findOneBy([{ id: user.tenant_id }]);
-      if (!tenant) {
-        return res.status(403).json({ error: 'Tenant is deactivated. Restore the tenant first.' });
-      }
-
-      // Restore user with status='active'
-      await db.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NULL, status = 'active', updated_by = $1, updated_at = NOW()
-         WHERE id = $2`,
-        [req.user?.id || null, user.id],
+      // Find the user's archived bindings — only restore those whose
+      // tenant is still active.
+      const bindings = await db.any(
+        `SELECT b.id, b.tenant_id, b.entity_type, b.entity_id, t.schema_name, t.deactivated_at AS tenant_deactivated
+         FROM admin.portal_user_tenants b
+         JOIN admin.tenants t ON t.id = b.tenant_id
+         WHERE b.portal_user_id = $1 AND b.deactivated_at IS NOT NULL`,
+        [user.id],
       );
 
-      // Cascade to restore linked entity in tenant schema
-      if (user.entity_type && user.entity_id) {
-        await this.#restoreLinkedEntity(user, tenant, req);
+      // If the user had bindings, refuse the restore unless at least one
+      // of their tenants is still active. A user with no bindings (e.g.
+      // bare registered users) restores without cascade.
+      const restorable = bindings.filter((b) => b.tenant_deactivated === null);
+      if (bindings.length && !restorable.length) {
+        return res.status(403).json({ error: 'No active tenant binding to restore. Restore the tenant first.' });
+      }
+
+      const updatedBy = req.user?.id || null;
+      await db.tx(async (t) => {
+        await t.none(
+          `UPDATE admin.portal_users
+           SET deactivated_at = NULL, status = 'active', updated_by = $1, updated_at = NOW()
+           WHERE id = $2`,
+          [updatedBy, user.id],
+        );
+        for (const b of restorable) {
+          await t.none(
+            `UPDATE admin.portal_user_tenants
+             SET deactivated_at = NULL, status = 'active', updated_by = $1, updated_at = NOW()
+             WHERE id = $2`,
+            [updatedBy, b.id],
+          );
+        }
+      });
+
+      for (const b of restorable) {
+        await this.#restoreLinkedEntity(b, req);
       }
 
       res.status(200).json({ message: `${this.errorLabel} marked as active` });
@@ -272,47 +321,49 @@ class PortalUsersController extends BaseController {
   /* ── Private helpers ──────────────────────────────────── */
 
   /**
-   * Archive the entity (e.g. employee) linked to a portal_user in its tenant schema.
+   * Archive the entity linked through a portal_user_tenants binding.
    */
-  async #archiveLinkedEntity(portalUser, req) {
-    const tenant = await db('tenants', 'admin').findOneBy([{ id: portalUser.tenant_id }]);
+  async #archiveLinkedEntity(binding, req) {
+    const tenant = await db('tenants', 'admin').findOneBy([{ id: binding.tenant_id }]);
     if (!tenant?.schema_name) return;
 
-    const table = this.#entityTable(portalUser.entity_type);
+    const table = this.#entityTable(binding.entity_type);
     if (!table) return;
 
     await db.none(
       `UPDATE ${pgp.as.name(tenant.schema_name)}.${pgp.as.name(table)}
        SET deactivated_at = NOW(), updated_by = $1, updated_at = NOW()
        WHERE id = $2 AND deactivated_at IS NULL`,
-      [req.user?.id || null, portalUser.entity_id],
+      [req.user?.id || null, binding.entity_id],
     );
-    logger.info(`Cascaded archive to ${tenant.schema_name}.${table} ${portalUser.entity_id}`);
+    logger.info(`Cascaded archive to ${tenant.schema_name}.${table} ${binding.entity_id}`);
   }
 
   /**
-   * Restore the entity (e.g. employee) linked to a portal_user in its tenant schema.
+   * Restore the entity linked through a portal_user_tenants binding.
    */
-  async #restoreLinkedEntity(portalUser, tenant, req) {
-    if (!tenant?.schema_name) return;
+  async #restoreLinkedEntity(binding, req) {
+    const schemaName = binding.schema_name
+      || (await db('tenants', 'admin').findOneBy([{ id: binding.tenant_id }]))?.schema_name;
+    if (!schemaName) return;
 
-    const table = this.#entityTable(portalUser.entity_type);
+    const table = this.#entityTable(binding.entity_type);
     if (!table) return;
 
     await db.none(
-      `UPDATE ${pgp.as.name(tenant.schema_name)}.${pgp.as.name(table)}
+      `UPDATE ${pgp.as.name(schemaName)}.${pgp.as.name(table)}
        SET deactivated_at = NULL, updated_by = $1, updated_at = NOW()
        WHERE id = $2 AND deactivated_at IS NOT NULL`,
-      [req.user?.id || null, portalUser.entity_id],
+      [req.user?.id || null, binding.entity_id],
     );
-    logger.info(`Cascaded restore to ${tenant.schema_name}.${table} ${portalUser.entity_id}`);
+    logger.info(`Cascaded restore to ${schemaName}.${table} ${binding.entity_id}`);
   }
 
   /**
    * Map entity_type to its table name.
    */
   #entityTable(entityType) {
-    const map = { employee: 'employees', vendor: 'vendors', client: 'clients', contact: 'contacts' };
+    const map = { employee: 'employees', vendor_contact: 'vendor_contacts', client: 'clients' };
     return map[entityType] || null;
   }
 }

--- a/apps/server/src/system/tenants/controllers/portalUsersController.js
+++ b/apps/server/src/system/tenants/controllers/portalUsersController.js
@@ -162,16 +162,49 @@ class PortalUsersController extends BaseController {
   };
 
   /**
+   * Run a parent ViewController method against a captured response so
+   * we can post-process its data before sending. Lets hydration errors
+   * stay inside the controller's normal try/catch flow rather than
+   * leaking as unhandled rejections through an async res.json wrapper.
+   */
+  async #captureSuper(method, req, res) {
+    let captured;
+    let captureType = null;
+    let capturedStatus = 200;
+    const captureRes = {
+      json(data) {
+        captured = data;
+        captureType = 'json';
+        return captureRes;
+      },
+      status(code) {
+        capturedStatus = code;
+        return captureRes;
+      },
+      setHeader: () => captureRes,
+      get headersSent() {
+        return false;
+      },
+    };
+    await super[method](req, captureRes);
+    return { type: captureType, status: capturedStatus, body: captured };
+  }
+
+  /**
    * Override GET / to strip password_hash from results and hydrate the
    * primary active binding (entity_type / entity_id / tenant_id).
    */
   async get(req, res) {
-    const origJson = res.json.bind(res);
-    res.json = async (data) => {
-      const hydrated = await this.#hydrateBindings(data);
-      return origJson(this.#stripPasswords(hydrated));
-    };
-    return super.get(req, res);
+    try {
+      const captured = await this.#captureSuper('get', req, res);
+      if (captured.status >= 400) {
+        return res.status(captured.status).json(captured.body);
+      }
+      const hydrated = await this.#hydrateBindings(captured.body);
+      return res.json(this.#stripPasswords(hydrated));
+    } catch (err) {
+      this.handleError(err, res, 'fetching', this.errorLabel);
+    }
   }
 
   /**
@@ -192,12 +225,16 @@ class PortalUsersController extends BaseController {
    * Override GET /where to strip password_hash and hydrate binding.
    */
   async getWhere(req, res) {
-    const origJson = res.json.bind(res);
-    res.json = async (data) => {
-      const hydrated = await this.#hydrateBindings(data);
-      return origJson(this.#stripPasswords(hydrated));
-    };
-    return super.getWhere(req, res);
+    try {
+      const captured = await this.#captureSuper('getWhere', req, res);
+      if (captured.status >= 400) {
+        return res.status(captured.status).json(captured.body);
+      }
+      const hydrated = await this.#hydrateBindings(captured.body);
+      return res.json(this.#stripPasswords(hydrated));
+    } catch (err) {
+      this.handleError(err, res, 'fetching', this.errorLabel);
+    }
   }
 
   /**

--- a/apps/server/src/system/tenants/controllers/tenantsController.js
+++ b/apps/server/src/system/tenants/controllers/tenantsController.js
@@ -99,6 +99,10 @@ class TenantsController extends BaseController {
       }
     }
 
+    if (!req.query.id && !req.query.tenant_code) {
+      return res.status(400).json({ error: 'id or tenant_code query parameter is required' });
+    }
+
     const now = new Date();
     req.body.deactivated_at = now;
 
@@ -107,32 +111,40 @@ class TenantsController extends BaseController {
       const count = await this.model('admin').updateWhere([{ ...req.query }], req.body);
       if (!count) return res.status(404).json({ error: `${this.errorLabel} not found or already inactive` });
 
-      // Cascade: archive every active binding to this tenant. Lock any
-      // portal_user whose last active binding just went away.
+      // Cascade: archive every active binding to this tenant; lock
+      // portal_users whose final active binding just went away. The
+      // RETURNING clause scopes the user-lock cascade to users we
+      // actually touched — bare-registered users with active bindings
+      // to other tenants are unaffected.
       const updatedBy = req.user?.id || null;
       await db.tx(async (t) => {
-        if (req.query.id) {
+        const affected = req.query.id
+          ? await t.manyOrNone(
+              `UPDATE admin.portal_user_tenants SET deactivated_at = $1, status = 'locked', updated_by = $2
+               WHERE tenant_id = $3 AND deactivated_at IS NULL
+               RETURNING portal_user_id`,
+              [now, updatedBy, req.query.id],
+            )
+          : await t.manyOrNone(
+              `UPDATE admin.portal_user_tenants SET deactivated_at = $1, status = 'locked', updated_by = $2
+               WHERE tenant_id = (SELECT id FROM admin.tenants WHERE tenant_code = $3)
+                 AND deactivated_at IS NULL
+               RETURNING portal_user_id`,
+              [now, updatedBy, req.query.tenant_code],
+            );
+
+        const affectedIds = [...new Set(affected.map((r) => r.portal_user_id))];
+        if (affectedIds.length) {
           await t.none(
-            `UPDATE admin.portal_user_tenants SET deactivated_at = $1, status = 'locked', updated_by = $2
-             WHERE tenant_id = $3 AND deactivated_at IS NULL`,
-            [now, updatedBy, req.query.id],
-          );
-        } else if (req.query.tenant_code) {
-          await t.none(
-            `UPDATE admin.portal_user_tenants SET deactivated_at = $1, status = 'locked', updated_by = $2
-             WHERE tenant_id = (SELECT id FROM admin.tenants WHERE tenant_code = $3)
-               AND deactivated_at IS NULL`,
-            [now, updatedBy, req.query.tenant_code],
+            `UPDATE admin.portal_users SET deactivated_at = $1, status = 'locked', updated_by = $2
+             WHERE id = ANY($3::uuid[])
+               AND deactivated_at IS NULL
+               AND id NOT IN (
+                 SELECT portal_user_id FROM admin.portal_user_tenants WHERE deactivated_at IS NULL
+               )`,
+            [now, updatedBy, affectedIds],
           );
         }
-        await t.none(
-          `UPDATE admin.portal_users SET deactivated_at = $1, status = 'locked', updated_by = $2
-           WHERE deactivated_at IS NULL
-             AND id NOT IN (
-               SELECT portal_user_id FROM admin.portal_user_tenants WHERE deactivated_at IS NULL
-             )`,
-          [now, updatedBy],
-        );
       });
 
       res.status(200).json({ message: `${this.errorLabel} marked as inactive` });

--- a/apps/server/src/system/tenants/controllers/tenantsController.js
+++ b/apps/server/src/system/tenants/controllers/tenantsController.js
@@ -107,21 +107,33 @@ class TenantsController extends BaseController {
       const count = await this.model('admin').updateWhere([{ ...req.query }], req.body);
       if (!count) return res.status(404).json({ error: `${this.errorLabel} not found or already inactive` });
 
-      // Cascade: deactivate and lock all currently-active users
-      if (req.query.id) {
-        await db.none(
+      // Cascade: archive every active binding to this tenant. Lock any
+      // portal_user whose last active binding just went away.
+      const updatedBy = req.user?.id || null;
+      await db.tx(async (t) => {
+        if (req.query.id) {
+          await t.none(
+            `UPDATE admin.portal_user_tenants SET deactivated_at = $1, status = 'locked', updated_by = $2
+             WHERE tenant_id = $3 AND deactivated_at IS NULL`,
+            [now, updatedBy, req.query.id],
+          );
+        } else if (req.query.tenant_code) {
+          await t.none(
+            `UPDATE admin.portal_user_tenants SET deactivated_at = $1, status = 'locked', updated_by = $2
+             WHERE tenant_id = (SELECT id FROM admin.tenants WHERE tenant_code = $3)
+               AND deactivated_at IS NULL`,
+            [now, updatedBy, req.query.tenant_code],
+          );
+        }
+        await t.none(
           `UPDATE admin.portal_users SET deactivated_at = $1, status = 'locked', updated_by = $2
-           WHERE tenant_id = $3 AND deactivated_at IS NULL`,
-          [now, req.user?.id || null, req.query.id],
+           WHERE deactivated_at IS NULL
+             AND id NOT IN (
+               SELECT portal_user_id FROM admin.portal_user_tenants WHERE deactivated_at IS NULL
+             )`,
+          [now, updatedBy],
         );
-      } else if (req.query.tenant_code) {
-        await db.none(
-          `UPDATE admin.portal_users SET deactivated_at = $1, status = 'locked', updated_by = $2
-           WHERE tenant_id = (SELECT id FROM admin.tenants WHERE tenant_code = $3)
-             AND deactivated_at IS NULL`,
-          [now, req.user?.id || null, req.query.tenant_code],
-        );
-      }
+      });
 
       res.status(200).json({ message: `${this.errorLabel} marked as inactive` });
     } catch (err) {

--- a/apps/server/tests/contract/admin.test.js
+++ b/apps/server/tests/contract/admin.test.js
@@ -76,6 +76,74 @@ describe('POST /api/tenants/v1/admin/impersonate', () => {
 
     expect(res.status).toBe(404);
   });
+
+  test('multi-binding target: target_tenant_id picks the requested binding', async () => {
+    const cookies = await loginRoot();
+
+    // Provision a portal_user with bindings to two tenants
+    const tenants = await db.manyOrNone('SELECT id, tenant_code FROM admin.tenants ORDER BY created_at ASC LIMIT 2');
+    if (tenants.length < 2) {
+      // Need a second tenant; create one via the API
+      await request(app)
+        .post('/api/tenants/v1/tenants')
+        .set('Cookie', cookies)
+        .send({
+          tenant_code: 'IMPB',
+          company: 'Imp Tenant B',
+          status: 'active',
+          tier: 'starter',
+          admin_first_name: 'B',
+          admin_last_name: 'Admin',
+          admin_email: 'admin@impb.test',
+          admin_password: 'ImpbPass123!',
+          billing_address: { address_line_1: '1 B St', country_code: 'US' },
+        });
+    }
+    const allTenants = await db.manyOrNone('SELECT id, tenant_code FROM admin.tenants ORDER BY created_at ASC LIMIT 2');
+    expect(allTenants.length).toBe(2);
+    const [tenantA, tenantB] = allTenants;
+
+    const user = await db.one(
+      `INSERT INTO admin.portal_users (email, password_hash, status)
+       VALUES ('multi@impb.test', 'x', 'active') RETURNING id`,
+    );
+    // Earliest binding to tenant A; later binding to tenant B
+    await db.none(
+      `INSERT INTO admin.portal_user_tenants (portal_user_id, tenant_id, entity_type, entity_id, status, created_at)
+       VALUES ($1, $2, 'vendor_contact', gen_random_uuid(), 'active', now() - interval '1 day')`,
+      [user.id, tenantA.id],
+    );
+    await db.none(
+      `INSERT INTO admin.portal_user_tenants (portal_user_id, tenant_id, entity_type, entity_id, status)
+       VALUES ($1, $2, 'vendor_contact', gen_random_uuid(), 'active')`,
+      [user.id, tenantB.id],
+    );
+
+    // Without target_tenant_id → earliest binding wins (tenant A)
+    let res = await request(app)
+      .post('/api/tenants/v1/admin/impersonate')
+      .set('Cookie', cookies)
+      .send({ target_user_id: user.id });
+    expect(res.status).toBe(200);
+    expect(res.body.target_user.tenant_id).toBe(tenantA.id);
+
+    // Clean up impersonation session before the next call
+    await request(app).post('/api/tenants/v1/admin/exit-impersonation').set('Cookie', cookies);
+
+    // With target_tenant_id pointing at B → tenant B binding is used
+    res = await request(app)
+      .post('/api/tenants/v1/admin/impersonate')
+      .set('Cookie', cookies)
+      .send({ target_user_id: user.id, target_tenant_id: tenantB.id });
+    expect(res.status).toBe(200);
+    expect(res.body.target_user.tenant_id).toBe(tenantB.id);
+
+    // Cleanup
+    await request(app).post('/api/tenants/v1/admin/exit-impersonation').set('Cookie', cookies);
+    await db.none('DELETE FROM admin.impersonation_logs WHERE target_user_id = $1', [user.id]);
+    await db.none('DELETE FROM admin.portal_user_tenants WHERE portal_user_id = $1', [user.id]);
+    await db.none('DELETE FROM admin.portal_users WHERE id = $1', [user.id]);
+  }, 30000);
 });
 
 describe('GET /api/tenants/v1/admin/impersonation-status', () => {

--- a/apps/server/tests/contract/emails.test.js
+++ b/apps/server/tests/contract/emails.test.js
@@ -261,7 +261,7 @@ describe('Login email sync — client and vendor_contact source types', () => {
     expect(res.status).toBe(201);
 
     const portal = await DB.db.oneOrNone(
-      `SELECT email FROM admin.portal_users WHERE entity_type = 'client' AND entity_id = $1 AND deactivated_at IS NULL`,
+      `SELECT pu.email FROM admin.portal_users pu JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id WHERE b.entity_type = 'client' AND b.entity_id = $1 AND b.deactivated_at IS NULL AND pu.deactivated_at IS NULL`,
       [res.body.id],
     );
     expect(portal?.email).toBe('client-login@emtest.com');
@@ -280,7 +280,7 @@ describe('Login email sync — client and vendor_contact source types', () => {
     expect(updateRes.status).toBe(200);
 
     const portalAfter = await DB.db.oneOrNone(
-      `SELECT email FROM admin.portal_users WHERE entity_type = 'client' AND entity_id = $1 AND deactivated_at IS NULL`,
+      `SELECT pu.email FROM admin.portal_users pu JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id WHERE b.entity_type = 'client' AND b.entity_id = $1 AND b.deactivated_at IS NULL AND pu.deactivated_at IS NULL`,
       [res.body.id],
     );
     expect(portalAfter?.email).toBe('client-login-updated@emtest.com');
@@ -316,7 +316,7 @@ describe('Login email sync — client and vendor_contact source types', () => {
     expect(res.status).toBe(201);
 
     const portal = await DB.db.oneOrNone(
-      `SELECT email FROM admin.portal_users WHERE entity_type = 'vendor_contact' AND entity_id = $1 AND deactivated_at IS NULL`,
+      `SELECT pu.email FROM admin.portal_users pu JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id WHERE b.entity_type = 'vendor_contact' AND b.entity_id = $1 AND b.deactivated_at IS NULL AND pu.deactivated_at IS NULL`,
       [res.body.id],
     );
     expect(portal?.email).toBe('vc-login@emtest.com');

--- a/apps/server/tests/contract/employees.test.js
+++ b/apps/server/tests/contract/employees.test.js
@@ -107,10 +107,11 @@ describe('Employee CRUD — /api/core/v1/employees', () => {
     expect(res.status).toBe(201);
     expect(res.body.is_app_user).toBe(true);
 
-    // Verify portal_user was created in admin schema
+    // Verify portal_user + binding were created in admin schema
     const portalUser = await db.oneOrNone(
-      `SELECT id, entity_type, entity_id, status FROM admin.portal_users
-       WHERE entity_type = 'employee' AND entity_id = $1`,
+      `SELECT pu.id, pu.status FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id
+       WHERE b.entity_type = 'employee' AND b.entity_id = $1`,
       [res.body.id],
     );
     expect(portalUser).not.toBeNull();
@@ -127,10 +128,11 @@ describe('Employee CRUD — /api/core/v1/employees', () => {
 
     expect(res.status).toBe(200);
 
-    // Verify portal_user was archived
+    // Verify portal_user + binding were archived
     const portalUser = await db.oneOrNone(
-      `SELECT status, deactivated_at FROM admin.portal_users
-       WHERE entity_type = 'employee' AND entity_id = $1`,
+      `SELECT pu.status, pu.deactivated_at FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id
+       WHERE b.entity_type = 'employee' AND b.entity_id = $1`,
       [bob.id],
     );
     expect(portalUser.status).toBe('locked');
@@ -194,7 +196,10 @@ describe('Employee CRUD — /api/core/v1/employees', () => {
     expect(employee.is_app_user).toBe(true);
 
     const portalUser = await db.oneOrNone(
-      `SELECT entity_type, entity_id, email, status FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`,
+      `SELECT pu.email, pu.status, b.entity_type, b.entity_id
+       FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id
+       WHERE pu.email = $1 AND pu.deactivated_at IS NULL`,
       ['alice@etest.com'],
     );
     expect(portalUser).not.toBeNull();
@@ -217,10 +222,10 @@ describe('Employee CRUD — /api/core/v1/employees', () => {
     expect(employee).not.toBeNull();
     expect(employee.is_app_user).toBe(false);
 
-    const portalUser = await db.oneOrNone(
-      `SELECT id FROM admin.portal_users WHERE entity_type = 'employee' AND entity_id = $1 AND deactivated_at IS NULL`,
+    const binding = await db.oneOrNone(
+      `SELECT id FROM admin.portal_user_tenants WHERE entity_type = 'employee' AND entity_id = $1 AND deactivated_at IS NULL`,
       [employee.id],
     );
-    expect(portalUser).toBeNull();
+    expect(binding).toBeNull();
   });
 });

--- a/apps/server/tests/contract/reports.test.js
+++ b/apps/server/tests/contract/reports.test.js
@@ -109,7 +109,32 @@ vi.mock('../../src/db/db.js', () => {
   dbProxy.none = vi.fn();
   dbProxy.result = vi.fn(async () => ({ rowCount: 1 }));
   dbProxy.manyOrNone = vi.fn(async () => []);
-  dbProxy.oneOrNone = vi.fn(async () => null);
+  // Catch-all for raw SQL lookups across login + authRedis. Passport's
+  // login query SELECTs t.* from a tenants/portal_user_tenants join;
+  // authRedis queries portal_user_tenants for home + matched bindings,
+  // and admin.tenants for the x-tenant-code lookup.
+  dbProxy.oneOrNone = vi.fn(async (sql) => {
+    if (typeof sql !== 'string') return null;
+    if (sql.includes('portal_user_tenants') && sql.includes('admin.tenants')) {
+      // passport's login JOIN returning a full tenant row
+      return mockTenant;
+    }
+    if (sql.includes('portal_user_tenants')) {
+      // authRedis home binding lookup
+      return {
+        id: 'binding-1',
+        portal_user_id: mockUser.id,
+        tenant_id: mockTenant.id,
+        entity_type: 'employee',
+        entity_id: '880e8400-e29b-41d4-a716-446655440000',
+        status: 'active',
+      };
+    }
+    if (sql.includes('admin.tenants')) {
+      return mockTenant;
+    }
+    return null;
+  });
   dbProxy.tx = vi.fn(async (fn) => {
     const t = {
       one: vi.fn(async () => ({ id: 'tx-entry' })),

--- a/apps/server/tests/contract/taxIdentifiers.test.js
+++ b/apps/server/tests/contract/taxIdentifiers.test.js
@@ -108,11 +108,13 @@ describe('Tax Identifiers CRUD — /api/core/v1/tax-identifiers', () => {
     expect(res.status).toBe(200);
   });
 
-  test('rejects duplicate (source_id, country_code, tax_type)', async () => {
+  test('rejects duplicate global (country_code, tax_type, tax_value)', async () => {
+    // The existing record has tax_value '98-7654321' (after the earlier update);
+    // a different source can no longer reuse the same global tuple.
     const res = await request(app)
       .post('/api/core/v1/tax-identifiers')
       .set('Cookie', cookies)
-      .send({ source_id: sourceId, country_code: 'US', tax_type: 'EIN', tax_value: '00-0000000' });
+      .send({ source_id: sourceId, country_code: 'US', tax_type: 'EIN', tax_value: '98-7654321' });
 
     expect(res.status).toBe(409);
   });

--- a/apps/server/tests/helpers/testDb.js
+++ b/apps/server/tests/helpers/testDb.js
@@ -103,11 +103,31 @@ async function reseedAdmin(db) {
     [rootEmail],
   );
 
-  if (!existingUser) {
+  let userId = existingUser?.id;
+  if (!userId) {
+    const inserted = await db.one(
+      `INSERT INTO admin.portal_users (email, password_hash, status)
+       VALUES ($1, $2, 'active')
+       RETURNING id`,
+      [rootEmail, passwordHash],
+    );
+    userId = inserted.id;
+  }
+
+  // Bind the root super user to the root tenant. Tests don't create the
+  // backing employees row (setupAdmin.js does that in real envs), so the
+  // binding's entity link stays NULL — entity_type/entity_id are
+  // nullable on portal_user_tenants for exactly this pre-link case.
+  const existingBinding = await db.oneOrNone(
+    `SELECT id FROM admin.portal_user_tenants WHERE portal_user_id = $1 AND deactivated_at IS NULL`,
+    [userId],
+  );
+  if (!existingBinding) {
     await db.none(
-      `INSERT INTO admin.portal_users (tenant_id, entity_type, entity_id, email, password_hash, status)
-       VALUES ($1, NULL, NULL, $2, $3, 'active')`,
-      [tenant.id, rootEmail, passwordHash],
+      `INSERT INTO admin.portal_user_tenants
+         (portal_user_id, tenant_id, status)
+       VALUES ($1, $2, 'active')`,
+      [userId, tenant.id],
     );
   }
 }
@@ -168,6 +188,12 @@ export async function bootstrapAdmin() {
       }
     },
   });
+
+  // Bootstrap migration creates the auth-only portal_users row. The root
+  // tenant binding lives on portal_user_tenants; in real deploys
+  // setupAdmin.js writes it after creating the admin employee. Tests don't
+  // run setupAdmin, so seed the binding here directly (matches reseedAdmin).
+  await reseedAdmin(db);
 
   adminReady = true;
   return db;

--- a/apps/server/tests/integration/bootstrap.test.js
+++ b/apps/server/tests/integration/bootstrap.test.js
@@ -72,37 +72,34 @@ describe('Bootstrap admin migration', () => {
     const user = await db.oneOrNone('SELECT * FROM admin.portal_users WHERE email = $1', [ROOT_EMAIL]);
     expect(user).not.toBeNull();
     expect(user.status).toBe('active');
-    expect(user.entity_type).toBeNull();
-    expect(user.entity_id).toBeNull();
     expect(user.password_hash).toBeDefined();
     expect(user.password_hash.startsWith('$2')).toBe(true); // bcrypt hash
   });
 
-  test('portal_users.tenant_id references the root tenant', async () => {
-    const tenant = await db.oneOrNone('SELECT id FROM admin.tenants WHERE tenant_code = $1', [ROOT_TENANT_CODE]);
-    const user = await db.oneOrNone('SELECT tenant_id FROM admin.portal_users WHERE email = $1', [ROOT_EMAIL]);
-    expect(user).not.toBeNull();
-    expect(user.tenant_id).toBe(tenant.id);
-  });
-
-  test('portal_users does NOT have tenant_code column (PRD §3.2.2)', async () => {
+  test('portal_users is auth-only — no tenant or entity columns', async () => {
     const cols = await db.manyOrNone(
       "SELECT column_name FROM information_schema.columns WHERE table_schema = 'admin' AND table_name = 'portal_users'",
     );
     const colNames = cols.map((c) => c.column_name);
+    expect(colNames).not.toContain('tenant_id');
     expect(colNames).not.toContain('tenant_code');
+    expect(colNames).not.toContain('entity_type');
+    expect(colNames).not.toContain('entity_id');
     expect(colNames).not.toContain('user_name');
     expect(colNames).not.toContain('full_name');
     expect(colNames).not.toContain('role');
   });
 
-  test('portal_users has entity_type and entity_id columns (PRD §3.2.2)', async () => {
+  test('portal_user_tenants table exists with binding columns', async () => {
     const cols = await db.manyOrNone(
-      "SELECT column_name FROM information_schema.columns WHERE table_schema = 'admin' AND table_name = 'portal_users'",
+      "SELECT column_name FROM information_schema.columns WHERE table_schema = 'admin' AND table_name = 'portal_user_tenants'",
     );
     const colNames = cols.map((c) => c.column_name);
+    expect(colNames).toContain('portal_user_id');
+    expect(colNames).toContain('tenant_id');
     expect(colNames).toContain('entity_type');
     expect(colNames).toContain('entity_id');
+    expect(colNames).toContain('status');
   });
 
   test('re-running bootstrap is idempotent', async () => {

--- a/apps/server/tests/integration/entityLifecycle.test.js
+++ b/apps/server/tests/integration/entityLifecycle.test.js
@@ -77,11 +77,12 @@ describe('Entity lifecycle — employee is_app_user with portal_users cascade', 
     expect(res.status).toBe(201);
     employeeId = res.body.id;
 
-    // Verify portal_user exists
+    // Verify portal_user + binding exist
     const portalUser = await db.oneOrNone(
-      `SELECT id, entity_type, entity_id, email, status
-       FROM admin.portal_users
-       WHERE entity_type = 'employee' AND entity_id = $1`,
+      `SELECT pu.id, pu.email, pu.status, b.entity_type, b.entity_id
+       FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id
+       WHERE b.entity_type = 'employee' AND b.entity_id = $1`,
       [employeeId],
     );
     expect(portalUser).not.toBeNull();
@@ -94,10 +95,12 @@ describe('Entity lifecycle — employee is_app_user with portal_users cascade', 
 
     expect(res.status).toBe(200);
 
-    // Verify portal_user is locked
+    // Verify portal_user + binding are both locked
     const portalUser = await db.oneOrNone(
-      `SELECT status, deactivated_at FROM admin.portal_users
-       WHERE entity_type = 'employee' AND entity_id = $1`,
+      `SELECT pu.status, pu.deactivated_at
+       FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id
+       WHERE b.entity_type = 'employee' AND b.entity_id = $1`,
       [employeeId],
     );
     expect(portalUser.status).toBe('locked');
@@ -118,8 +121,10 @@ describe('Entity lifecycle — employee is_app_user with portal_users cascade', 
 
     // Verify portal_user is restored
     const portalUser = await db.oneOrNone(
-      `SELECT status, deactivated_at FROM admin.portal_users
-       WHERE entity_type = 'employee' AND entity_id = $1`,
+      `SELECT pu.status, pu.deactivated_at
+       FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id
+       WHERE b.entity_type = 'employee' AND b.entity_id = $1`,
       [employeeId],
     );
     expect(portalUser.status).toBe('active');

--- a/apps/server/tests/integration/tenantLifecycle.test.js
+++ b/apps/server/tests/integration/tenantLifecycle.test.js
@@ -94,10 +94,17 @@ describe('Tenant lifecycle — create, provision, archive, restore', () => {
     const user = await db.oneOrNone('SELECT * FROM admin.portal_users WHERE id = $1', [adminUserId]);
     expect(user).not.toBeNull();
     expect(user.email).toBe('admin@testco.com');
-    expect(user.tenant_id).toBe(tenantId);
     expect(user.status).toBe('invited');
     expect(user.password_hash).toBeDefined();
     expect(user.password_hash.startsWith('$2')).toBe(true); // bcrypt
+
+    const binding = await db.oneOrNone(
+      'SELECT tenant_id, entity_type FROM admin.portal_user_tenants WHERE portal_user_id = $1 AND deactivated_at IS NULL',
+      [adminUserId],
+    );
+    expect(binding).not.toBeNull();
+    expect(binding.tenant_id).toBe(tenantId);
+    expect(binding.entity_type).toBe('employee');
   });
 
   test('5. Admin user can log in', async () => {

--- a/apps/server/tests/unit/authRedis.test.js
+++ b/apps/server/tests/unit/authRedis.test.js
@@ -126,16 +126,24 @@ describe('authRedis middleware', () => {
   test('populates req.user for valid JWT and existing user + tenant', async () => {
     const userId = '550e8400-e29b-41d4-a716-446655440000';
     const tenantId = '660e8400-e29b-41d4-a716-446655440000';
+    const entityId = '880e8400-e29b-41d4-a716-446655440000';
     const token = jwt.sign({ sub: userId, ph: null }, SECRET, { expiresIn: '15m' });
 
     mockFindOneBy.mockResolvedValue({
       id: userId,
       email: 'admin@axerra.io',
-      entity_type: null,
-      entity_id: null,
       status: 'active',
-      tenant_id: tenantId,
       deactivated_at: null,
+    });
+
+    // Home binding lookup
+    mockOneOrNone.mockResolvedValueOnce({
+      id: 'binding-1',
+      portal_user_id: userId,
+      tenant_id: tenantId,
+      entity_type: 'employee',
+      entity_id: entityId,
+      status: 'active',
     });
 
     mockFindById.mockResolvedValue({
@@ -156,6 +164,8 @@ describe('authRedis middleware', () => {
     expect(req.user).toBeDefined();
     expect(req.user.id).toBe(userId);
     expect(req.user.email).toBe('admin@axerra.io');
+    expect(req.user.entity_type).toBe('employee');
+    expect(req.user.entity_id).toBe(entityId);
     expect(req.user.tenant_code).toBe('axerra');
     expect(req.user.schema_name).toBe('axerra');
   });
@@ -182,11 +192,25 @@ describe('authRedis middleware', () => {
     mockFindOneBy.mockResolvedValue({
       id: userId,
       email: 'admin@axerra.io',
-      entity_type: null,
-      entity_id: null,
       status: 'active',
-      tenant_id: tenantId,
     });
+
+    // 1) home binding lookup, 2) x-tenant-code → tenants row, 3) matched binding for that tenant (none)
+    mockOneOrNone
+      .mockResolvedValueOnce({
+        id: 'binding-1',
+        portal_user_id: userId,
+        tenant_id: tenantId,
+        entity_type: 'employee',
+        entity_id: 'emp-1',
+        status: 'active',
+      })
+      .mockResolvedValueOnce({
+        id: 'acme-id',
+        tenant_code: 'ACME',
+        schema_name: 'acme',
+      })
+      .mockResolvedValueOnce(null);
 
     mockFindById.mockResolvedValue({
       id: tenantId,
@@ -214,10 +238,7 @@ describe('authRedis middleware', () => {
     mockFindOneBy.mockResolvedValue({
       id: userId,
       email: 'admin@axerra.io',
-      entity_type: null,
-      entity_id: null,
       status: 'active',
-      tenant_id: homeTenantId,
     });
 
     mockFindById.mockResolvedValue({
@@ -227,13 +248,23 @@ describe('authRedis middleware', () => {
       allowed_modules: ['projects', 'accounting'],
     });
 
-    // Mock the raw SQL query for effective tenant lookup
-    mockOneOrNone.mockResolvedValue({
-      id: acmeTenantId,
-      tenant_code: 'ACME',
-      schema_name: 'acme',
-      allowed_modules: ['projects'],
-    });
+    // 1) home binding, 2) x-tenant-code → tenants row, 3) matched binding (none)
+    mockOneOrNone
+      .mockResolvedValueOnce({
+        id: 'binding-1',
+        portal_user_id: userId,
+        tenant_id: homeTenantId,
+        entity_type: 'employee',
+        entity_id: 'emp-1',
+        status: 'active',
+      })
+      .mockResolvedValueOnce({
+        id: acmeTenantId,
+        tenant_code: 'ACME',
+        schema_name: 'acme',
+        allowed_modules: ['projects'],
+      })
+      .mockResolvedValueOnce(null);
 
     const req = makeReq({
       cookies: { auth_token: token },


### PR DESCRIPTION
## Summary

Tasks 4 + 5 of the Import Dedup & Multi-Tenant Vendor Access plan, bundled into one PR per [discussion in the planning thread](https://github.com/silverstone-i/axerra/pull/49) — dropping the auth columns and updating the controllers that write them must land together for the system to compile.

`portal_users` is now auth-only (`id`, `email`, `password_hash`, `status`). Tenant linkage and the polymorphic entity link move to a new `admin.portal_user_tenants` join table:

| Column | Notes |
|---|---|
| `portal_user_id` | FK to portal_users (CASCADE) |
| `tenant_id` | FK to tenants (CASCADE) |
| `entity_type` | nullable — supports pre-link bare registrations |
| `entity_id` | nullable |
| `status` | `'active'` / `'invited'` / `'locked'` |
| `deactivated_at` | soft-delete |

Unique `(portal_user_id, tenant_id) WHERE deactivated_at IS NULL` so a user can't have two active bindings to the same tenant.

Employees and clients keep exactly one active binding. Vendor_contacts may have one per tenant — Task 6 builds the existing-email match → bind flow on top of this.

## What changed

- **Schemas:** new `portalUserTenantsSchema`, slimmed `portalUsersSchema`. `email` was already globally unique on portal_users so that part of the spec was already in place.
- **Auth resolution:** `passportService` and `authRedis` resolve the user's home tenant via the JOIN to `portal_user_tenants` instead of `portal_users.tenant_id`. authRedis takes the earliest active binding as home, upgrades to a matching binding if `x-tenant-code` resolves to one, and falls back to home for tenants the user has no binding to (preserves Axerra free-switching).
- **Provisioning (Task 5):** `#provisionAppUser` / `#archiveAppUser` / `#restoreAppUser` in the employee, client, and vendor_contact controllers now write/read both rows transactionally. Reset-password lookups go through a small new `portalUserBindings` helper. `spreadsheetHelpers.provisionAppUser` writes the binding too.
- **Axerra-side cascades:** `portalUsersController` archive/restore cascades across all of a user's bindings. `tenantsController` archive cascades to bindings and locks any user whose last active binding just went away.
- **Bootstrap + setup:** bootstrap migration seeds auth-only portal_users; `setupAdmin.js` writes the binding when it links the root super user to the admin employee. `tenantSetup` does the same for new tenants.
- **Task 1 sync:** `emailsController#syncLoginEmail` now resolves `portal_users.id` via the binding rather than the dropped `entity_type/entity_id` columns.
- **Tests + testDb:** integration / contract / authRedis unit tests join `portal_user_tenants` where they previously filtered on `portal_users.entity_type`. testDb helper seeds the root tenant binding. taxIdentifiers contract test points its duplicate case at the new global `tax_value` uniqueness from #48.

## Out of scope (deferred per plan)

- **Binding-existence enforcement** on every request — Task 13.
- **Roles on portal_user_tenants** — entity tables already carry roles; `permissionLoader.resolveEntityRoles` continues to read from there. The spec mentioned roles on the binding; can be folded in later when permission resolution unifies.
- **Vendor existing-email match → bind** — Task 6.
- **Identity-swap on tenant-side email change** — Task 7.

## Risk notes

This is the highest-blast-radius change in the plan. Sixteen `req.user.tenant_id` callsites were reviewed — all read the value populated by authRedis from the active binding, so they continue to work without per-callsite edits. The `portalUsers.entity_type`/`entity_id` lookups across employee/client/vendor_contact archive/restore/provision and the Axerra portal-users controller were rewritten end to end.

## Test plan

- [x] `npm run lint` clean
- [x] `npm -w apps/server test` — 496 / 496 pass (122 unit, 35 rbac, 249 contract, 86 integration, plus 4 misc)
- [ ] Reviewer: confirm authRedis fallback behavior for Axerra cross-tenant switching matches what you want
- [ ] Reviewer: confirm restore semantics for portal_users with no bindings (bare registrations) — currently allowed without cascade