### PR TITLE
feat(server): vendor registration — bind existing portal_user on email match (Task 6)

### DIFF
--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -339,10 +339,12 @@ class VendorContactsController extends BaseController {
    *      restore it (and re-activate the portal_user if archived). The
    *      portal_user's credentials are NOT reset; they belong to the
    *      user, especially when they have other active bindings.
-   *   2. An active portal_user with this login email already exists —
-   *      bind that portal_user to this vendor_contact (status='invited').
-   *      Supplied password is ignored. The portal_user globally stays
-   *      active; only this binding is in invite state.
+   *   2. A portal_user with this login email already exists (active or
+   *      archived) — bind that portal_user to this vendor_contact with
+   *      the new binding in status='invited'. Supplied password is
+   *      ignored. The portal_user's global status stays as-is
+   *      (reactivated if archived); only the per-tenant binding row
+   *      starts in invite state.
    *   3. No match anywhere — create a new portal_users row plus binding
    *      with the hashed temp password (or a generated one).
    */
@@ -425,9 +427,21 @@ class VendorContactsController extends BaseController {
           );
         }
 
-        if (sameTenantBinding) {
-          // Either bare binding (entity_type NULL) or archived binding —
-          // upgrade in place to point at the vendor_contact.
+        // Decide whether to upgrade the existing binding row in place or
+        // insert a new one. Upgrading is only safe when the row is bare
+        // (entity_type IS NULL — typical /portal-users/register output)
+        // or already points at this same vendor_contact (idempotent
+        // re-provisioning of an archived binding). Otherwise inserting
+        // a new binding preserves the archived row's historical entity
+        // linkage; the (portal_user_id, tenant_id) WHERE active partial
+        // unique index doesn't conflict because the prior row is
+        // archived.
+        const canUpgradeInPlace =
+          sameTenantBinding
+          && (sameTenantBinding.entity_type === null
+            || (sameTenantBinding.entity_type === 'vendor_contact' && sameTenantBinding.entity_id === vendorContact.id));
+
+        if (canUpgradeInPlace) {
           await t.none(
             `UPDATE admin.portal_user_tenants
              SET deactivated_at = NULL,
@@ -494,7 +508,14 @@ class VendorContactsController extends BaseController {
   }
 
   /**
-   * Archive (soft-delete) the portal_users + binding linked to a vendor contact.
+   * Archive the per-tenant binding for a vendor_contact app user.
+   *
+   * Vendor_contacts can share a portal_user across tenants (Task 6's
+   * email-match → bind path). Archiving only this tenant's binding
+   * must NOT lock the global portal_user when other tenants still
+   * have active bindings to it — that would break their logins.
+   * The portal_user is only locked when this was the user's last
+   * remaining active binding.
    */
   async #archiveAppUser(vendorContactId, req) {
     const binding = await findActiveBinding('vendor_contact', vendorContactId, req.user?.tenant_id);
@@ -508,14 +529,20 @@ class VendorContactsController extends BaseController {
          WHERE id = $2`,
         [updatedBy, binding.id],
       );
+      // Only lock the portal_user globally if this was the last active
+      // binding. Mirrors tenantsController's cascade pattern.
       await t.none(
         `UPDATE admin.portal_users
          SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-         WHERE id = $2`,
+         WHERE id = $2 AND deactivated_at IS NULL
+           AND NOT EXISTS (
+             SELECT 1 FROM admin.portal_user_tenants
+             WHERE portal_user_id = $2 AND deactivated_at IS NULL
+           )`,
         [updatedBy, binding.portal_user_id],
       );
     });
-    logger.info(`Archived portal_user ${binding.portal_user_id} + binding for vendor_contact ${vendorContactId}`);
+    logger.info(`Archived binding for vendor_contact ${vendorContactId} → portal_user ${binding.portal_user_id}`);
   }
 
   /**

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -376,17 +376,78 @@ class VendorContactsController extends BaseController {
     }
 
     // ── Case 2: existing portal_user with this email → bind, ignore password ──
+    // Match active rows first; fall back to archived rows so we never
+    // create a duplicate credentials row for the same email. If matched
+    // archived, the portal_user gets reactivated as part of the bind.
     const existingUser = await db.oneOrNone(
-      'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+      `SELECT id, deactivated_at FROM admin.portal_users
+       WHERE email = $1
+       ORDER BY deactivated_at IS NULL DESC, deactivated_at DESC NULLS FIRST
+       LIMIT 1`,
       [loginEmail],
     );
     if (existingUser) {
-      await db.none(
-        `INSERT INTO admin.portal_user_tenants
-           (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
-         VALUES ($1, $2, 'vendor_contact', $3, 'invited', $4)`,
-        [existingUser.id, tenantId, vendorContact.id, updatedBy],
+      // Detect a pre-existing binding for (this portal_user, this tenant).
+      // The (portal_user_id, tenant_id) WHERE active partial unique index
+      // means we can only have one active binding here; bare bindings
+      // from /portal-users/register get upgraded in place, entity bindings
+      // collide loudly.
+      const sameTenantBinding = await db.oneOrNone(
+        `SELECT id, entity_type, entity_id, deactivated_at
+         FROM admin.portal_user_tenants
+         WHERE portal_user_id = $1 AND tenant_id = $2
+         ORDER BY deactivated_at IS NULL DESC, created_at DESC
+         LIMIT 1`,
+        [existingUser.id, tenantId],
       );
+
+      if (sameTenantBinding && sameTenantBinding.deactivated_at === null && sameTenantBinding.entity_type) {
+        if (sameTenantBinding.entity_type !== 'vendor_contact' || sameTenantBinding.entity_id !== vendorContact.id) {
+          const err = new Error(
+            'A portal user with this email already has an active binding to this tenant. Resolve the existing binding before re-using the email.',
+          );
+          err.status = 409;
+          throw err;
+        }
+        // Idempotent re-provisioning: same vendor_contact already bound
+        // (the prior-binding branch should have caught this — defensive).
+        logger.info(`Re-provisioning hit existing matching binding for vendor_contact ${vendorContact.id}; no-op`);
+        return existingUser.id;
+      }
+
+      await db.tx(async (t) => {
+        if (existingUser.deactivated_at) {
+          await t.none(
+            `UPDATE admin.portal_users
+             SET deactivated_at = NULL, status = 'active', updated_by = $1
+             WHERE id = $2`,
+            [updatedBy, existingUser.id],
+          );
+        }
+
+        if (sameTenantBinding) {
+          // Either bare binding (entity_type NULL) or archived binding —
+          // upgrade in place to point at the vendor_contact.
+          await t.none(
+            `UPDATE admin.portal_user_tenants
+             SET deactivated_at = NULL,
+                 entity_type = 'vendor_contact',
+                 entity_id = $1,
+                 status = 'invited',
+                 updated_by = $2
+             WHERE id = $3`,
+            [vendorContact.id, updatedBy, sameTenantBinding.id],
+          );
+        } else {
+          await t.none(
+            `INSERT INTO admin.portal_user_tenants
+               (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+             VALUES ($1, $2, 'vendor_contact', $3, 'invited', $4)`,
+            [existingUser.id, tenantId, vendorContact.id, updatedBy],
+          );
+        }
+      });
+
       logger.info(`Bound existing portal_user ${existingUser.id} to vendor_contact ${vendorContact.id} (email match)`);
       return existingUser.id;
     }

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -332,15 +332,66 @@ class VendorContactsController extends BaseController {
   /* ── Private helpers ──────────────────────────────────── */
 
   /**
-   * Create or restore a portal_users + portal_user_tenants binding for a
-   * vendor_contact gaining app access. Vendors may end up with multiple
-   * bindings across tenants (Task 6 handles existing-email match → bind);
-   * here we just manage the per-tenant binding pair.
+   * Provision app-user access for a vendor_contact. Three cases per the
+   * Import Dedup & Multi-Tenant Vendor Access spec, Part 3:
+   *
+   *   1. A prior binding for this vendor_contact in this tenant exists —
+   *      restore it (and re-activate the portal_user if archived). The
+   *      portal_user's credentials are NOT reset; they belong to the
+   *      user, especially when they have other active bindings.
+   *   2. An active portal_user with this login email already exists —
+   *      bind that portal_user to this vendor_contact (status='invited').
+   *      Supplied password is ignored. The portal_user globally stays
+   *      active; only this binding is in invite state.
+   *   3. No match anywhere — create a new portal_users row plus binding
+   *      with the hashed temp password (or a generated one).
    */
   async #provisionAppUser(vendorContact, req, suppliedPassword, loginEmail) {
     const tenantId = req.user?.tenant_id;
     if (!tenantId) throw new Error('Tenant context required to provision app user');
+    const updatedBy = req.user?.id || null;
 
+    // ── Case 1: prior binding for THIS vendor_contact in this tenant ──
+    const priorBinding = await findAnyBinding('vendor_contact', vendorContact.id, tenantId);
+    if (priorBinding) {
+      await db.tx(async (t) => {
+        await t.none(
+          `UPDATE admin.portal_user_tenants
+           SET deactivated_at = NULL, status = 'active', updated_by = $1
+           WHERE id = $2`,
+          [updatedBy, priorBinding.id],
+        );
+        // If the portal_user itself was archived (e.g. when its last
+        // active binding got locked), reactivate it. Don't touch its
+        // credentials — they belong to the user.
+        await t.none(
+          `UPDATE admin.portal_users
+           SET deactivated_at = NULL, status = 'active', updated_by = $1
+           WHERE id = $2 AND deactivated_at IS NOT NULL`,
+          [updatedBy, priorBinding.portal_user_id],
+        );
+      });
+      logger.info(`Restored binding for vendor_contact ${vendorContact.id} → portal_user ${priorBinding.portal_user_id}`);
+      return priorBinding.portal_user_id;
+    }
+
+    // ── Case 2: existing portal_user with this email → bind, ignore password ──
+    const existingUser = await db.oneOrNone(
+      'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+      [loginEmail],
+    );
+    if (existingUser) {
+      await db.none(
+        `INSERT INTO admin.portal_user_tenants
+           (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+         VALUES ($1, $2, 'vendor_contact', $3, 'invited', $4)`,
+        [existingUser.id, tenantId, vendorContact.id, updatedBy],
+      );
+      logger.info(`Bound existing portal_user ${existingUser.id} to vendor_contact ${vendorContact.id} (email match)`);
+      return existingUser.id;
+    }
+
+    // ── Case 3: no match — create new portal_user + binding ────────────
     if (suppliedPassword) {
       const pwRules = [
         { test: (p) => p.length >= 8, msg: 'at least 8 characters' },
@@ -360,29 +411,6 @@ class VendorContactsController extends BaseController {
     const clearPassword = suppliedPassword || crypto.randomBytes(12).toString('base64url');
     const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
     const passwordHash = await bcrypt.hash(clearPassword, rounds);
-    const updatedBy = req.user?.id || null;
-
-    const priorBinding = await findAnyBinding('vendor_contact', vendorContact.id, tenantId);
-
-    if (priorBinding) {
-      await db.tx(async (t) => {
-        await t.none(
-          `UPDATE admin.portal_users
-           SET deactivated_at = NULL, status = 'invited',
-               password_hash = $1, email = $2, updated_by = $3
-           WHERE id = $4`,
-          [passwordHash, loginEmail, updatedBy, priorBinding.portal_user_id],
-        );
-        await t.none(
-          `UPDATE admin.portal_user_tenants
-           SET deactivated_at = NULL, status = 'active', updated_by = $1
-           WHERE id = $2`,
-          [updatedBy, priorBinding.id],
-        );
-      });
-      logger.info(`Restored portal_user ${priorBinding.portal_user_id} + binding for vendor_contact ${vendorContact.id}`);
-      return priorBinding.portal_user_id;
-    }
 
     const portalUserId = await db.tx(async (t) => {
       const user = await t.one(

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -546,7 +546,13 @@ class VendorContactsController extends BaseController {
   }
 
   /**
-   * Restore the portal_users + binding linked to a vendor contact.
+   * Restore the per-tenant binding for a vendor_contact.
+   *
+   * Only touches admin.portal_users when it is actually archived. If
+   * the portal_user is already active/invited via another tenant's
+   * binding, leave its global state alone — overwriting status='active'
+   * would clear a force-password-change ('invited') state that
+   * belongs to the user, not to this tenant's vendor_contact.
    */
   async #restoreAppUser(vendorContactId, req) {
     const binding = await db.oneOrNone(
@@ -562,7 +568,7 @@ class VendorContactsController extends BaseController {
       await t.none(
         `UPDATE admin.portal_users
          SET deactivated_at = NULL, status = 'active', updated_by = $1
-         WHERE id = $2`,
+         WHERE id = $2 AND deactivated_at IS NOT NULL`,
         [updatedBy, binding.portal_user_id],
       );
       await t.none(
@@ -572,7 +578,7 @@ class VendorContactsController extends BaseController {
         [updatedBy, binding.id],
       );
     });
-    logger.info(`Restored portal_user ${binding.portal_user_id} + binding for vendor_contact ${vendorContactId}`);
+    logger.info(`Restored binding for vendor_contact ${vendorContactId} → portal_user ${binding.portal_user_id}`);
   }
 }
 

--- a/apps/server/tests/contract/vendorContacts.test.js
+++ b/apps/server/tests/contract/vendorContacts.test.js
@@ -272,4 +272,114 @@ describe('Vendor Contact app-user provisioning — cross-tenant existing-email m
     expect(tenantBBinding).toBeDefined();
     expect(tenantBBinding.status).toBe('invited');
   });
+
+  test('Case 1: archive → re-provision restores binding without resetting credentials', async () => {
+    // Create a fresh vendor + vendor_contact in tenant A so we can
+    // archive/restore without disturbing the cross-tenant SHARED_EMAIL state.
+    const vendorRes = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesA)
+      .send({ name: 'Lifecycle Vendor', code: 'LCV01' });
+
+    const createRes = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorRes.body.id,
+        first_name: 'Lana',
+        last_name: 'Lifecycle',
+        email: 'lana.lifecycle@vendor.test',
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'OriginalPass123!',
+      });
+    expect(createRes.status).toBe(201);
+    const contactId = createRes.body.id;
+
+    const portalBefore = await db.one(
+      'SELECT id, email, password_hash, status FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+      ['lana.lifecycle@vendor.test'],
+    );
+
+    // Toggle is_app_user OFF — archives the binding (and the portal_user
+    // since this is the only binding for it).
+    const offRes = await request(app)
+      .put(`/api/core/v1/vendor-contacts/update?id=${contactId}`)
+      .set('Cookie', cookiesA)
+      .send({ is_app_user: false });
+    expect(offRes.status).toBe(200);
+
+    // Toggle is_app_user back ON with a different password and email
+    // — Case 1 should restore the binding and leave portal_user
+    // credentials alone.
+    const onRes = await request(app)
+      .put(`/api/core/v1/vendor-contacts/update?id=${contactId}`)
+      .set('Cookie', cookiesA)
+      .send({
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'IgnoredOnRestore123!',
+      });
+    expect(onRes.status).toBe(200);
+
+    const portalAfter = await db.one(
+      'SELECT email, password_hash, status FROM admin.portal_users WHERE id = $1',
+      [portalBefore.id],
+    );
+    // Binding restored, portal_user reactivated, credentials unchanged
+    expect(portalAfter.email).toBe(portalBefore.email);
+    expect(portalAfter.password_hash).toBe(portalBefore.password_hash);
+    expect(portalAfter.status).toBe('active');
+
+    const restoredBinding = await db.oneOrNone(
+      `SELECT status, deactivated_at FROM admin.portal_user_tenants
+       WHERE portal_user_id = $1 AND entity_id = $2`,
+      [portalBefore.id, contactId],
+    );
+    expect(restoredBinding).not.toBeNull();
+    expect(restoredBinding.deactivated_at).toBeNull();
+    expect(restoredBinding.status).toBe('active');
+  });
+
+  test('archiving a vendor_contact does NOT lock a portal_user that has other active bindings', async () => {
+    // SHARED_EMAIL portal_user has bindings in tenant A and tenant B
+    // (from the earlier two tests). Archive the tenant-B vendor_contact
+    // and confirm the portal_user stays active because the tenant-A
+    // binding is still alive.
+    const portal = await db.one(
+      'SELECT id, status FROM admin.portal_users WHERE email = $1',
+      [SHARED_EMAIL],
+    );
+    expect(portal.status).toBe('invited'); // still in initial invited state
+
+    const tenantBContact = await db.one(
+      `SELECT b.entity_id FROM admin.portal_user_tenants b
+       JOIN admin.tenants t ON t.id = b.tenant_id
+       WHERE b.portal_user_id = $1 AND t.tenant_code = 'VCTSTB' AND b.deactivated_at IS NULL`,
+      [portal.id],
+    );
+
+    const archiveRes = await request(app)
+      .delete(`/api/core/v1/vendor-contacts/archive?id=${tenantBContact.entity_id}`)
+      .set('Cookie', cookiesB)
+      .send({});
+    expect(archiveRes.status).toBe(200);
+
+    const portalAfter = await db.one(
+      'SELECT deactivated_at, status FROM admin.portal_users WHERE id = $1',
+      [portal.id],
+    );
+    // Portal_user remains active because the tenant-A binding is still alive
+    expect(portalAfter.deactivated_at).toBeNull();
+    expect(portalAfter.status).not.toBe('locked');
+
+    // The tenant-B binding itself is locked
+    const lockedBinding = await db.one(
+      `SELECT status, deactivated_at FROM admin.portal_user_tenants
+       WHERE portal_user_id = $1 AND entity_id = $2`,
+      [portal.id, tenantBContact.entity_id],
+    );
+    expect(lockedBinding.status).toBe('locked');
+    expect(lockedBinding.deactivated_at).not.toBeNull();
+  });
 });

