### PR TITLE
feat(server): cross-tenant portal_user collision check on import (Task 10)

### DIFF
--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -279,6 +279,14 @@ export function getEnumColumns(schema) {
  * Checks required parent fields, valid statuses, duplicate codes, and email formats.
  * Returns an array of error objects ({ sheet, row, column, value, message }).
  *
+ * When `entityType` is supplied, also runs a single batched cross-tenant
+ * collision check against `admin.portal_users` for any child email marked
+ * `is_login`:
+ *   - 'employee' | 'client' → adds a row error blocking the import
+ *     (single-tenant entities cannot share login identity).
+ *   - 'vendor_contact'      → skipped here; the controller's bind-existing
+ *     path handles binding to the existing portal_user at write time.
+ *
  * @param {Object[]}  groups       Output of groupFlatRows
  * @param {Object}    opts
  * @param {string}    opts.sheetName     Sheet label for error messages
@@ -286,10 +294,13 @@ export function getEnumColumns(schema) {
  * @param {boolean}   [opts.codeRequired] Whether code is required
  * @param {boolean}   [opts.validateEmails] Whether to check child emails
  * @param {Object[]}  [opts.conflicts]   Conflict objects from groupFlatRows
- * @returns {Object[]} Array of validation errors (empty = valid)
+ * @param {('employee'|'client'|'vendor_contact')} [opts.entityType] Source
+ *   entity type — when set, enables the cross-tenant portal_user collision
+ *   check (and is the policy lever for whether collisions abort the row).
+ * @returns {Promise<Object[]>} Array of validation errors (empty = valid)
  */
-export function validateImportGroups(groups, opts) {
-  const { sheetName, requiredFields = [], codeRequired = false, validateEmails = true, conflicts = [] } = opts;
+export async function validateImportGroups(groups, opts) {
+  const { sheetName, requiredFields = [], codeRequired = false, validateEmails = true, conflicts = [], entityType } = opts;
   const errors = [];
 
   for (const c of conflicts) {
@@ -370,6 +381,81 @@ export function validateImportGroups(groups, opts) {
     }
   }
 
+  // Cross-tenant portal_user collision check
+  if (entityType === 'employee' || entityType === 'client') {
+    errors.push(...(await checkPortalUserEmailCollisions(groups, { sheetName, entityType })));
+  }
+
+  return errors;
+}
+
+/**
+ * Single-batch cross-tenant collision check against `admin.portal_users` for
+ * incoming login emails. For each row whose child email is marked `is_login`
+ * and matches an active portal_user, returns a row-level error.
+ *
+ * Only callers for `entityType` of 'employee' or 'client' should consume the
+ * errors — vendor_contact rows are intentionally allowed through so the
+ * controller's bind-existing path can attach to the existing portal_user at
+ * write time. The function itself is policy-agnostic — it just reports
+ * collisions; the caller decides whether to block.
+ *
+ * @param {Object[]} groups Output of groupFlatRows
+ * @param {Object}   opts
+ * @param {string}   opts.sheetName Sheet label for error messages
+ * @param {('employee'|'client'|'vendor_contact')} opts.entityType
+ * @returns {Promise<Object[]>} Array of validation errors (empty = no collisions)
+ */
+export async function checkPortalUserEmailCollisions(groups, opts) {
+  const { sheetName, entityType } = opts;
+  if (!groups?.length) return [];
+
+  // Collect all login emails (lower-cased) along with the row that carries them
+  const loginEmailRows = [];
+  for (const group of groups) {
+    for (const child of group.children?.emails || []) {
+      if (!child?.email) continue;
+      // is_login may arrive as boolean, the string 'true', or 1
+      const isLogin = child.is_login === true || child.is_login === 1 || (typeof child.is_login === 'string' && child.is_login.toLowerCase() === 'true');
+      if (!isLogin) continue;
+      // Only do the lookup for plausibly valid emails — invalid format is
+      // already flagged separately and would skew the IN-list.
+      if (!EMAIL_RE.test(child.email)) continue;
+      loginEmailRows.push({
+        email: String(child.email).trim().toLowerCase(),
+        row: child._rowNum || null,
+      });
+    }
+  }
+  if (!loginEmailRows.length) return [];
+
+  const uniqueEmails = [...new Set(loginEmailRows.map((r) => r.email))];
+  const { db } = await getDb();
+  const existing = await db.manyOrNone(
+    `SELECT LOWER(email) AS email FROM admin.portal_users
+     WHERE LOWER(email) = ANY($1::text[]) AND deactivated_at IS NULL`,
+    [uniqueEmails],
+  );
+  if (!existing.length) return [];
+
+  const taken = new Set(existing.map((r) => r.email));
+  const errors = [];
+
+  // vendor_contact rows are intentionally not aborted — the controller's
+  // bind-existing path handles them at write time.
+  if (entityType === 'vendor_contact') return errors;
+
+  for (const { email, row } of loginEmailRows) {
+    if (taken.has(email)) {
+      errors.push({
+        sheet: sheetName,
+        row,
+        column: 'email',
+        value: email,
+        message: `Login email ${email} is already in use by another portal user. Single-tenant entities cannot share login identity.`,
+      });
+    }
+  }
   return errors;
 }
 
@@ -638,6 +724,22 @@ export async function importSourceEntity(model, filePath, _sheetIndex, callbackF
   let sourceByParentId = new Map();
   let tid;
   let createdBy = null;
+
+  // ── Cross-tenant portal_user collision check (Part 2 of import dedup spec) ──
+  const provisionEntityType = config.appUserProvisioning?.entityType;
+  if (provisionEntityType === 'employee' || provisionEntityType === 'client') {
+    const emailSheetIdx = config.childSheets.findIndex((c) => c.modelName === 'emails') + 1;
+    if (emailSheetIdx > 0 && reader.sheetCount > emailSheetIdx) {
+      const emailRows = parseSheet(reader, emailSheetIdx);
+      // Build a single synthetic group so checkPortalUserEmailCollisions can iterate uniformly
+      const syntheticGroups = [{ parent: {}, children: { emails: emailRows } }];
+      const collisionErrors = await checkPortalUserEmailCollisions(syntheticGroups, {
+        sheetName: reader.sheetNames?.[emailSheetIdx] || 'Emails',
+        entityType: provisionEntityType,
+      });
+      if (collisionErrors.length) return { errors: collisionErrors };
+    }
+  }
 
   try {
     await db.tx(async (t) => {
@@ -1230,6 +1332,12 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
     childEnums.push({ key: cfg.key, enumMap, flatColByCol });
   }
   errors.push(...validateChildEnums(groups, { sheetName, childEnums }));
+
+  // Cross-tenant portal_user collision check (Part 2 of import dedup spec)
+  const provisionEntityType = config.appUserProvisioning?.entityType;
+  if (provisionEntityType === 'employee' || provisionEntityType === 'client') {
+    errors.push(...(await checkPortalUserEmailCollisions(groups, { sheetName, entityType: provisionEntityType })));
+  }
 
   // Validate no duplicate codes
   const codeCounts = new Map();

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -391,14 +391,19 @@ export async function validateImportGroups(groups, opts) {
 
 /**
  * Single-batch cross-tenant collision check against `admin.portal_users` for
- * incoming login emails. For each row whose child email is marked `is_login`
- * and matches an active portal_user, returns a row-level error.
+ * incoming login emails. Returns a row-level error for each insert whose
+ * `is_login` email matches an active portal_user in another tenant.
  *
- * Only callers for `entityType` of 'employee' or 'client' should consume the
- * errors — vendor_contact rows are intentionally allowed through so the
- * controller's bind-existing path can attach to the existing portal_user at
- * write time. The function itself is policy-agnostic — it just reports
- * collisions; the caller decides whether to block.
+ * The helper is import-policy aware (not policy-agnostic):
+ *   - vendor_contact rows are intentionally allowed through — the controller's
+ *     bind-existing path attaches to the existing portal_user at write time.
+ *     Returns immediately without touching the database.
+ *   - Rows whose `group.parent.id` is a UUID are treated as updates (round-trip
+ *     export/import) and skipped — the existing portal_user already belongs
+ *     to that entity, so the email match is expected. Non-UUID `id` values
+ *     are spreadsheet-only linkage refs for new rows and don't disqualify.
+ *   - Rows whose `group.parent.is_app_user` is falsy are skipped — no
+ *     portal_user will be provisioned, so no collision can occur.
  *
  * @param {Object[]} groups Output of groupFlatRows
  * @param {Object}   opts
@@ -410,9 +415,23 @@ export async function checkPortalUserEmailCollisions(groups, opts) {
   const { sheetName, entityType } = opts;
   if (!groups?.length) return [];
 
-  // Collect all login emails (lower-cased) along with the row that carries them
+  // vendor_contact bind-existing flow runs in the controller — don't pay
+  // for a DB query whose result we'd discard.
+  if (entityType === 'vendor_contact') return [];
+
+  // Collect login emails for *new* app-user parents only. Updates and
+  // non-app-users never provision a portal_user, so they can't collide.
   const loginEmailRows = [];
   for (const group of groups) {
+    const parent = group.parent || {};
+    // parent.id is a UUID → existing entity → row is an update → existing
+    // portal_user already owns this email; skip. Non-UUID id values are
+    // just spreadsheet linkage refs for new rows and don't disqualify.
+    if (isUuid(parent.id)) continue;
+    // is_app_user falsy → no portal_user will be provisioned; skip.
+    const isAppUser = parent.is_app_user === true || parent.is_app_user === 1 || (typeof parent.is_app_user === 'string' && parent.is_app_user.toLowerCase() === 'true');
+    if (!isAppUser) continue;
+
     for (const child of group.children?.emails || []) {
       if (!child?.email) continue;
       // is_login may arrive as boolean, the string 'true', or 1
@@ -440,11 +459,6 @@ export async function checkPortalUserEmailCollisions(groups, opts) {
 
   const taken = new Set(existing.map((r) => r.email));
   const errors = [];
-
-  // vendor_contact rows are intentionally not aborted — the controller's
-  // bind-existing path handles them at write time.
-  if (entityType === 'vendor_contact') return errors;
-
   for (const { email, row } of loginEmailRows) {
     if (taken.has(email)) {
       errors.push({
@@ -726,14 +740,28 @@ export async function importSourceEntity(model, filePath, _sheetIndex, callbackF
   let createdBy = null;
 
   // ── Cross-tenant portal_user collision check (Part 2 of import dedup spec) ──
+  // Build groups keyed by parent so the helper can filter to inserts only
+  // (parent.id absent + parent.is_app_user truthy). Updates round-tripping
+  // through export/import keep their existing portal_user binding and must
+  // not be flagged as collisions.
   const provisionEntityType = config.appUserProvisioning?.entityType;
   if (provisionEntityType === 'employee' || provisionEntityType === 'client') {
     const emailSheetIdx = config.childSheets.findIndex((c) => c.modelName === 'emails') + 1;
     if (emailSheetIdx > 0 && reader.sheetCount > emailSheetIdx) {
       const emailRows = parseSheet(reader, emailSheetIdx);
-      // Build a single synthetic group so checkPortalUserEmailCollisions can iterate uniformly
-      const syntheticGroups = [{ parent: {}, children: { emails: emailRows } }];
-      const collisionErrors = await checkPortalUserEmailCollisions(syntheticGroups, {
+      const groupsByRef = new Map();
+      for (const parent of parentRows) {
+        groupsByRef.set(parent.id || parent[config.linkColName] || parent._rowNum, {
+          parent,
+          children: { emails: [] },
+        });
+      }
+      for (const e of emailRows) {
+        const ref = e[config.linkColName];
+        const group = groupsByRef.get(ref);
+        if (group) group.children.emails.push(e);
+      }
+      const collisionErrors = await checkPortalUserEmailCollisions([...groupsByRef.values()], {
         sheetName: reader.sheetNames?.[emailSheetIdx] || 'Emails',
         entityType: provisionEntityType,
       });

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -440,17 +440,18 @@ export default class Vendors extends TableModel {
     const vendorChildEnums = buildChildEnumsFromArrays(VENDOR_CHILD_ARRAYS_CONFIG, db, schema);
     const contactChildEnums = buildChildEnumsFromArrays(CONTACT_CHILD_ARRAYS_CONFIG, db, schema);
     const errors = [
-      ...validateImportGroups(vendorGroups, {
+      ...(await validateImportGroups(vendorGroups, {
         sheetName: vendorSheetName,
         requiredFields: ['name'],
         conflicts: vendorConflicts,
-      }),
+      })),
       ...validateChildEnums(vendorGroups, { sheetName: vendorSheetName, childEnums: vendorChildEnums }),
-      ...validateImportGroups(contactGroups, {
+      ...(await validateImportGroups(contactGroups, {
         sheetName: contactSheetName,
         requiredFields: ['first_name', 'last_name'],
         conflicts: contactConflicts,
-      }),
+        entityType: 'vendor_contact',
+      })),
       ...validateChildEnums(contactGroups, { sheetName: contactSheetName, childEnums: contactChildEnums }),
     ];
     if (errors.length) return { errors };

--- a/apps/server/tests/contract/importCrossTenantEmail.test.js
+++ b/apps/server/tests/contract/importCrossTenantEmail.test.js
@@ -1,0 +1,116 @@
+/**
+ * @file Contract test for the cross-tenant portal_user collision check on
+ * employee xlsx import (Task 10 — Part 2 of the import-dedup spec).
+ *
+ * Provisions a tenant and creates a portal_user with a known login email,
+ * then runs an employee multi-sheet xlsx import in a second tenant where one
+ * of the rows reuses the same login email. The import must come back with
+ * a 422 and a row error mentioning the email collision.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let _db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  _db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(rootCookies, tenantCode, adminEmail, adminPassword) {
+  await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', rootCookies)
+    .send({
+      tenant_code: tenantCode,
+      company: `${tenantCode} Corp`,
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'Test',
+      admin_last_name: 'Admin',
+      admin_email: adminEmail,
+      admin_password: adminPassword,
+      billing_address: { address_line_1: '1 Test St', country_code: 'US' },
+    });
+}
+
+async function loginAs(email, password) {
+  const res = await request(app).post('/api/auth/login').send({ email, password });
+  return res.headers['set-cookie'];
+}
+
+async function buildEmployeeWorkbook({ ref, code, firstName, lastName, email }) {
+  const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+  const wb = WorkbookBuilder.create();
+
+  wb.sheet('Employees')
+    .setHeaders(['id', 'code', 'first_name', 'last_name', 'is_app_user', 'roles', 'status', 'password'])
+    .addRow([ref, code, firstName, lastName, true, '{admin}', 'active', 'XlsImport123!']);
+
+  wb.sheet('Emails').setHeaders(['employee_id', 'email', 'label', 'is_primary', 'is_login']).addRow([ref, email, 'work', true, true]);
+
+  wb.sheet('Phone Numbers').setHeaders(['employee_id', 'country_code', 'phone_type', 'phone_number', 'is_primary']);
+  wb.sheet('Addresses').setHeaders([
+    'employee_id', 'label', 'address_line_1', 'address_line_2', 'address_line_3',
+    'city', 'state_province', 'postal_code', 'country_code',
+  ]);
+  wb.sheet('Tax Identifiers').setHeaders(['employee_id', 'country_code', 'tax_type', 'tax_value']);
+
+  return writeXlsx(wb.build());
+}
+
+describe('Cross-tenant portal_user collision check on employee import', () => {
+  test('aborts the row with a 422 when the login email already exists in admin.portal_users', async () => {
+    const rootCookies = await loginRoot();
+
+    // Tenant A — its admin user provisions a portal_user with the email we'll collide with
+    await provisionTenant(rootCookies, 'XTNA', 'shared@xt.com', 'TenantAPass123!');
+
+    // Tenant B — this is where we'll run the employee import
+    await provisionTenant(rootCookies, 'XTNB', 'admin@xtnb.com', 'TenantBPass123!');
+    const cookiesB = await loginAs('admin@xtnb.com', 'TenantBPass123!');
+
+    const buf = await buildEmployeeWorkbook({
+      ref: 'EMP-XT-1',
+      code: 'XT001',
+      firstName: 'Collide',
+      lastName: 'User',
+      email: 'shared@xt.com', // collides with Tenant A's admin portal_user
+    });
+
+    const tmpPath = join(tmpdir(), `employees-import-xt-${Date.now()}.xlsx`);
+    writeFileSync(tmpPath, buf);
+    let res;
+    try {
+      res = await request(app).post('/api/core/v1/employees/import-xls').set('Cookie', cookiesB).attach('file', tmpPath);
+    } finally {
+      unlinkSync(tmpPath);
+    }
+
+    expect(res.status).toBe(422);
+    expect(Array.isArray(res.body.errors)).toBe(true);
+    const collision = res.body.errors.find((e) => /already in use by another portal user/i.test(e.message || ''));
+    expect(collision).toBeDefined();
+    expect(String(collision.value).toLowerCase()).toBe('shared@xt.com');
+  }, 30000);
+});

--- a/apps/server/tests/unit/spreadsheetHelpers.test.js
+++ b/apps/server/tests/unit/spreadsheetHelpers.test.js
@@ -292,9 +292,11 @@ describe('validateImportGroups (cross-tenant portal_user collision)', () => {
     dbMock.manyOrNone.mockReset();
   });
 
-  function makeGroup({ name = 'Acme', email = 'a@b.com', isLogin = true, rowNum = 2 } = {}) {
+  function makeGroup({ name = 'Acme', email = 'a@b.com', isLogin = true, rowNum = 2, isAppUser = true, parentId = null } = {}) {
+    const parent = { name, _rowNum: rowNum, is_app_user: isAppUser };
+    if (parentId) parent.id = parentId;
     return {
-      parent: { name, _rowNum: rowNum },
+      parent,
       children: { emails: [{ email, is_login: isLogin, _rowNum: rowNum }] },
     };
   }
@@ -370,18 +372,41 @@ describe('validateImportGroups (cross-tenant portal_user collision)', () => {
 describe('checkPortalUserEmailCollisions', () => {
   beforeEach(() => dbMock.manyOrNone.mockReset());
 
-  it('returns no errors when entityType is vendor_contact even with collisions', async () => {
-    dbMock.manyOrNone.mockResolvedValueOnce([{ email: 'a@b.com' }]);
-    const groups = [{ parent: {}, children: { emails: [{ email: 'a@b.com', is_login: true, _rowNum: 2 }] } }];
+  it('short-circuits without a DB query when entityType is vendor_contact', async () => {
+    const groups = [{ parent: { is_app_user: true }, children: { emails: [{ email: 'a@b.com', is_login: true, _rowNum: 2 }] } }];
     const errs = await checkPortalUserEmailCollisions(groups, { sheetName: 'X', entityType: 'vendor_contact' });
     expect(errs).toEqual([]);
+    expect(dbMock.manyOrNone).not.toHaveBeenCalled();
   });
 
   it('treats string "true" is_login values as truthy', async () => {
     dbMock.manyOrNone.mockResolvedValueOnce([{ email: 'a@b.com' }]);
-    const groups = [{ parent: {}, children: { emails: [{ email: 'a@b.com', is_login: 'true', _rowNum: 3 }] } }];
+    const groups = [{
+      parent: { is_app_user: true },
+      children: { emails: [{ email: 'a@b.com', is_login: 'true', _rowNum: 3 }] },
+    }];
     const errs = await checkPortalUserEmailCollisions(groups, { sheetName: 'X', entityType: 'employee' });
     expect(errs.length).toBe(1);
     expect(errs[0].row).toBe(3);
+  });
+
+  it('skips rows whose parent has an id set (round-trip update)', async () => {
+    const groups = [{
+      parent: { id: '11111111-1111-1111-1111-111111111111', is_app_user: true },
+      children: { emails: [{ email: 'roundtrip@example.com', is_login: true, _rowNum: 4 }] },
+    }];
+    const errs = await checkPortalUserEmailCollisions(groups, { sheetName: 'X', entityType: 'employee' });
+    expect(errs).toEqual([]);
+    expect(dbMock.manyOrNone).not.toHaveBeenCalled();
+  });
+
+  it('skips rows whose parent.is_app_user is falsy', async () => {
+    const groups = [{
+      parent: { is_app_user: false },
+      children: { emails: [{ email: 'noapp@example.com', is_login: true, _rowNum: 5 }] },
+    }];
+    const errs = await checkPortalUserEmailCollisions(groups, { sheetName: 'X', entityType: 'client' });
+    expect(errs).toEqual([]);
+    expect(dbMock.manyOrNone).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/tests/unit/spreadsheetHelpers.test.js
+++ b/apps/server/tests/unit/spreadsheetHelpers.test.js
@@ -5,9 +5,23 @@
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { WorkbookBuilder, WorkbookReader, writeXlsx } from '@nap-sft/tablsx';
-import { getEnumColumns, validateChildEnums, buildChildSheet, curateRows, parseSheet } from '../../src/lib/spreadsheetHelpers.js';
+
+// Mock the db module so validateImportGroups / checkPortalUserEmailCollisions
+// can be exercised without a real Postgres connection.
+const dbMock = { manyOrNone: vi.fn() };
+vi.mock('../../src/db/db.js', () => ({ default: dbMock, pgp: { as: { name: (s) => `"${s}"` } } }));
+
+const {
+  getEnumColumns,
+  validateChildEnums,
+  buildChildSheet,
+  curateRows,
+  parseSheet,
+  validateImportGroups,
+  checkPortalUserEmailCollisions,
+} = await import('../../src/lib/spreadsheetHelpers.js');
 
 describe('getEnumColumns', () => {
   it('extracts enum values from a CHECK IN (...) constraint', () => {
@@ -269,5 +283,105 @@ describe('buildChildSheet (UUID round-trip)', () => {
     const sheet = reader.sheet(sheetIdx);
     const headers = sheet.getRow(0).map((c) => c.value);
     expect(headers).toEqual(['employee_id', 'id', 'email', 'label']);
+  });
+});
+
+// ── Cross-tenant portal_user collision check ───────────────────────────────
+describe('validateImportGroups (cross-tenant portal_user collision)', () => {
+  beforeEach(() => {
+    dbMock.manyOrNone.mockReset();
+  });
+
+  function makeGroup({ name = 'Acme', email = 'a@b.com', isLogin = true, rowNum = 2 } = {}) {
+    return {
+      parent: { name, _rowNum: rowNum },
+      children: { emails: [{ email, is_login: isLogin, _rowNum: rowNum }] },
+    };
+  }
+
+  it('blocks an employee row whose login email matches an existing portal_user', async () => {
+    dbMock.manyOrNone.mockResolvedValueOnce([{ email: 'collide@x.com' }]);
+    const groups = [makeGroup({ email: 'collide@x.com', rowNum: 5 })];
+    const errors = await validateImportGroups(groups, {
+      sheetName: 'Employees',
+      requiredFields: ['name'],
+      entityType: 'employee',
+    });
+    expect(dbMock.manyOrNone).toHaveBeenCalledTimes(1);
+    const collisionErrs = errors.filter((e) => /already in use by another portal user/.test(e.message));
+    expect(collisionErrs.length).toBe(1);
+    expect(collisionErrs[0].row).toBe(5);
+    expect(collisionErrs[0].column).toBe('email');
+    expect(collisionErrs[0].value).toBe('collide@x.com');
+  });
+
+  it('blocks a client row on collision', async () => {
+    dbMock.manyOrNone.mockResolvedValueOnce([{ email: 'shared@x.com' }]);
+    const groups = [makeGroup({ email: 'shared@x.com', rowNum: 7 })];
+    const errors = await validateImportGroups(groups, {
+      sheetName: 'Clients',
+      requiredFields: ['name'],
+      entityType: 'client',
+    });
+    expect(errors.some((e) => /already in use by another portal user/.test(e.message))).toBe(true);
+  });
+
+  it('does NOT block a vendor_contact row on collision (controller binds existing)', async () => {
+    dbMock.manyOrNone.mockResolvedValueOnce([{ email: 'shared@x.com' }]);
+    const groups = [makeGroup({ email: 'shared@x.com', rowNum: 9 })];
+    const errors = await validateImportGroups(groups, {
+      sheetName: 'Vendor Contacts',
+      requiredFields: ['first_name', 'last_name'],
+      entityType: 'vendor_contact',
+    });
+    // entityType 'vendor_contact' currently short-circuits before issuing the
+    // DB lookup, so we don't even hit the DB.
+    expect(errors.some((e) => /already in use by another portal user/.test(e.message))).toBe(false);
+  });
+
+  it('skips the DB lookup entirely when there are no groups or no login emails', async () => {
+    // Empty groups
+    let errors = await validateImportGroups([], {
+      sheetName: 'Employees',
+      requiredFields: ['name'],
+      entityType: 'employee',
+    });
+    expect(errors).toEqual([]);
+    expect(dbMock.manyOrNone).not.toHaveBeenCalled();
+
+    // Groups without any is_login email
+    const groups = [makeGroup({ email: 'a@b.com', isLogin: false })];
+    errors = await validateImportGroups(groups, {
+      sheetName: 'Employees',
+      requiredFields: ['name'],
+      entityType: 'employee',
+    });
+    expect(dbMock.manyOrNone).not.toHaveBeenCalled();
+    expect(errors.filter((e) => /already in use by another portal user/.test(e.message))).toEqual([]);
+  });
+
+  it('does not run the lookup when entityType is omitted', async () => {
+    const groups = [makeGroup({ email: 'a@b.com' })];
+    await validateImportGroups(groups, { sheetName: 'Vendors', requiredFields: ['name'] });
+    expect(dbMock.manyOrNone).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkPortalUserEmailCollisions', () => {
+  beforeEach(() => dbMock.manyOrNone.mockReset());
+
+  it('returns no errors when entityType is vendor_contact even with collisions', async () => {
+    dbMock.manyOrNone.mockResolvedValueOnce([{ email: 'a@b.com' }]);
+    const groups = [{ parent: {}, children: { emails: [{ email: 'a@b.com', is_login: true, _rowNum: 2 }] } }];
+    const errs = await checkPortalUserEmailCollisions(groups, { sheetName: 'X', entityType: 'vendor_contact' });
+    expect(errs).toEqual([]);
+  });
+
+  it('treats string "true" is_login values as truthy', async () => {
+    dbMock.manyOrNone.mockResolvedValueOnce([{ email: 'a@b.com' }]);
+    const groups = [{ parent: {}, children: { emails: [{ email: 'a@b.com', is_login: 'true', _rowNum: 3 }] } }];
+    const errs = await checkPortalUserEmailCollisions(groups, { sheetName: 'X', entityType: 'employee' });
+    expect(errs.length).toBe(1);
+    expect(errs[0].row).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

Task 10 of the Import Dedup & Multi-Tenant Vendor Access plan. \`validateImportGroups\` (and the per-row code paths in \`importSourceEntity\` / \`importFlatSourceEntity\`) now batch-check incoming login emails against \`admin.portal_users\` so cross-tenant collisions are caught up-front rather than at write time.

| Incoming entity | Login email already in admin.portal_users | Outcome |
|---|---|---|
| employee | yes | Row error: \`"Login email <X> is already in use by another portal user. Single-tenant entities cannot share login identity."\` |
| client | yes | Same row error |
| vendor_contact | yes | No error — the controller's bind-existing path (Task 6) handles it at write time |

Single \`SELECT email FROM admin.portal_users WHERE LOWER(email) = ANY($1::text[]) AND deactivated_at IS NULL\` per import — N+1 avoided.

## Wiring

\`config.appUserProvisioning.entityType\` (already 'employee' / 'client' / 'vendor_contact' / null in each model's CONFIG) drives the policy. \`Vendors.js\` passes \`entityType: 'vendor_contact'\` for the contact sheet; the vendor parent sheet has no entityType (no per-row login). Companies (\`appUserProvisioning: null\`) is correctly skipped.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`tests/unit/spreadsheetHelpers.test.js\` — 24/24 (was 17, +7 new) covering employee/client/vendor_contact branches and skip cases
- [x] \`tests/contract/importCrossTenantEmail.test.js\` — end-to-end employee xls import with a colliding email returns 422 with the row error