### PR TITLE
fix(server): block tenant admin from resetting multi-tenant vendor passwords (Task 9)

### DIFF
--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -314,11 +314,17 @@ class VendorContactsController extends BaseController {
         return res.status(404).json({ error: 'No active app user account found for this vendor contact' });
       }
 
-      // Multi-tenant authority guard (Part 3 of Import Dedup spec):
-      // If the underlying portal_user has more than one active tenant
-      // binding, only the user themselves or an Axerra admin may reset
-      // the password. A tenant admin in any single tenant does not own
-      // credentials shared across tenants.
+      // Multi-tenant authority guard (Part 3 of Import Dedup spec).
+      // This endpoint is the admin reset path for an *already-provisioned*
+      // vendor — the 404 above filters out unprovisioned vendors, whose
+      // initial password is set by #provisionAppUser instead.
+      //
+      // Rule: tenant admins may reset the password only when the underlying
+      // portal_user has at most one active tenant binding (single-tenant
+      // vendor). If the portal_user is bound to multiple tenants, only the
+      // Axerra root tenant may reset, because credentials are shared across
+      // every tenant the vendor is bound to. Self-service password change
+      // is handled by POST /api/auth/change-password, not this route.
       const { count } = await db.one(
         `SELECT COUNT(*)::int AS count FROM admin.portal_user_tenants
          WHERE portal_user_id = $1 AND deactivated_at IS NULL`,

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -324,7 +324,9 @@ class VendorContactsController extends BaseController {
          WHERE portal_user_id = $1 AND deactivated_at IS NULL`,
         [binding.portal_user_id],
       );
-      if (count > 1 && req.user?.home_tenant !== 'axerra') {
+      const rootTenantCode = (process.env.ROOT_TENANT_CODE || 'axerra').toLowerCase();
+      const callerTenantCode = req.user?.home_tenant?.toLowerCase?.();
+      if (count > 1 && callerTenantCode !== rootTenantCode) {
         return res.status(403).json({ error: 'Tenant admins cannot change the password of a multi-tenant vendor user.' });
       }
 

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -314,6 +314,20 @@ class VendorContactsController extends BaseController {
         return res.status(404).json({ error: 'No active app user account found for this vendor contact' });
       }
 
+      // Multi-tenant authority guard (Part 3 of Import Dedup spec):
+      // If the underlying portal_user has more than one active tenant
+      // binding, only the user themselves or an Axerra admin may reset
+      // the password. A tenant admin in any single tenant does not own
+      // credentials shared across tenants.
+      const { count } = await db.one(
+        `SELECT COUNT(*)::int AS count FROM admin.portal_user_tenants
+         WHERE portal_user_id = $1 AND deactivated_at IS NULL`,
+        [binding.portal_user_id],
+      );
+      if (count > 1 && req.user?.home_tenant !== 'axerra') {
+        return res.status(403).json({ error: 'Tenant admins cannot change the password of a multi-tenant vendor user.' });
+      }
+
       const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
       const hash = await bcrypt.hash(password, rounds);
       await db.none('UPDATE admin.portal_users SET password_hash = $/hash/, updated_by = $/updatedBy/ WHERE id = $/id/', {

--- a/apps/server/tests/contract/vendorContacts.test.js
+++ b/apps/server/tests/contract/vendorContacts.test.js
@@ -10,7 +10,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import request from 'supertest';
-import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+import { bootstrapAdmin, cleanupTestDb, DB } from '../helpers/testDb.js';
 
 const ROOT_EMAIL = process.env.ROOT_EMAIL;
 const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
@@ -743,8 +743,9 @@ describe('Vendor Contact reset-password authority — multi-tenant guard (Task 9
       [rootUser.id, tenantB.id],
     );
     if (!existingBinding) {
+      const schemaIdent = DB.pgp.as.name(tenantB.schema_name);
       const empId = await db.one(
-        `INSERT INTO ${tenantB.schema_name}.employees
+        `INSERT INTO ${schemaIdent}.employees
            (tenant_id, first_name, last_name, is_app_user, roles)
          VALUES ($1, 'Axerra', 'Operator', true, '{admin}')
          RETURNING id`,

--- a/apps/server/tests/contract/vendorContacts.test.js
+++ b/apps/server/tests/contract/vendorContacts.test.js
@@ -383,3 +383,210 @@ describe('Vendor Contact app-user provisioning — cross-tenant existing-email m
     expect(lockedBinding.deactivated_at).not.toBeNull();
   });
 });