--- a/apps/server/tests/contract/vendorContacts.test.js
+++ b/apps/server/tests/contract/vendorContacts.test.js
@@ -138,3 +138,132 @@ describe('Vendor Contact CRUD — /api/core/v1/vendor-contacts', () => {
     expect(source.table_id).toBe(contactId);
   });
 });
+
+describe('Vendor Contact app-user provisioning — cross-tenant existing-email match → bind', () => {
+  let cookiesA;
+  let cookiesB;
+  let vendorIdA;
+  let vendorIdB;
+  const SHARED_EMAIL = 'vera.shared@vendor.test';
+
+  beforeAll(async () => {
+    const rootCookies = await loginRoot();
+
+    // Tenant A reuses the VCTEST tenant from the prior describe.
+    const loginA = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@vctest.com', password: 'VctestPass123!' });
+    cookiesA = loginA.headers['set-cookie'];
+
+    // Provision a second tenant B for the cross-tenant bind case.
+    await request(app)
+      .post('/api/tenants/v1/tenants')
+      .set('Cookie', rootCookies)
+      .send({
+        tenant_code: 'VCTSTB',
+        company: 'Vendor Contact Test Corp B',
+        status: 'active',
+        tier: 'starter',
+        admin_first_name: 'B',
+        admin_last_name: 'Admin',
+        admin_email: 'admin@vctstb.com',
+        admin_password: 'VctstbPass123!',
+        billing_address: { address_line_1: '1 B St', country_code: 'US' },
+      });
+    const loginB = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@vctstb.com', password: 'VctstbPass123!' });
+    cookiesB = loginB.headers['set-cookie'];
+
+    const vendorA = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesA)
+      .send({ name: 'Bind Vendor A', code: 'BVEN' });
+    vendorIdA = vendorA.body.id;
+
+    const vendorB = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesB)
+      .send({ name: 'Bind Vendor B', code: 'BVENB' });
+    vendorIdB = vendorB.body.id;
+  }, 30000);
+
+  test('first vendor_contact in tenant A with new email creates portal_user + binding', async () => {
+    const res = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorIdA,
+        first_name: 'Vera',
+        last_name: 'Shared',
+        email: SHARED_EMAIL,
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'VendorPass123!',
+      });
+    expect(res.status).toBe(201);
+
+    const portal = await db.oneOrNone(
+      'SELECT id, status FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+      [SHARED_EMAIL],
+    );
+    expect(portal).not.toBeNull();
+    expect(portal.status).toBe('invited');
+
+    const binding = await db.oneOrNone(
+      `SELECT entity_type, entity_id, status FROM admin.portal_user_tenants
+       WHERE portal_user_id = $1 AND deactivated_at IS NULL`,
+      [portal.id],
+    );
+    expect(binding.entity_type).toBe('vendor_contact');
+    expect(binding.entity_id).toBe(res.body.id);
+    expect(binding.status).toBe('active');
+  });
+
+  test('second vendor_contact in tenant B with same email binds to the existing portal_user, status=invited, no new portal_user, password unchanged', async () => {
+    const before = await db.one(
+      'SELECT COUNT(*)::int AS count, MAX(password_hash) AS hash FROM admin.portal_users WHERE email = $1',
+      [SHARED_EMAIL],
+    );
+    expect(before.count).toBe(1);
+
+    const res = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesB)
+      .send({
+        vendor_id: vendorIdB,
+        first_name: 'Vera',
+        last_name: 'Shared',
+        email: SHARED_EMAIL,
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'AttemptedHijack123!',
+      });
+    expect(res.status).toBe(201);
+
+    // No new portal_users row was created
+    const after = await db.one(
+      'SELECT COUNT(*)::int AS count, MAX(password_hash) AS hash FROM admin.portal_users WHERE email = $1',
+      [SHARED_EMAIL],
+    );
+    expect(after.count).toBe(1);
+    // Supplied password was ignored — credentials unchanged
+    expect(after.hash).toBe(before.hash);
+
+    // The new tenant-B binding points at the existing portal_user with status='invited'
+    const portal = await db.one(
+      'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+      [SHARED_EMAIL],
+    );
+    const bindings = await db.any(
+      `SELECT entity_id, tenant_id, status FROM admin.portal_user_tenants
+       WHERE portal_user_id = $1 AND deactivated_at IS NULL
+       ORDER BY created_at ASC`,
+      [portal.id],
+    );
+    expect(bindings.length).toBe(2);
+    const tenantBBinding = bindings.find((b) => b.entity_id === res.body.id);
+    expect(tenantBBinding).toBeDefined();
+    expect(tenantBBinding.status).toBe('invited');
+  });
+});

