### PR TITLE
feat(server): vendor self-service login-email change (Task 8)

### DIFF
--- a/apps/server/src/system/auth/apiRoutes/v1/authRouter.js
+++ b/apps/server/src/system/auth/apiRoutes/v1/authRouter.js
@@ -6,7 +6,7 @@
  */
 
 import { Router } from 'express';
-import { login, refresh, logout, me, check, changePassword } from '../../controllers/authController.js';
+import { login, refresh, logout, me, check, changePassword, changeEmail } from '../../controllers/authController.js';
 
 const router = Router();
 
@@ -14,6 +14,7 @@ router.post('/login', login);
 router.post('/refresh', refresh);
 router.post('/logout', logout);
 router.post('/change-password', changePassword);
+router.patch('/me/email', changeEmail);
 router.get('/me', me);
 router.get('/check', check);
 

--- a/apps/server/src/system/auth/apiRoutes/v1/authRouter.js
+++ b/apps/server/src/system/auth/apiRoutes/v1/authRouter.js
@@ -1,5 +1,5 @@
 /**
- * @file Auth routes — login, refresh, logout, me, check, change-password per PRD §3.1.1
+ * @file Auth routes — login, refresh, logout, me, check, change-password, change-email (self-service) per PRD §3.1.1
  * @module auth/apiRoutes/v1/authRouter
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.

--- a/apps/server/src/system/auth/controllers/authController.js
+++ b/apps/server/src/system/auth/controllers/authController.js
@@ -12,8 +12,17 @@ import passport from '../services/passportService.js';
 import { signAccessToken, signRefreshToken, verifyRefresh } from '../services/tokenService.js';
 import { setAuthCookies, clearAuthCookies } from '../../../lib/cookies.js';
 import jwt from 'jsonwebtoken';
-import db from '../../../db/db.js';
+import db, { pgp } from '../../../db/db.js';
 import { invalidateByUser } from '../../../services/permCacheInvalidator.js';
+import logger from '../../../lib/logger.js';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const SOURCE_TYPE_BY_ENTITY_TYPE = {
+  employee: 'employee',
+  client: 'client',
+  vendor_contact: 'vendor_contact',
+};
 
 /**
  * POST /api/auth/login — Authenticate with email/password
@@ -228,4 +237,90 @@ export const changePassword = async (req, res) => {
   }
 };
 
-export default { login, refresh, logout, me, check, changePassword };
+/**
+ * PATCH /api/auth/me/email — Change the authenticated user's login email.
+ *
+ * Updates admin.portal_users.email for the caller and cascades the change
+ * to every tenant-scoped emails row (is_login=true) for each active binding
+ * the user has. Runs inside a single transaction so partial failures roll
+ * back the global identity update.
+ */
+export const changeEmail = async (req, res) => {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ message: 'Unauthorized' });
+
+  const newEmailRaw = req.body?.email;
+  if (typeof newEmailRaw !== 'string') {
+    return res.status(400).json({ message: 'email is required' });
+  }
+  const newEmail = newEmailRaw.trim();
+  if (!EMAIL_RE.test(newEmail)) {
+    return res.status(400).json({ message: 'Invalid email format' });
+  }
+
+  try {
+    const result = await db.tx(async (t) => {
+      // Update the global portal_users identity. The partial unique index
+      // on (email) WHERE deactivated_at IS NULL surfaces collisions as 23505.
+      const updated = await t.oneOrNone(
+        `UPDATE admin.portal_users
+            SET email = $1, updated_by = $2
+          WHERE id = $3 AND deactivated_at IS NULL
+          RETURNING id, email, status`,
+        [newEmail, userId, userId],
+      );
+      if (!updated) {
+        const err = new Error('User not found');
+        err.code = 'USER_NOT_FOUND';
+        throw err;
+      }
+
+      // Cascade to per-tenant emails.is_login rows for each active binding.
+      const bindings = await t.manyOrNone(
+        `SELECT b.entity_type, b.entity_id, tn.schema_name
+           FROM admin.portal_user_tenants b
+           JOIN admin.tenants tn ON tn.id = b.tenant_id
+          WHERE b.portal_user_id = $1
+            AND b.deactivated_at IS NULL
+            AND b.entity_type IS NOT NULL
+            AND b.entity_id IS NOT NULL`,
+        [userId],
+      );
+
+      for (const binding of bindings) {
+        const sourceType = SOURCE_TYPE_BY_ENTITY_TYPE[binding.entity_type];
+        if (!sourceType) continue;
+        const s = pgp.as.name(binding.schema_name);
+        await t.none(
+          `UPDATE ${s}.emails AS e
+              SET email = $1, updated_by = $2
+             FROM ${s}.sources AS s
+            WHERE e.source_id = s.id
+              AND s.source_type = $3
+              AND s.table_id = $4
+              AND e.is_login = true
+              AND e.deactivated_at IS NULL`,
+          [newEmail, userId, sourceType, binding.entity_id],
+        );
+      }
+
+      return updated;
+    });
+
+    return res.json({
+      message: 'Email changed successfully',
+      user: { id: result.id, email: result.email, status: result.status },
+    });
+  } catch (err) {
+    if (err?.code === '23505') {
+      return res.status(409).json({ message: 'Email is already in use' });
+    }
+    if (err?.code === 'USER_NOT_FOUND') {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    logger.error('Failed to change login email', { userId, error: err.message });
+    return res.status(500).json({ message: 'Error changing email' });
+  }
+};
+
+export default { login, refresh, logout, me, check, changePassword, changeEmail };

