### PR TITLE
feat: identity-swap on vendor_contact login email change (Task 7)

### DIFF
--- a/apps/client/src/hooks/useVendorContacts.js
+++ b/apps/client/src/hooks/useVendorContacts.js
@@ -65,3 +65,15 @@ export function useResetVendorContactPassword() {
     onSuccess: () => qc.invalidateQueries({ queryKey: VENDOR_CONTACTS_KEY }),
   });
 }
+
+export function useSwapVendorContactLoginEmail() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, new_email, password }) => vendorContactApi.swapLoginEmail(id, { new_email, password }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: VENDOR_CONTACTS_KEY });
+      qc.invalidateQueries({ queryKey: ['emails'] });
+      qc.invalidateQueries({ queryKey: ['portal-users'] });
+    },
+  });
+}

--- a/apps/client/src/pages/Core/VendorsPage.jsx
+++ b/apps/client/src/pages/Core/VendorsPage.jsx
@@ -489,8 +489,8 @@ export default function VendorsPage() {
           swapPending
             ? `This will transfer access for this tenant from ${swapPending.originalEmail} to ${swapPending.newEmail}. ` +
               `${swapPending.originalEmail} will lose access to this tenant. ` +
-              `If ${swapPending.newEmail} already has an Axerra account, that account will be linked. ` +
-              `Otherwise a new account is created with the supplied temporary password. Proceed?`
+              `If ${swapPending.newEmail} already has an Axerra account, that account will be linked and its existing password is kept. ` +
+              `Otherwise a new account is created with the password you supplied (or a generated one if none was provided). Proceed?`
             : ''
         }
         confirmLabel="Transfer access"

--- a/apps/client/src/pages/Core/VendorsPage.jsx
+++ b/apps/client/src/pages/Core/VendorsPage.jsx
@@ -40,7 +40,7 @@ import {
   useTaxIdentifiers, useCreateTaxIdentifier, useUpdateTaxIdentifier, useArchiveTaxIdentifier,
 } from '../../hooks/useTaxIdentifiers.js';
 import {
-  useVendorContacts, useCreateVendorContact, useUpdateVendorContact, useArchiveVendorContact, useRestoreVendorContact, useResetVendorContactPassword,
+  useVendorContacts, useCreateVendorContact, useUpdateVendorContact, useArchiveVendorContact, useRestoreVendorContact, useResetVendorContactPassword, useSwapVendorContactLoginEmail,
 } from '../../hooks/useVendorContacts.js';
 import { useImportXls, useExportXls } from '../../hooks/useImportExport.js';
 import { useActivePaymentTerms } from '../../hooks/usePaymentTerms.js';