--- a/apps/server/tests/contract/vendorContacts.test.js
+++ b/apps/server/tests/contract/vendorContacts.test.js
@@ -149,10 +149,16 @@ describe('Vendor Contact app-user provisioning — cross-tenant existing-email m
   beforeAll(async () => {
     const rootCookies = await loginRoot();
 
-    // Tenant A reuses the VCTEST tenant from the prior describe.
-    const loginA = await request(app)
+    // Tenant A: provision if not already (so this describe runs in isolation).
+    let loginA = await request(app)
       .post('/api/auth/login')
       .send({ email: 'admin@vctest.com', password: 'VctestPass123!' });
+    if (!loginA.headers['set-cookie']?.length) {
+      await provisionTenant(rootCookies);
+      loginA = await request(app)
+        .post('/api/auth/login')
+        .send({ email: 'admin@vctest.com', password: 'VctestPass123!' });
+    }
     cookiesA = loginA.headers['set-cookie'];
 
     // Provision a second tenant B for the cross-tenant bind case.


### PR DESCRIPTION
## Summary

Task 6 of the Import Dedup & Multi-Tenant Vendor Access plan. Vendor registration with a login email that already maps to an active \`portal_user\` now binds the existing portal_user to the new tenant rather than failing or duplicating credentials.

| Case | Behavior |
|---|---|
| Prior binding for this vendor_contact in this tenant | Restore the binding; reactivate \`portal_users\` if archived. Credentials left alone. |
| Active \`portal_user\` exists for this email | Insert a new \`portal_user_tenants\` row pointing at it, \`status='invited'\` for this binding only. **Supplied password ignored.** Portal_user globally stays as it was. |
| No match | Unchanged — create new \`portal_users\` row + binding with hashed temp password. |

Scope is \`vendorContactsController.#provisionAppUser\` only. Employees and clients keep the strict-collision behavior — the new global \`portal_users.email\` unique index rejects duplicates at the DB layer, matching the spec's "single-tenant entities cannot share login identity" rule.

## Notable behavior change

The prior-binding restore branch from Task 5 no longer rewrites \`portal_users.password_hash / email / status\` on restore. For multi-tenant vendors those columns belong to the user globally and shouldn't be mutated by another tenant's provisioning flow. The binding is unarchived; if the portal_user itself was archived (e.g. after losing its last active binding) it is reactivated, but credentials are left alone.

## Out of scope (future tasks)

- Notification hooks (Part 5) — deferred.
- Identity-swap on tenant-side email change — Task 7.
- Vendor self-service email change — Task 8.
- Password-change endpoint lockdown — Task 9.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm -w apps/server test\` — 499 / 499 (2 new contract tests for the cross-tenant bind case)
- [ ] Reviewer: confirm restore-without-credential-reset is the right call for multi-tenant vendors