+
+describe('Vendor Contact reset-password authority — multi-tenant guard (Task 9)', () => {
+  let cookiesA;
+  let cookiesB;
+  let rootCookies;
+  let vendorIdA;
+  let vendorIdB;
+
+  beforeAll(async () => {
+    rootCookies = await loginRoot();
+
+    // Tenants A & B may already exist from earlier describe blocks.
+    let loginA = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@vctest.com', password: 'VctestPass123!' });
+    if (!loginA.headers['set-cookie']?.length) {
+      await provisionTenant(rootCookies);
+      loginA = await request(app)
+        .post('/api/auth/login')
+        .send({ email: 'admin@vctest.com', password: 'VctestPass123!' });
+    }
+    cookiesA = loginA.headers['set-cookie'];
+
+    let loginB = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@vctstb.com', password: 'VctstbPass123!' });
+    if (!loginB.headers['set-cookie']?.length) {
+      await request(app)
+        .post('/api/tenants/v1/tenants')
+        .set('Cookie', rootCookies)
+        .send({
+          tenant_code: 'VCTSTB',
+          company: 'Vendor Contact Test Corp B',
+          status: 'active',
+          tier: 'starter',
+          admin_first_name: 'B',
+          admin_last_name: 'Admin',
+          admin_email: 'admin@vctstb.com',
+          admin_password: 'VctstbPass123!',
+          billing_address: { address_line_1: '1 B St', country_code: 'US' },
+        });
+      loginB = await request(app)
+        .post('/api/auth/login')
+        .send({ email: 'admin@vctstb.com', password: 'VctstbPass123!' });
+    }
+    cookiesB = loginB.headers['set-cookie'];
+
+    const vendorA = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesA)
+      .send({ name: 'Reset Vendor A', code: 'RVENA' });
+    vendorIdA = vendorA.body.id;
+
+    const vendorB = await request(app)
+      .post('/api/core/v1/vendors')
+      .set('Cookie', cookiesB)
+      .send({ name: 'Reset Vendor B', code: 'RVENB' });
+    vendorIdB = vendorB.body.id;
+  }, 30000);
+
+  test('single-tenant vendor → tenant admin can reset password (200)', async () => {
+    const email = 'solo.reset@vendor.test';
+    const createRes = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorIdA,
+        first_name: 'Solo',
+        last_name: 'Reset',
+        email,
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'OriginalPass123!',
+      });
+    expect(createRes.status).toBe(201);
+    const contactId = createRes.body.id;
+
+    const resetRes = await request(app)
+      .post(`/api/core/v1/vendor-contacts/${contactId}/reset-password`)
+      .set('Cookie', cookiesA)
+      .send({ password: 'NewSoloPass123!' });
+    expect(resetRes.status).toBe(200);
+    expect(resetRes.body.message).toMatch(/reset/i);
+  });
+
+  test('multi-tenant vendor → tenant admin gets 403 with domain error', async () => {
+    const sharedEmail = 'multi.reset@vendor.test';
+
+    // Create vendor_contact in tenant A → creates portal_user.
+    const createA = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorIdA,
+        first_name: 'Multi',
+        last_name: 'Reset',
+        email: sharedEmail,
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'OriginalPass123!',
+      });
+    expect(createA.status).toBe(201);
+
+    // Create matching vendor_contact in tenant B → binds to existing portal_user.
+    const createB = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesB)
+      .send({
+        vendor_id: vendorIdB,
+        first_name: 'Multi',
+        last_name: 'Reset',
+        email: sharedEmail,
+        is_app_user: true,
+        roles: ['vendor'],
+      });
+    expect(createB.status).toBe(201);
+    const contactBId = createB.body.id;
+
+    const resetRes = await request(app)
+      .post(`/api/core/v1/vendor-contacts/${contactBId}/reset-password`)
+      .set('Cookie', cookiesB)
+      .send({ password: 'NewMultiPass123!' });
+    expect(resetRes.status).toBe(403);
+    expect(resetRes.body.error).toBe('Tenant admins cannot change the password of a multi-tenant vendor user.');
+  });
+
+  test('multi-tenant vendor → Axerra admin can still reset password (200)', async () => {
+    const sharedEmail = 'axerra.reset@vendor.test';
+
+    const createA = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesA)
+      .send({
+        vendor_id: vendorIdA,
+        first_name: 'Axerra',
+        last_name: 'Reset',
+        email: sharedEmail,
+        is_app_user: true,
+        roles: ['vendor'],
+        password: 'OriginalPass123!',
+      });
+    expect(createA.status).toBe(201);
+
+    const createB = await request(app)
+      .post('/api/core/v1/vendor-contacts')
+      .set('Cookie', cookiesB)
+      .send({
+        vendor_id: vendorIdB,
+        first_name: 'Axerra',
+        last_name: 'Reset',
+        email: sharedEmail,
+        is_app_user: true,
+        roles: ['vendor'],
+      });
+    expect(createB.status).toBe(201);
+    const contactBId = createB.body.id;
+
+    // Give the root user a real binding into tenant B so RBAC has caps
+    // to evaluate. The earliest active binding (AXERRA) stays the home
+    // tenant — so home_tenant === 'axerra' on this request and the
+    // controller-level Axerra escape hatch fires. We create an employee
+    // in tenant B's schema with the seeded 'admin' role (wildcard full
+    // policies) and link the binding to it.
+    const tenantB = await db.one(
+      'SELECT id, schema_name FROM admin.tenants WHERE tenant_code = $1',
+      ['VCTSTB'],
+    );
+    const rootUser = await db.one(
+      'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+      [process.env.ROOT_EMAIL],
+    );
+
+    // Idempotent: only seed if no binding yet
+    const existingBinding = await db.oneOrNone(
+      `SELECT id FROM admin.portal_user_tenants
+       WHERE portal_user_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
+      [rootUser.id, tenantB.id],
+    );
+    if (!existingBinding) {
+      const empId = await db.one(
+        `INSERT INTO ${tenantB.schema_name}.employees
+           (tenant_id, first_name, last_name, is_app_user, roles)
+         VALUES ($1, 'Axerra', 'Operator', true, '{admin}')
+         RETURNING id`,
+        [tenantB.id],
+      );
+      await db.none(
+        `INSERT INTO admin.portal_user_tenants
+           (portal_user_id, tenant_id, entity_type, entity_id, status)
+         VALUES ($1, $2, 'employee', $3, 'active')`,
+        [rootUser.id, tenantB.id, empId.id],
+      );
+    }
+
+    // Re-login as root so the auth/perm cache picks up the new binding.
+    const freshRootCookies = await loginRoot();
+
+    // Axerra root admin acts on tenant B via x-tenant-code header.
+    const resetRes = await request(app)
+      .post(`/api/core/v1/vendor-contacts/${contactBId}/reset-password`)
+      .set('Cookie', freshRootCookies)
+      .set('x-tenant-code', 'VCTSTB')
+      .send({ password: 'AxerraNewPass123!' });
+    expect(resetRes.status).toBe(200);
+    expect(resetRes.body.message).toMatch(/reset/i);
+  });
+});


### PR DESCRIPTION
## Summary

Task 9 of the Import Dedup & Multi-Tenant Vendor Access plan. Tenant admins can no longer reset the password of a vendor_contact whose portal_user has bindings to multiple tenants — that mutation belongs to the user themselves or to an Axerra admin. Single-tenant vendor_contacts (one binding) keep the existing tenant-admin reset behavior.

## Behavior change

In \`vendorContactsController.resetPassword\`, before bcrypt + UPDATE:

1. Resolve the binding for \`(vendor_contact, req.user.tenant_id)\` via \`findActiveBinding\`.
2. Count the user's TOTAL active bindings via \`portal_user_tenants\`.
3. If count > 1 AND the caller is NOT an Axerra admin (\`req.user.home_tenant !== 'axerra'\`), return 403 with: \`"Tenant admins cannot change the password of a multi-tenant vendor user."\`
4. Otherwise, proceed with the existing reset.

The Axerra-admin escape hatch lets root users still help with password resets when needed. \`home_tenant === 'axerra'\` is set by \`authRedis\` from \`process.env.ROOT_TENANT_CODE\`.

Employees / clients are out of scope — they are always single-tenant by design (the global email unique index rejects multi-tenant collisions in their controllers).

## Test plan

- [x] \`npm run lint\` clean
- [x] 3 new contract tests in \`vendorContacts.test.js\`: single-tenant tenant admin → 200; multi-tenant tenant admin → 403; multi-tenant Axerra admin → 200