@@ -126,6 +126,7 @@ export default function VendorsPage() {
   const archiveContactMut = useArchiveVendorContact();
   const restoreContactMut = useRestoreVendorContact();
   const resetContactPwMut = useResetVendorContactPassword();
+  const swapLoginEmailMut = useSwapVendorContactLoginEmail();
 
   /* ── Selection (new system) ─────────────────────────────────── */
   const selection = useListSelection(rows);
@@ -193,6 +194,7 @@ export default function VendorsPage() {
     contactEditOpen, contactEditForm, setContactEditForm, onContactEditField,
     contactEditEmails, setContactEditEmails, contactEditPhones, setContactEditPhones,
     contactEditRow, openContactEdit, handleContactEdit, closeContactEdit, updateContactLoading,
+    swapPending, confirmSwap, closeSwapConfirm, swapLoading,
     contactPwAnchor, handleContactAppUserToggle, handleContactPwConfirm, handleContactPwCancel,
     contactViewFilter, setContactViewFilter, filteredContacts,
     contactSelection, viewContactSelection,
@@ -218,6 +220,7 @@ export default function VendorsPage() {
     createPhoneMut,
     updatePhoneMut,
     archivePhoneMut,
+    swapLoginEmailMut,
   });
 
   /* ── Bundled close handlers ─────────────────────────────────── */
@@ -478,6 +481,24 @@ export default function VendorsPage() {
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
+
+      <ConfirmDialog
+        open={!!swapPending}
+        title="Transfer tenant access?"
+        message={
+          swapPending
+            ? `This will transfer access for this tenant from ${swapPending.originalEmail} to ${swapPending.newEmail}. ` +
+              `${swapPending.originalEmail} will lose access to this tenant. ` +
+              `If ${swapPending.newEmail} already has an Axerra account, that account will be linked. ` +
+              `Otherwise a new account is created with the supplied temporary password. Proceed?`
+            : ''
+        }
+        confirmLabel="Transfer access"
+        cancelLabel="Cancel"
+        loading={swapLoading}
+        onConfirm={confirmSwap}
+        onCancel={closeSwapConfirm}
+      />
 
       <ResetPasswordDialog
         open={resetPwDialog.isOpen}

--- a/apps/client/src/pages/Core/vendors/useVendorContactDialogs.js
+++ b/apps/client/src/pages/Core/vendors/useVendorContactDialogs.js
@@ -288,10 +288,16 @@ export function useVendorContactDialogs({
         && newLoginEm.email.trim().toLowerCase() !== originalLoginEmail.trim().toLowerCase();
 
       if (wasAppUser && stillAppUser && valueChanged && swapLoginEmailMut) {
-        // Defer the rest of the save — open the confirmation. The
-        // parent component renders the dialog and calls confirmSwap()
-        // on accept.
-        setSwapPending({ newEmail: newLoginEm.email, originalEmail: originalLoginEmail });
+        // Defer the rest of the save — open the confirmation. Capture
+        // the contact id and the password the user typed at this moment
+        // so confirmSwap doesn't depend on contactEditRow / contactEditForm
+        // staying mounted while the ConfirmDialog is open.
+        setSwapPending({
+          contactId: contactEditRow.id,
+          newEmail: newLoginEm.email,
+          originalEmail: originalLoginEmail,
+          password: contactEditForm.password || undefined,
+        });
         return;
       }
 
@@ -303,22 +309,30 @@ export function useVendorContactDialogs({
 
   const confirmSwap = useCallback(async () => {
     if (!swapPending || !swapLoginEmailMut) return;
+    if (!swapPending.contactId) {
+      setSwapPending(null);
+      return;
+    }
     try {
       await swapLoginEmailMut.mutateAsync({
-        id: contactEditRow.id,
+        id: swapPending.contactId,
         new_email: swapPending.newEmail,
-        password: contactEditForm.password || undefined,
+        password: swapPending.password,
       });
       setSwapPending(null);
       // After the swap, the tenant emails table already reflects the
       // new email, so the saveCollection re-send on the login-email
       // row is a no-op (server's guard is keyed on email value change).
-      await performContactEdit();
+      // performContactEdit only runs if the edit dialog is still open —
+      // if the user closed it mid-swap, skip the rest of the save.
+      if (contactEditRow?.id === swapPending.contactId) {
+        await performContactEdit();
+      }
     } catch (err) {
       setSwapPending(null);
       toast(errMsg(err), 'error');
     }
-  }, [swapPending, swapLoginEmailMut, contactEditRow, contactEditForm, performContactEdit, toast]);
+  }, [swapPending, swapLoginEmailMut, contactEditRow, performContactEdit, toast]);
 
   return {
     // Contact view
@@ -336,7 +350,12 @@ export function useVendorContactDialogs({
     contactEditEmails, setContactEditEmails,
     contactEditPhones, setContactEditPhones,
     contactEditRow, openContactEdit, handleContactEdit,
-    closeContactEdit: useCallback(() => { setContactEditOpen(false); setContactEditRow(null); }, []),
+    closeContactEdit: useCallback(() => {
+      setContactEditOpen(false);
+      setContactEditRow(null);
+      setOriginalLoginEmail(null);
+      setSwapPending(null);
+    }, []),
     updateContactLoading: updateContactMut.isPending,
     // Identity-swap on login-email change (Task 7)
     swapPending, confirmSwap, closeSwapConfirm,

--- a/apps/client/src/pages/Core/vendors/useVendorContactDialogs.js
+++ b/apps/client/src/pages/Core/vendors/useVendorContactDialogs.js
@@ -42,6 +42,10 @@ const BLANK_CONTACT_FORM = {
  * @param {object}   opts.createPhoneMut
  * @param {object}   opts.updatePhoneMut
  * @param {object}   opts.archivePhoneMut
+ * @param {object}   [opts.swapLoginEmailMut] Mutation for the identity-swap
+ *                   endpoint — required when editing app-user contacts so
+ *                   tenant admins can swap who has access to this tenant
+ *                   instead of mutating the global portal_user identity.
  */
 export function useVendorContactDialogs({
   editRow,
@@ -63,6 +67,7 @@ export function useVendorContactDialogs({
   createPhoneMut,
   updatePhoneMut,
   archivePhoneMut,
+  swapLoginEmailMut,
 }) {
   /* ── Tab filter ──────────────────────────────────────────────── */
   const [contactViewFilter, setContactViewFilter] = useState('active');
@@ -156,6 +161,11 @@ export function useVendorContactDialogs({
     setContactCreateOpen(true);
   }, [resetContactCreateForm]);
 
+  // Tracks the original login email so handleContactEdit can detect
+  // identity-swap intent (tenant admin changing the value of the
+  // is_login=true email row on an existing app-user contact).
+  const [originalLoginEmail, setOriginalLoginEmail] = useState(null);
+
   const openContactEdit = useCallback((row) => {
     setContactEditRow(row);
     setContactEditForm({
@@ -164,10 +174,17 @@ export function useVendorContactDialogs({
       is_app_user: row.is_app_user || false, roles: row.roles || [],
       password: '',
     });
-    setContactEditEmails([...(contactEmails[row.id] || [])]);
+    const emails = contactEmails[row.id] || [];
+    setContactEditEmails([...emails]);
     setContactEditPhones([...(contactPhones[row.id] || [])]);
+    const loginEm = emails.find((em) => em.is_login);
+    setOriginalLoginEmail(loginEm ? loginEm.email : null);
     setContactEditOpen(true);
   }, [contactEmails, contactPhones, setContactEditForm]);
+
+  /* ── Identity-swap pending state (Task 7) ─────────────────────── */
+  const [swapPending, setSwapPending] = useState(null); // { newEmail, originalEmail } | null
+  const closeSwapConfirm = useCallback(() => setSwapPending(null), []);
 
   /* ── Contact Create handler ──────────────────────────────────── */
   const handleContactCreate = useCallback(async () => {
@@ -219,43 +236,89 @@ export function useVendorContactDialogs({
   }, [contactCreateForm, contactCreateEmails, contactCreatePhones, editRow, editContacts, createContactMut, createEmailMut, createPhoneMut, toast, refreshContactChildren, resetContactCreateForm, setEditContacts]);
 
   /* ── Contact Edit handler ────────────────────────────────────── */
+  // Pulled out so the swap-confirmation flow can re-enter it after the
+  // user accepts the identity-swap warning.
+  const performContactEdit = useCallback(async () => {
+    const changes = {
+      first_name: contactEditForm.first_name, last_name: contactEditForm.last_name,
+      position: contactEditForm.position, department: contactEditForm.department,
+      is_app_user: contactEditForm.is_app_user, roles: contactEditForm.roles,
+      ...(contactEditForm.password && { password: contactEditForm.password }),
+    };
+    if (changes.is_app_user && !contactEditRow?.is_app_user) {
+      const loginEm = contactEditEmails.find((em) => em.is_login && !em._deleted)
+        || contactEditEmails.find((em) => em.is_primary && !em._deleted)
+        || contactEditEmails.find((em) => !em._deleted);
+      if (loginEm) changes.email = loginEm.email;
+    }
+    await updateContactMut.mutateAsync({ filter: { id: contactEditRow.id }, changes });
+
+    const sid = contactEditRow.source_id;
+    await saveCollection(contactEditEmails, {
+      sourceId: sid, fields: EMAIL_LOGIN_FIELDS,
+      createMut: createEmailMut.mutateAsync, updateMut: updateEmailMut.mutateAsync, archiveMut: archiveEmailMut.mutateAsync,
+    });
+    await saveCollection(contactEditPhones, {
+      sourceId: sid, fields: PHONE_FIELDS,
+      createMut: createPhoneMut.mutateAsync, updateMut: updatePhoneMut.mutateAsync, archiveMut: archivePhoneMut.mutateAsync,
+    });
+
+    await refreshContactChildren();
+    if (contactEditForm.is_app_user !== contactEditRow?.is_app_user) {
+      qc.invalidateQueries({ queryKey: ['portal-users'] });
+    }
+    setContactEditOpen(false);
+    setContactEditRow(null);
+    toast('Contact updated');
+  }, [contactEditRow, contactEditForm, contactEditEmails, contactEditPhones, updateContactMut, createEmailMut, updateEmailMut, archiveEmailMut, createPhoneMut, updatePhoneMut, archivePhoneMut, qc, toast, refreshContactChildren]);
+
   const handleContactEdit = useCallback(async () => {
     try {
-      const changes = {
-        first_name: contactEditForm.first_name, last_name: contactEditForm.last_name,
-        position: contactEditForm.position, department: contactEditForm.department,
-        is_app_user: contactEditForm.is_app_user, roles: contactEditForm.roles,
-        ...(contactEditForm.password && { password: contactEditForm.password }),
-      };
-      if (changes.is_app_user && !contactEditRow?.is_app_user) {
-        const loginEm = contactEditEmails.find((em) => em.is_login && !em._deleted)
-          || contactEditEmails.find((em) => em.is_primary && !em._deleted)
-          || contactEditEmails.find((em) => !em._deleted);
-        if (loginEm) changes.email = loginEm.email;
-      }
-      await updateContactMut.mutateAsync({ filter: { id: contactEditRow.id }, changes });
+      // Identity-swap detection (Task 7): if an app-user contact's
+      // is_login email value changed, route through the swap endpoint
+      // before any other email/phone writes. Without this, updateEmail
+      // on the login row returns 400 from the server-side guard.
+      const wasAppUser = !!contactEditRow?.is_app_user;
+      const stillAppUser = !!contactEditForm.is_app_user;
+      const newLoginEm = contactEditEmails.find((em) => em.is_login && !em._deleted);
+      const valueChanged =
+        newLoginEm
+        && originalLoginEmail
+        && newLoginEm.email
+        && newLoginEm.email.trim().toLowerCase() !== originalLoginEmail.trim().toLowerCase();
 
-      const sid = contactEditRow.source_id;
-      await saveCollection(contactEditEmails, {
-        sourceId: sid, fields: EMAIL_LOGIN_FIELDS,
-        createMut: createEmailMut.mutateAsync, updateMut: updateEmailMut.mutateAsync, archiveMut: archiveEmailMut.mutateAsync,
-      });
-      await saveCollection(contactEditPhones, {
-        sourceId: sid, fields: PHONE_FIELDS,
-        createMut: createPhoneMut.mutateAsync, updateMut: updatePhoneMut.mutateAsync, archiveMut: archivePhoneMut.mutateAsync,
-      });
-
-      await refreshContactChildren();
-      if (contactEditForm.is_app_user !== contactEditRow?.is_app_user) {
-        qc.invalidateQueries({ queryKey: ['portal-users'] });
+      if (wasAppUser && stillAppUser && valueChanged && swapLoginEmailMut) {
+        // Defer the rest of the save — open the confirmation. The
+        // parent component renders the dialog and calls confirmSwap()
+        // on accept.
+        setSwapPending({ newEmail: newLoginEm.email, originalEmail: originalLoginEmail });
+        return;
       }
-      setContactEditOpen(false);
-      setContactEditRow(null);
-      toast('Contact updated');
+
+      await performContactEdit();
     } catch (err) {
       toast(errMsg(err), 'error');
     }
-  }, [contactEditRow, contactEditForm, contactEditEmails, contactEditPhones, updateContactMut, createEmailMut, updateEmailMut, archiveEmailMut, createPhoneMut, updatePhoneMut, archivePhoneMut, qc, toast, refreshContactChildren]);
+  }, [contactEditRow, contactEditForm, contactEditEmails, originalLoginEmail, swapLoginEmailMut, performContactEdit, toast]);
+
+  const confirmSwap = useCallback(async () => {
+    if (!swapPending || !swapLoginEmailMut) return;
+    try {
+      await swapLoginEmailMut.mutateAsync({
+        id: contactEditRow.id,
+        new_email: swapPending.newEmail,
+        password: contactEditForm.password || undefined,
+      });
+      setSwapPending(null);
+      // After the swap, the tenant emails table already reflects the
+      // new email, so the saveCollection re-send on the login-email
+      // row is a no-op (server's guard is keyed on email value change).
+      await performContactEdit();
+    } catch (err) {
+      setSwapPending(null);
+      toast(errMsg(err), 'error');
+    }
+  }, [swapPending, swapLoginEmailMut, contactEditRow, contactEditForm, performContactEdit, toast]);
 
   return {
     // Contact view
@@ -275,6 +338,9 @@ export function useVendorContactDialogs({
     contactEditRow, openContactEdit, handleContactEdit,
     closeContactEdit: useCallback(() => { setContactEditOpen(false); setContactEditRow(null); }, []),
     updateContactLoading: updateContactMut.isPending,
+    // Identity-swap on login-email change (Task 7)
+    swapPending, confirmSwap, closeSwapConfirm,
+    swapLoading: !!swapLoginEmailMut?.isPending,
     // Password popover
     contactPwAnchor, handleContactAppUserToggle, handleContactPwConfirm, handleContactPwCancel,
     // Contact list

--- a/apps/client/src/services/vendorContactApi.js
+++ b/apps/client/src/services/vendorContactApi.js
@@ -24,6 +24,7 @@ export const vendorContactApi = {
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
   resetPassword: (id, password) => client.post(`${BASE}/${id}/reset-password`, { password }),
+  swapLoginEmail: (id, payload) => client.put(`${BASE}/${id}/swap-login-email`, payload),
   importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };

--- a/apps/server/src/system/core/apiRoutes/v1/vendorContactsRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/vendorContactsRouter.js
@@ -25,6 +25,14 @@ export default createRouter(
       rbac('full'),
       (req, res) => vendorContactsController.resetPassword(req, res),
     );
+    router.put(
+      '/:id/swap-login-email',
+      withMeta({ module: 'core', router: 'vendor-contacts', action: 'swap-login-email' }),
+      moduleEntitlement,
+      addAuditFields,
+      rbac('full'),
+      (req, res) => vendorContactsController.swapLoginEmail(req, res),
+    );
   },
   {
     getMiddlewares: [meta],

--- a/apps/server/src/system/core/controllers/emailsController.js
+++ b/apps/server/src/system/core/controllers/emailsController.js
@@ -75,6 +75,25 @@ class EmailsController extends BaseController {
       const before = await this.model(schema).findById(emailId);
       if (!before) return res.status(404).json({ error: `${this.errorLabel} not found` });
 
+      // Identity-swap guard: changing the email value of a vendor_contact's
+      // login email is treated as transferring tenant access from one
+      // portal_user to another (Task 7 spec). Reject the direct edit and
+      // direct callers to /api/core/v1/vendor-contacts/:id/swap-login-email
+      // so the explicit confirmation + swap flow runs.
+      if (req.body.email && req.body.email !== before.email && before.is_login) {
+        const s = pgp.as.name(schema);
+        const source = await db.oneOrNone(
+          `SELECT source_type FROM ${s}.sources WHERE id = $1 AND deactivated_at IS NULL`,
+          [before.source_id],
+        );
+        if (source?.source_type === 'vendor_contact') {
+          return res.status(400).json({
+            error:
+              'Changing a vendor contact login email is an identity swap. Use PUT /api/core/v1/vendor-contacts/:id/swap-login-email so the access transfer is explicit.',
+          });
+        }
+      }
+
       // If setting is_login to true, check no other login email exists
       if (req.body.is_login && !before.is_login) {
         const existing = await this.model(schema).findOneBy([{

--- a/apps/server/src/system/core/controllers/emailsController.js
+++ b/apps/server/src/system/core/controllers/emailsController.js
@@ -83,13 +83,15 @@ class EmailsController extends BaseController {
       if (req.body.email && req.body.email !== before.email && before.is_login) {
         const s = pgp.as.name(schema);
         const source = await db.oneOrNone(
-          `SELECT source_type FROM ${s}.sources WHERE id = $1 AND deactivated_at IS NULL`,
+          `SELECT source_type, table_id FROM ${s}.sources WHERE id = $1 AND deactivated_at IS NULL`,
           [before.source_id],
         );
         if (source?.source_type === 'vendor_contact') {
           return res.status(400).json({
-            error:
-              'Changing a vendor contact login email is an identity swap. Use PUT /api/core/v1/vendor-contacts/:id/swap-login-email so the access transfer is explicit.',
+            error: 'Changing a vendor contact login email is an identity swap.',
+            code: 'VENDOR_CONTACT_LOGIN_EMAIL_SWAP_REQUIRED',
+            vendor_contact_id: source.table_id,
+            swap_endpoint: `/api/core/v1/vendor-contacts/${source.table_id}/swap-login-email`,
           });
         }
       }

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -360,11 +360,16 @@ class VendorContactsController extends BaseController {
   async swapLoginEmail(req, res) {
     const contactId = req.params.id;
     const tenantId = req.user?.tenant_id;
-    const { new_email, password: suppliedPassword } = req.body || {};
+    const { new_email: rawEmail, password: suppliedPassword } = req.body || {};
 
-    if (!new_email || typeof new_email !== 'string') {
+    if (!rawEmail || typeof rawEmail !== 'string') {
       return res.status(400).json({ error: 'new_email is required' });
     }
+    // Normalise email to lowercase up-front: portal_users.email is varchar
+    // with a case-sensitive partial unique index, so without normalisation
+    // 'Vera@x.com' and 'vera@x.com' could create duplicate active rows
+    // and the lookup below would miss an existing user with different casing.
+    const new_email = rawEmail.trim().toLowerCase();
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(new_email)) {
       return res.status(400).json({ error: 'new_email is not a valid email address' });
     }
@@ -408,23 +413,36 @@ class VendorContactsController extends BaseController {
         [contact.source_id],
       );
 
-      if (loginEmailRow && loginEmailRow.email.toLowerCase() === new_email.toLowerCase()) {
+      if (loginEmailRow && loginEmailRow.email.toLowerCase() === new_email) {
         return res.status(400).json({ error: 'new_email matches the current login email — nothing to swap' });
       }
 
-      // 2. Look up new_email in admin.portal_users (active first, archived fallback).
+      const previousPortalUserId = currentBinding.portal_user_id;
+      let newPortalUserId;
+
+      // 2. Look up new_email in admin.portal_users (active first, archived
+      // fallback). Case-insensitive match defends against pre-normalisation
+      // rows that may exist with mixed casing.
       const matchedUser = await db.oneOrNone(
         `SELECT id, deactivated_at FROM admin.portal_users
-         WHERE email = $1
+         WHERE LOWER(email) = $1
          ORDER BY deactivated_at IS NULL DESC, deactivated_at DESC NULLS FIRST
          LIMIT 1`,
         [new_email],
       );
 
-      let newPortalUserId;
-      const previousPortalUserId = currentBinding.portal_user_id;
+      // The match could be the same portal_user already bound to this
+      // contact in this tenant — a real swap requires a different identity.
+      // Refuse with 400 so the caller doesn't accidentally downgrade their
+      // own binding to status='invited'.
+      if (matchedUser?.id === previousPortalUserId) {
+        return res.status(400).json({
+          error:
+            'new_email belongs to the same portal user already bound to this contact. Update the tenant login-email row directly if it is out of sync.',
+        });
+      }
 
-      await db.tx(async (t) => {
+      const runSwap = () => db.tx(async (t) => {
         // 3. Deactivate the current binding — old portal_user loses tenant access.
         await t.none(
           `UPDATE admin.portal_user_tenants
@@ -526,6 +544,68 @@ class VendorContactsController extends BaseController {
         }
       });
 
+      let usedMatchPath = !!matchedUser;
+      try {
+        await runSwap();
+      } catch (err) {
+        // Concurrent insert race: between the lookup and our INSERT into
+        // admin.portal_users, another request may have created a row with
+        // this email. Re-lookup once and retry through the match path.
+        const isUniqueViolation = err.code === '23505' && /portal_users.*email/i.test(err.constraint || err.detail || '');
+        if (!isUniqueViolation) throw err;
+        const racedUser = await db.oneOrNone(
+          `SELECT id, deactivated_at FROM admin.portal_users WHERE LOWER(email) = $1 LIMIT 1`,
+          [new_email],
+        );
+        if (!racedUser) throw err;
+        if (racedUser.id === previousPortalUserId) {
+          return res.status(400).json({
+            error:
+              'Concurrent update produced a portal_user that is already bound to this contact. Please try again.',
+          });
+        }
+        // Reuse the match path — rebuild the matched-user state. Note: the
+        // failed first attempt already rolled back, so the current binding
+        // is still active; runSwap will deactivate it on retry.
+        const retried = await db.tx(async (t) => {
+          await t.none(
+            `UPDATE admin.portal_user_tenants
+             SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+             WHERE id = $2`,
+            [updatedBy, currentBinding.id],
+          );
+          if (racedUser.deactivated_at) {
+            await t.none(
+              `UPDATE admin.portal_users
+               SET deactivated_at = NULL, status = 'active', updated_by = $1
+               WHERE id = $2 AND deactivated_at IS NOT NULL`,
+              [updatedBy, racedUser.id],
+            );
+          }
+          await t.none(
+            `INSERT INTO admin.portal_user_tenants
+               (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+             VALUES ($1, $2, 'vendor_contact', $3, 'invited', $4)`,
+            [racedUser.id, tenantId, contact.id, updatedBy],
+          );
+          if (loginEmailRow) {
+            await t.none(
+              `UPDATE ${s}.emails SET email = $1, updated_by = $2 WHERE id = $3`,
+              [new_email, updatedBy, loginEmailRow.id],
+            );
+          } else {
+            await t.none(
+              `INSERT INTO ${s}.emails (tenant_id, source_id, email, label, is_primary, is_login, created_by)
+               VALUES ($1, $2, $3, 'work', true, true, $4)`,
+              [tenantId, contact.source_id, new_email, updatedBy],
+            );
+          }
+          return racedUser.id;
+        });
+        newPortalUserId = retried;
+        usedMatchPath = true;
+      }
+
       logger.info(
         `Identity swap on vendor_contact ${contactId} in tenant ${tenantId}: ` +
           `portal_user ${previousPortalUserId} → ${newPortalUserId} ` +
@@ -536,7 +616,7 @@ class VendorContactsController extends BaseController {
         message: 'Login email swapped',
         previous_portal_user_id: previousPortalUserId,
         portal_user_id: newPortalUserId,
-        matched_existing: !!matchedUser,
+        matched_existing: usedMatchPath,
       });
     } catch (err) {
       if (err.status) return res.status(err.status).json({ error: err.message });

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -329,6 +329,221 @@ class VendorContactsController extends BaseController {
     }
   }
 
+  /**
+   * PUT /:id/swap-login-email — identity-swap semantics for tenant admins.
+   *
+   * Per the Import Dedup & Multi-Tenant Vendor Access spec (Part 3), changing
+   * a vendor_contact's login email by a tenant admin is treated as
+   * "transfer access to this tenant from one identity to another", NOT as
+   * "edit this person's email."
+   *
+   * Flow (in a single transaction):
+   *   1. Look up the current active binding for (vendor_contact, this tenant).
+   *   2. Look up new_email in admin.portal_users (active or archived).
+   *   3. Deactivate the current binding (the previous portal_user loses
+   *      access to this tenant; their global identity is preserved and
+   *      may still be active in other tenants).
+   *   4a. Match found → upgrade or insert a binding for the matched
+   *       portal_user with status='invited'. Reactivate that user if
+   *       archived. Supplied password is ignored.
+   *   4b. No match → create a new portal_users row with new_email + temp
+   *       password (or one supplied), then create a binding.
+   *   5. Update the vendor_contact's tenant-scoped login email row to the
+   *      new email so the tenant data view stays consistent.
+   *
+   * The previous portal_user may end up with no active bindings; they are
+   * NOT auto-archived — Task 12's orphan-portal_users maintenance API
+   * cleans those up explicitly.
+   *
+   * Body: { new_email, password? }
+   */
+  async swapLoginEmail(req, res) {
+    const contactId = req.params.id;
+    const tenantId = req.user?.tenant_id;
+    const { new_email, password: suppliedPassword } = req.body || {};
+
+    if (!new_email || typeof new_email !== 'string') {
+      return res.status(400).json({ error: 'new_email is required' });
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(new_email)) {
+      return res.status(400).json({ error: 'new_email is not a valid email address' });
+    }
+
+    if (suppliedPassword) {
+      const pwRules = [
+        { test: (p) => p.length >= 8, msg: 'at least 8 characters' },
+        { test: (p) => /[A-Z]/.test(p), msg: 'an uppercase letter' },
+        { test: (p) => /[a-z]/.test(p), msg: 'a lowercase letter' },
+        { test: (p) => /[0-9]/.test(p), msg: 'a digit' },
+        { test: (p) => /[^A-Za-z0-9]/.test(p), msg: 'a special character' },
+      ];
+      const failures = pwRules.filter((r) => !r.test(suppliedPassword)).map((r) => r.msg);
+      if (failures.length) {
+        return res.status(400).json({ error: `Password must contain ${failures.join(', ')}` });
+      }
+    }
+
+    const schema = this.getSchema(req);
+    const s = pgp.as.name(schema);
+    const updatedBy = req.user?.id || null;
+
+    try {
+      // 1. Resolve current active binding
+      const currentBinding = await findActiveBinding('vendor_contact', contactId, tenantId);
+      if (!currentBinding) {
+        return res.status(400).json({ error: 'Vendor contact has no active app-user binding to swap' });
+      }
+
+      // Lookup current contact for source_id
+      const contact = await db.oneOrNone(
+        `SELECT id, source_id FROM ${s}.vendor_contacts WHERE id = $1 AND deactivated_at IS NULL`,
+        [contactId],
+      );
+      if (!contact) return res.status(404).json({ error: 'Vendor contact not found' });
+
+      // Locate the existing login-email row in the tenant schema
+      const loginEmailRow = await db.oneOrNone(
+        `SELECT id, email FROM ${s}.emails
+         WHERE source_id = $1 AND is_login = true AND deactivated_at IS NULL`,
+        [contact.source_id],
+      );
+
+      if (loginEmailRow && loginEmailRow.email.toLowerCase() === new_email.toLowerCase()) {
+        return res.status(400).json({ error: 'new_email matches the current login email — nothing to swap' });
+      }
+
+      // 2. Look up new_email in admin.portal_users (active first, archived fallback).
+      const matchedUser = await db.oneOrNone(
+        `SELECT id, deactivated_at FROM admin.portal_users
+         WHERE email = $1
+         ORDER BY deactivated_at IS NULL DESC, deactivated_at DESC NULLS FIRST
+         LIMIT 1`,
+        [new_email],
+      );
+
+      let newPortalUserId;
+      const previousPortalUserId = currentBinding.portal_user_id;
+
+      await db.tx(async (t) => {
+        // 3. Deactivate the current binding — old portal_user loses tenant access.
+        await t.none(
+          `UPDATE admin.portal_user_tenants
+           SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+           WHERE id = $2`,
+          [updatedBy, currentBinding.id],
+        );
+
+        if (matchedUser) {
+          // 4a. Reactivate the matched portal_user if archived; do not
+          // touch credentials.
+          if (matchedUser.deactivated_at) {
+            await t.none(
+              `UPDATE admin.portal_users
+               SET deactivated_at = NULL, status = 'active', updated_by = $1
+               WHERE id = $2 AND deactivated_at IS NOT NULL`,
+              [updatedBy, matchedUser.id],
+            );
+          }
+
+          // Find any pre-existing binding for (matched user, this tenant)
+          // — bare bindings get upgraded; entity bindings collide loudly;
+          // archived rows: insert a new active binding alongside.
+          const sameTenantBinding = await t.oneOrNone(
+            `SELECT id, entity_type, entity_id, deactivated_at
+             FROM admin.portal_user_tenants
+             WHERE portal_user_id = $1 AND tenant_id = $2
+             ORDER BY deactivated_at IS NULL DESC, created_at DESC
+             LIMIT 1`,
+            [matchedUser.id, tenantId],
+          );
+
+          if (sameTenantBinding && sameTenantBinding.deactivated_at === null && sameTenantBinding.entity_type) {
+            const err = new Error(
+              'A portal user with the new email already has an active binding to this tenant. Resolve it before swapping.',
+            );
+            err.status = 409;
+            throw err;
+          }
+
+          const canUpgradeInPlace =
+            sameTenantBinding
+            && (sameTenantBinding.entity_type === null
+              || (sameTenantBinding.entity_type === 'vendor_contact' && sameTenantBinding.entity_id === contact.id));
+
+          if (canUpgradeInPlace) {
+            await t.none(
+              `UPDATE admin.portal_user_tenants
+               SET deactivated_at = NULL,
+                   entity_type = 'vendor_contact',
+                   entity_id = $1,
+                   status = 'invited',
+                   updated_by = $2
+               WHERE id = $3`,
+              [contact.id, updatedBy, sameTenantBinding.id],
+            );
+          } else {
+            await t.none(
+              `INSERT INTO admin.portal_user_tenants
+                 (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+               VALUES ($1, $2, 'vendor_contact', $3, 'invited', $4)`,
+              [matchedUser.id, tenantId, contact.id, updatedBy],
+            );
+          }
+          newPortalUserId = matchedUser.id;
+        } else {
+          // 4b. No match — create new portal_user + binding
+          const clearPassword = suppliedPassword || crypto.randomBytes(12).toString('base64url');
+          const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
+          const passwordHash = await bcrypt.hash(clearPassword, rounds);
+          const newUser = await t.one(
+            `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
+             VALUES ($1, $2, 'invited', $3)
+             RETURNING id`,
+            [new_email, passwordHash, updatedBy],
+          );
+          await t.none(
+            `INSERT INTO admin.portal_user_tenants
+               (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+             VALUES ($1, $2, 'vendor_contact', $3, 'invited', $4)`,
+            [newUser.id, tenantId, contact.id, updatedBy],
+          );
+          newPortalUserId = newUser.id;
+        }
+
+        // 5. Update the tenant-scoped login email row so the tenant data view stays consistent.
+        if (loginEmailRow) {
+          await t.none(
+            `UPDATE ${s}.emails SET email = $1, updated_by = $2 WHERE id = $3`,
+            [new_email, updatedBy, loginEmailRow.id],
+          );
+        } else {
+          // Defensive: no login email row — create one
+          await t.none(
+            `INSERT INTO ${s}.emails (tenant_id, source_id, email, label, is_primary, is_login, created_by)
+             VALUES ($1, $2, $3, 'work', true, true, $4)`,
+            [tenantId, contact.source_id, new_email, updatedBy],
+          );
+        }
+      });
+
+      logger.info(
+        `Identity swap on vendor_contact ${contactId} in tenant ${tenantId}: ` +
+          `portal_user ${previousPortalUserId} → ${newPortalUserId} ` +
+          `(by user ${updatedBy ?? 'unknown'})`,
+      );
+
+      res.json({
+        message: 'Login email swapped',
+        previous_portal_user_id: previousPortalUserId,
+        portal_user_id: newPortalUserId,
+        matched_existing: !!matchedUser,
+      });
+    } catch (err) {
+      if (err.status) return res.status(err.status).json({ error: err.message });
+      this.handleError(err, res, 'swapping login email for', this.errorLabel);
+    }
+  }
+
   /* ── Private helpers ──────────────────────────────────── */
 
   /**

--- a/apps/server/tests/contract/vendorContacts.test.js
+++ b/apps/server/tests/contract/vendorContacts.test.js
@@ -341,6 +341,187 @@ describe('Vendor Contact app-user provisioning — cross-tenant existing-email m
     expect(restoredBinding.status).toBe('active');
   });
 
+  test('swap-login-email (no match) deactivates current binding and creates new portal_user', async () => {
+    const vendorRes = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesA)
+      .send({ name: 'Swap Vendor NoMatch', code: 'SWAP1' });
+
+    const contactRes = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorRes.body.id,
+        first_name: 'Swap',
+        last_name: 'Original',
+        email: 'swap.original@vendor.test',
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'OriginalPass123!',
+      });
+    expect(contactRes.status).toBe(201);
+    const contactId = contactRes.body.id;
+
+    const bindingBefore = await db.one(
+      `SELECT b.portal_user_id FROM admin.portal_user_tenants b
+       JOIN admin.portal_users pu ON pu.id = b.portal_user_id
+       WHERE b.entity_type = 'vendor_contact' AND b.entity_id = $1 AND b.deactivated_at IS NULL`,
+      [contactId],
+    );
+
+    const swapRes = await request(app)
+      .put(`/api/core/v1/vendor-contacts/${contactId}/swap-login-email`)
+      .set('Cookie', cookiesA)
+      .send({ new_email: 'swap.replacement@vendor.test', password: 'NewPersonPass123!' });
+    expect(swapRes.status).toBe(200);
+    expect(swapRes.body.matched_existing).toBe(false);
+    expect(swapRes.body.previous_portal_user_id).toBe(bindingBefore.portal_user_id);
+    expect(swapRes.body.portal_user_id).not.toBe(bindingBefore.portal_user_id);
+
+    // Old binding archived; new active binding points at the new portal_user
+    const oldBinding = await db.one(
+      'SELECT deactivated_at, status FROM admin.portal_user_tenants WHERE portal_user_id = $1 AND entity_id = $2',
+      [bindingBefore.portal_user_id, contactId],
+    );
+    expect(oldBinding.deactivated_at).not.toBeNull();
+    expect(oldBinding.status).toBe('locked');
+
+    const newBinding = await db.one(
+      `SELECT pu.email, b.status FROM admin.portal_user_tenants b
+       JOIN admin.portal_users pu ON pu.id = b.portal_user_id
+       WHERE b.entity_id = $1 AND b.deactivated_at IS NULL`,
+      [contactId],
+    );
+    expect(newBinding.email).toBe('swap.replacement@vendor.test');
+    expect(newBinding.status).toBe('invited');
+  });
+
+  test('swap-login-email (match) deactivates current binding and binds existing portal_user', async () => {
+    // Seed a portal_user we can match against
+    const seedVendor = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesB)
+      .send({ name: 'Swap Match Seed Vendor', code: 'SWAPMS' });
+    await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesB)
+      .send({
+        vendor_id: seedVendor.body.id,
+        first_name: 'Match',
+        last_name: 'Seed',
+        email: 'match.target@vendor.test',
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'SeedPass123!',
+      });
+    const seedUser = await db.one(
+      'SELECT id, password_hash FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+      ['match.target@vendor.test'],
+    );
+
+    // Create a vendor + contact in tenant A whose login we'll swap to the seeded email
+    const vendorRes = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesA)
+      .send({ name: 'Swap Match Vendor', code: 'SWAP2' });
+    const contactRes = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorRes.body.id,
+        first_name: 'Match',
+        last_name: 'Subject',
+        email: 'match.subject@vendor.test',
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'SubjectPass123!',
+      });
+    const contactId = contactRes.body.id;
+
+    const swapRes = await request(app)
+      .put(`/api/core/v1/vendor-contacts/${contactId}/swap-login-email`)
+      .set('Cookie', cookiesA)
+      .send({ new_email: 'match.target@vendor.test', password: 'IgnoredOnMatch123!' });
+    expect(swapRes.status).toBe(200);
+    expect(swapRes.body.matched_existing).toBe(true);
+    expect(swapRes.body.portal_user_id).toBe(seedUser.id);
+
+    // Seeded portal_user's password_hash unchanged
+    const seedAfter = await db.one(
+      'SELECT password_hash FROM admin.portal_users WHERE id = $1',
+      [seedUser.id],
+    );
+    expect(seedAfter.password_hash).toBe(seedUser.password_hash);
+
+    // Tenant A binding now points at the seeded portal_user with status='invited'
+    const newBinding = await db.one(
+      `SELECT b.portal_user_id, b.status FROM admin.portal_user_tenants b
+       WHERE b.entity_id = $1 AND b.deactivated_at IS NULL`,
+      [contactId],
+    );
+    expect(newBinding.portal_user_id).toBe(seedUser.id);
+    expect(newBinding.status).toBe('invited');
+  });
+
+  test('swap-login-email refuses when same email supplied', async () => {
+    const vendorRes = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesA)
+      .send({ name: 'Swap Same', code: 'SWAP3' });
+    const contactRes = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorRes.body.id,
+        first_name: 'Same',
+        last_name: 'Email',
+        email: 'same.email@vendor.test',
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'SamePass123!',
+      });
+
+    const swapRes = await request(app)
+      .put(`/api/core/v1/vendor-contacts/${contactRes.body.id}/swap-login-email`)
+      .set('Cookie', cookiesA)
+      .send({ new_email: 'same.email@vendor.test' });
+    expect(swapRes.status).toBe(400);
+    expect(swapRes.body.error).toMatch(/nothing to swap/i);
+  });
+
+  test('emailsController rejects direct edits to vendor_contact login email', async () => {
+    const vendorRes = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesA)
+      .send({ name: 'Direct Edit Block', code: 'DIRBL' });
+    const contactRes = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorRes.body.id,
+        first_name: 'Direct',
+        last_name: 'Block',
+        email: 'direct.block@vendor.test',
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'DirectBlockPass123!',
+      });
+
+    // Find the login email row id
+    const emailsList = await request(app)
+      .get(`/api/core/v1/emails?source_id=${contactRes.body.source_id}`)
+      .set('Cookie', cookiesA);
+    const loginEmail = (emailsList.body.rows ?? emailsList.body).find((e) => e.is_login);
+    expect(loginEmail).toBeDefined();
+
+    const updateRes = await request(app)
+      .put(`/api/core/v1/emails/update?id=${loginEmail.id}`)
+      .set('Cookie', cookiesA)
+      .send({ email: 'direct.attempt@vendor.test' });
+    expect(updateRes.status).toBe(400);
+    expect(updateRes.body.error).toMatch(/identity swap|swap-login-email/i);
+  });
+
   test('archiving a vendor_contact does NOT lock a portal_user that has other active bindings', async () => {
     // SHARED_EMAIL portal_user has bindings in tenant A and tenant B
     // (from the earlier two tests). Archive the tenant-B vendor_contact


### PR DESCRIPTION
## Summary

Task 7 of the Import Dedup & Multi-Tenant Vendor Access plan. When a tenant admin changes a vendor_contact's login email, the operation is now treated as **transferring tenant access between identities** rather than as editing the person's email globally — matching the spec's "identity swap" semantics.

The risk this addresses: a vendor's portal_user can be bound to many tenants. Before this PR, the existing emails-table edit + \`#syncLoginEmail\` propagation would mutate the global \`portal_users.email\` from one tenant's UI, leaking the change to every other tenant the vendor was bound to.

## Server

- New endpoint \`PUT /api/core/v1/vendor-contacts/:id/swap-login-email\`. Body: \`{ new_email, password? }\`. Runs the spec's swap flow in a single transaction: resolve current binding → look up new_email in portal_users (active or archived) → deactivate current binding → match-found upgrade-or-insert binding (status='invited', password ignored) OR no-match create new portal_user + binding → update tenant emails row.
- \`emailsController.update\` now returns 400 on direct email-value changes to a vendor_contact \`is_login\` row, directing callers to the swap endpoint.

## Client

- New mutation hook + API method for the swap endpoint.
- \`useVendorContactDialogs\` captures the original login email on open; on save it detects an identity-swap intent and pops a ConfirmDialog before calling the swap endpoint, then re-enters the rest of the save once accepted.
- "Transfer tenant access?" ConfirmDialog names both addresses and explains what will happen.

## Test plan

- [x] \`npm run lint\` clean
- [x] Targeted contract tests: vendorContacts (13/13), emails (11/11)
- [x] Four new contract tests covering no-match swap, match swap (preserves matched portal_user password_hash), same-email rejection, emailsController block on direct vendor_contact login-email edits
- [ ] Reviewer: confirm the ConfirmDialog wording is right — this is the highest-blast-radius UX in the plan