--- a/apps/server/src/system/auth/controllers/authController.js
+++ b/apps/server/src/system/auth/controllers/authController.js
@@ -1,5 +1,5 @@
 /**
- * @file Auth controller — login, refresh, logout, me, check, changePassword per PRD §3.1.1
+ * @file Auth controller — login, refresh, logout, me, check, changePassword, changeEmail per PRD §3.1.1
  * @module auth/controllers/authController
  *
  * Auth flow with RBAC permission caching and cache invalidation on logout.
@@ -17,6 +17,7 @@ import { invalidateByUser } from '../../../services/permCacheInvalidator.js';
 import logger from '../../../lib/logger.js';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EMAIL_MAX_LEN = 128;
 
 const SOURCE_TYPE_BY_ENTITY_TYPE = {
   employee: 'employee',
@@ -257,6 +258,9 @@ export const changeEmail = async (req, res) => {
   if (!EMAIL_RE.test(newEmail)) {
     return res.status(400).json({ message: 'Invalid email format' });
   }
+  if (newEmail.length > EMAIL_MAX_LEN) {
+    return res.status(400).json({ message: `Email must be ${EMAIL_MAX_LEN} characters or fewer` });
+  }
 
   try {
     const result = await db.tx(async (t) => {
@@ -290,15 +294,15 @@ export const changeEmail = async (req, res) => {
       for (const binding of bindings) {
         const sourceType = SOURCE_TYPE_BY_ENTITY_TYPE[binding.entity_type];
         if (!sourceType) continue;
-        const s = pgp.as.name(binding.schema_name);
+        const schemaIdent = pgp.as.name(binding.schema_name);
         await t.none(
-          `UPDATE ${s}.emails AS e
+          `UPDATE ${schemaIdent}.emails AS e
               SET email = $1, updated_by = $2
-             FROM ${s}.sources AS s
-            WHERE e.source_id = s.id
-              AND s.source_type = $3
-              AND s.table_id = $4
-              AND s.deactivated_at IS NULL
+             FROM ${schemaIdent}.sources AS src
+            WHERE e.source_id = src.id
+              AND src.source_type = $3
+              AND src.table_id = $4
+              AND src.deactivated_at IS NULL
               AND e.is_login = true
               AND e.deactivated_at IS NULL`,
           [newEmail, userId, sourceType, binding.entity_id],

--- a/apps/server/src/system/auth/controllers/authController.js
+++ b/apps/server/src/system/auth/controllers/authController.js
@@ -298,6 +298,7 @@ export const changeEmail = async (req, res) => {
             WHERE e.source_id = s.id
               AND s.source_type = $3
               AND s.table_id = $4
+              AND s.deactivated_at IS NULL
               AND e.is_login = true
               AND e.deactivated_at IS NULL`,
           [newEmail, userId, sourceType, binding.entity_id],

--- a/apps/server/tests/contract/authChangeEmail.test.js
+++ b/apps/server/tests/contract/authChangeEmail.test.js
@@ -1,0 +1,223 @@
+/**
+ * @file Contract tests for self-service login-email change endpoint
+ * @module tests/contract/authChangeEmail
+ *
+ * Covers PATCH /api/auth/me/email — vendors update their own portal_users
+ * email and the change cascades to per-tenant emails.is_login rows in
+ * every active binding.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(rootCookies, code, company, adminEmail, adminPass) {
+  await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', rootCookies)
+    .send({
+      tenant_code: code,
+      company,
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'T',
+      admin_last_name: 'A',
+      admin_email: adminEmail,
+      admin_password: adminPass,
+      billing_address: { address_line_1: '1 St', country_code: 'US' },
+    });
+}
+
+async function login(email, password) {
+  const res = await request(app).post('/api/auth/login').send({ email, password });
+  return res.headers['set-cookie'];
+}
+
+async function fetchLoginEmails(portalUserId) {
+  // Returns [{ schema_name, entity_type, entity_id, email }] for is_login rows
+  // across all active bindings of this portal_user.
+  const bindings = await db.manyOrNone(
+    `SELECT b.entity_type, b.entity_id, tn.schema_name
+       FROM admin.portal_user_tenants b
+       JOIN admin.tenants tn ON tn.id = b.tenant_id
+      WHERE b.portal_user_id = $1
+        AND b.deactivated_at IS NULL
+        AND b.entity_type IS NOT NULL`,
+    [portalUserId],
+  );
+  const rows = [];
+  for (const b of bindings) {
+    const r = await db.oneOrNone(
+      `SELECT e.email
+         FROM ${b.schema_name}.emails e
+         JOIN ${b.schema_name}.sources s ON s.id = e.source_id
+        WHERE s.source_type = $1
+          AND s.table_id = $2
+          AND e.is_login = true
+          AND e.deactivated_at IS NULL`,
+      [b.entity_type, b.entity_id],
+    );
+    rows.push({ schema_name: b.schema_name, entity_type: b.entity_type, entity_id: b.entity_id, email: r?.email || null });
+  }
+  return rows;
+}
+
+describe('PATCH /api/auth/me/email — self-service login email change', () => {
+  let rootCookies;
+  let cookiesA;
+  let cookiesB;
+  let vendorIdA;
+  let vendorIdB;
+  const ORIGINAL_EMAIL = 'sally.shared@vendor.test';
+  const NEW_EMAIL = 'sally.renamed@vendor.test';
+  const COLLIDING_EMAIL = 'collider@vendor.test';
+
+  beforeAll(async () => {
+    rootCookies = await loginRoot();
+
+    await provisionTenant(rootCookies, 'CETEN1', 'CE Tenant 1', 'admin@ceten1.com', 'CetenPass123!');
+    await provisionTenant(rootCookies, 'CETEN2', 'CE Tenant 2', 'admin@ceten2.com', 'CetenPass123!');
+
+    cookiesA = await login('admin@ceten1.com', 'CetenPass123!');
+    cookiesB = await login('admin@ceten2.com', 'CetenPass123!');
+
+    const vA = await request(app).post('/api/core/v1/vendors').set('Cookie', cookiesA).send({ name: 'V A', code: 'VA1' });
+    vendorIdA = vA.body.id;
+    const vB = await request(app).post('/api/core/v1/vendors').set('Cookie', cookiesB).send({ name: 'V B', code: 'VB1' });
+    vendorIdB = vB.body.id;
+
+    // Create vendor_contact app-user in tenant A — this auto-creates a portal_user
+    // and an emails row with is_login=true.
+    const cA = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorIdA,
+        first_name: 'Sally',
+        last_name: 'Shared',
+        email: ORIGINAL_EMAIL,
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'SallyPass123!',
+      });
+    expect(cA.status).toBe(201);
+
+    // Bind in tenant B as the same person — Task 6 attaches to the existing portal_user.
+    const cB = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesB)
+      .send({
+        vendor_id: vendorIdB,
+        first_name: 'Sally',
+        last_name: 'Shared',
+        email: ORIGINAL_EMAIL,
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'IgnoredPass123!',
+      });
+    expect(cB.status).toBe(201);
+
+    // Activate the invited portal_user so the user can log in (status='invited' →
+    // 'active' triggered by changePassword; do that directly in DB to avoid the
+    // first-login forced-password dance).
+    await db.none(
+      `UPDATE admin.portal_users SET status = 'active' WHERE email = $1`,
+      [ORIGINAL_EMAIL],
+    );
+    // Activate every binding (Task 6 leaves the second tenant's binding as 'invited')
+    await db.none(
+      `UPDATE admin.portal_user_tenants
+          SET status = 'active'
+        WHERE portal_user_id = (SELECT id FROM admin.portal_users WHERE email = $1)
+          AND deactivated_at IS NULL`,
+      [ORIGINAL_EMAIL],
+    );
+  }, 60000);
+
+  test('returns 401 when not authenticated', async () => {
+    const res = await request(app).patch('/api/auth/me/email').send({ email: 'foo@bar.com' });
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 400 for invalid email format', async () => {
+    const cookies = await login(ORIGINAL_EMAIL, 'SallyPass123!');
+    const res = await request(app).patch('/api/auth/me/email').set('Cookie', cookies).send({ email: 'not-an-email' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/Invalid email/i);
+  });
+
+  test('returns 409 when new email collides with another portal_user', async () => {
+    // Seed a colliding portal_user
+    await db.none(
+      `INSERT INTO admin.portal_users (email, password_hash, status)
+       VALUES ($1, 'x', 'active')`,
+      [COLLIDING_EMAIL],
+    );
+
+    const cookies = await login(ORIGINAL_EMAIL, 'SallyPass123!');
+    const res = await request(app).patch('/api/auth/me/email').set('Cookie', cookies).send({ email: COLLIDING_EMAIL });
+    expect(res.status).toBe(409);
+
+    // portal_users.email unchanged
+    const stillThere = await db.one(
+      `SELECT email FROM admin.portal_users WHERE id = (
+         SELECT portal_user_id FROM admin.portal_user_tenants
+          WHERE entity_type = 'vendor_contact' AND deactivated_at IS NULL
+          ORDER BY created_at ASC LIMIT 1
+       )`,
+    );
+    expect(stillThere.email).toBe(ORIGINAL_EMAIL);
+  });
+
+  test('updates portal_users.email and cascades to is_login rows in every bound tenant', async () => {
+    const cookies = await login(ORIGINAL_EMAIL, 'SallyPass123!');
+
+    const portalBefore = await db.one(
+      `SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`,
+      [ORIGINAL_EMAIL],
+    );
+
+    const beforeRows = await fetchLoginEmails(portalBefore.id);
+    expect(beforeRows.length).toBe(2);
+    for (const r of beforeRows) expect(r.email).toBe(ORIGINAL_EMAIL);
+
+    const res = await request(app).patch('/api/auth/me/email').set('Cookie', cookies).send({ email: NEW_EMAIL });
+    expect(res.status).toBe(200);
+    expect(res.body.user.email).toBe(NEW_EMAIL);
+
+    // portal_users.email reflects the change
+    const after = await db.oneOrNone(
+      `SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`,
+      [NEW_EMAIL],
+    );
+    expect(after).not.toBeNull();
+    expect(after.id).toBe(portalBefore.id);
+
+    // Both tenants' is_login=true emails rows reflect the change
+    const afterRows = await fetchLoginEmails(after.id);
+    expect(afterRows.length).toBe(2);
+    for (const r of afterRows) expect(r.email).toBe(NEW_EMAIL);
+  });
+});


### PR DESCRIPTION
## Summary

Task 8 of the Import Dedup & Multi-Tenant Vendor Access plan. New self-service endpoint \`PATCH /api/auth/me/email\` so a vendor (or any portal_user) can update their own login email — single source of truth on \`admin.portal_users\`, with a cascade across every tenant binding's \`emails.is_login=true\` row.

## Server

- \`changeEmail\` controller in \`authController.js\`: pulls \`req.user.id\` (no target user param — this surface can't be misused for tenant-admin email edits), validates with \`EMAIL_RE\`, then in a single \`db.tx\`:
  1. \`UPDATE admin.portal_users SET email = $1 WHERE id = $req.user.id\`. 23505 from the \`(email) WHERE active\` partial unique index → 409.
  2. \`SELECT b.entity_type, b.entity_id, t.schema_name FROM admin.portal_user_tenants b JOIN admin.tenants t ON ... WHERE b.portal_user_id = $1 AND b.deactivated_at IS NULL\`.
  3. For each binding, \`UPDATE <schema>.emails ... FROM <schema>.sources WHERE source_type = entity_type AND table_id = entity_id AND is_login = true\` — propagates the new email into every tenant the user has access to.
- Route: \`PATCH /api/auth/me/email\`.

Bindings with \`entity_type IS NULL\` (root super-user pre-link or bare \`/portal-users/register\` rows) are filtered out of the cascade — there's no tenant-scoped emails row to update for those.

## Out of scope

- Axerra-admin variant (admin changes another user's email) deferred — flagged in commit message.
- Client "My Account" UI deferred — would be a separate client-only PR.

## Test plan

- [x] \`npm run lint\` clean
- [x] 4 new contract tests in \`tests/contract/authChangeEmail.test.js\`: success cascades to multi-tenant emails rows; collision returns 409; invalid email format 400; unauthenticated 401