### PR TITLE
feat(server): vendor tenant-switching binding validation (Task 13)

### DIFF
--- a/apps/server/src/middleware/authRedis.js
+++ b/apps/server/src/middleware/authRedis.js
@@ -138,33 +138,47 @@ export function authRedis() {
       // ── Schema + binding resolution ─────────────────────────────────────
       // Schema/data resolution follows the resolved tenant_code. Entity
       // context (entity_type/entity_id) follows the matching binding when
-      // one exists — otherwise it falls back to the home binding so
-      // Axerra cross-tenant switching keeps working without a binding.
+      // one exists.
+      //
+      // Cross-tenant switch policy (Task 13):
+      //   - Tenant users (vendors, clients, employees) MUST have an active
+      //     portal_user_tenants binding to the requested tenant. No binding
+      //     → 403. Without this guard a vendor in tenant A could set
+      //     `x-tenant-code: TENANT_B` and read TENANT_B data with their
+      //     home-tenant permissions.
+      //   - Axerra root users may switch without a binding — that's the
+      //     design for cross-tenant administration. The Axerra escape
+      //     hatch keys off `home_tenant === ROOT_TENANT_CODE` (case-
+      //     insensitive, same pattern as requireRootTenant).
+      const rootTenantCode = (process.env.ROOT_TENANT_CODE || 'axerra').toLowerCase();
+      const isRootHomeTenant = homeTenantCode === rootTenantCode;
       const homeSchemaName = homeTenantRecord.schema_name;
       let dataSchemaName = homeSchemaName;
       let effectiveTenantRecord = homeTenantRecord;
       let activeBinding = homeBinding;
       if (headerTenant && tenantCode !== homeTenantCode) {
-        try {
-          const row = await db.oneOrNone(
-            'SELECT * FROM admin.tenants WHERE LOWER(tenant_code) = $1 AND deactivated_at IS NULL',
-            [tenantCode],
-          );
-          if (row) {
-            dataSchemaName = row.schema_name;
-            effectiveTenantRecord = row;
-            const matchedBinding = await db.oneOrNone(
-              `SELECT id, portal_user_id, tenant_id, entity_type, entity_id, status
-               FROM admin.portal_user_tenants
-               WHERE portal_user_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-              [uid, row.id],
-            );
-            if (matchedBinding) {
-              activeBinding = matchedBinding;
-            }
-          }
-        } catch {
-          // Fall back to home schema if lookup fails
+        // DB errors here propagate to the outer catch which 401s — we
+        // can't safely authorize a request whose tenant resolution failed.
+        const row = await db.oneOrNone(
+          'SELECT * FROM admin.tenants WHERE LOWER(tenant_code) = $1 AND deactivated_at IS NULL',
+          [tenantCode],
+        );
+        if (!row) {
+          return res.status(404).json({ error: `Unknown tenant_code: ${tenantCode}` });
+        }
+        const matchedBinding = await db.oneOrNone(
+          `SELECT id, portal_user_id, tenant_id, entity_type, entity_id, status
+           FROM admin.portal_user_tenants
+           WHERE portal_user_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
+          [uid, row.id],
+        );
+        if (!matchedBinding && !isRootHomeTenant) {
+          return res.status(403).json({ error: 'No active binding to the requested tenant' });
+        }
+        dataSchemaName = row.schema_name;
+        effectiveTenantRecord = row;
+        if (matchedBinding) {
+          activeBinding = matchedBinding;
         }
       }
 

--- a/apps/server/tests/unit/authRedis.test.js
+++ b/apps/server/tests/unit/authRedis.test.js
@@ -7,9 +7,25 @@
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 import jwt from 'jsonwebtoken';
 import { authRedis } from '../../src/middleware/authRedis.js';
+
+// Pin ROOT_TENANT_CODE for the lifetime of this file. Other test suites
+// (helpers/testDb.js, contract/reports.test.js) write the env at module
+// load, and Vitest can reuse workers across files — without an explicit
+// pin here, root-vs-non-root expectations would be order-dependent.
+const ORIGINAL_ROOT_TENANT_CODE = process.env.ROOT_TENANT_CODE;
+beforeAll(() => {
+  process.env.ROOT_TENANT_CODE = 'AXERRA';
+});
+afterAll(() => {
+  if (ORIGINAL_ROOT_TENANT_CODE === undefined) {
+    delete process.env.ROOT_TENANT_CODE;
+  } else {
+    process.env.ROOT_TENANT_CODE = ORIGINAL_ROOT_TENANT_CODE;
+  }
+});
 
 // Mock Redis module
 vi.mock('../../src/db/redis.js', () => {
@@ -435,6 +451,7 @@ describe('authRedis middleware', () => {
     await middleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Unknown tenant_code: nope' });
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/tests/unit/authRedis.test.js
+++ b/apps/server/tests/unit/authRedis.test.js
@@ -286,4 +286,155 @@ describe('authRedis middleware', () => {
     expect(req.user.tenant_id).toBe(acmeTenantId);
     expect(req.user.home_tenant).toBe('axerra');
   });
+
+  // ── Task 13: cross-tenant binding validation ──────────────────────────
+
+  test('non-Axerra user with no binding to requested tenant → 403', async () => {
+    const userId = '550e8400-e29b-41d4-a716-446655440000';
+    const homeTenantId = '660e8400-e29b-41d4-a716-446655440000';
+    const otherTenantId = '770e8400-e29b-41d4-a716-446655440000';
+    const token = jwt.sign({ sub: userId, ph: null }, SECRET, { expiresIn: '15m' });
+
+    mockFindOneBy.mockResolvedValue({
+      id: userId,
+      email: 'vendor@acme.com',
+      status: 'active',
+    });
+
+    mockFindById.mockResolvedValue({
+      id: homeTenantId,
+      tenant_code: 'ACME',
+      schema_name: 'acme',
+    });
+
+    // 1) home binding (ACME), 2) requested tenant lookup (BETA), 3) matched binding for BETA → none
+    mockOneOrNone
+      .mockResolvedValueOnce({
+        id: 'binding-1',
+        portal_user_id: userId,
+        tenant_id: homeTenantId,
+        entity_type: 'vendor_contact',
+        entity_id: 'vc-1',
+        status: 'active',
+      })
+      .mockResolvedValueOnce({
+        id: otherTenantId,
+        tenant_code: 'BETA',
+        schema_name: 'beta',
+      })
+      .mockResolvedValueOnce(null);
+
+    const req = makeReq({
+      cookies: { auth_token: token },
+      headers: { 'x-tenant-code': 'BETA' },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'No active binding to the requested tenant' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('non-Axerra user with binding to requested tenant → switches successfully', async () => {
+    const userId = '550e8400-e29b-41d4-a716-446655440000';
+    const homeTenantId = '660e8400-e29b-41d4-a716-446655440000';
+    const otherTenantId = '770e8400-e29b-41d4-a716-446655440000';
+    const token = jwt.sign({ sub: userId, ph: null }, SECRET, { expiresIn: '15m' });
+
+    mockFindOneBy.mockResolvedValue({
+      id: userId,
+      email: 'vendor@multi.com',
+      status: 'active',
+    });
+
+    mockFindById.mockResolvedValue({
+      id: homeTenantId,
+      tenant_code: 'ACME',
+      schema_name: 'acme',
+    });
+
+    // 1) home binding (ACME), 2) requested tenant (BETA), 3) matched binding (BETA)
+    mockOneOrNone
+      .mockResolvedValueOnce({
+        id: 'binding-1',
+        portal_user_id: userId,
+        tenant_id: homeTenantId,
+        entity_type: 'vendor_contact',
+        entity_id: 'vc-1',
+        status: 'active',
+      })
+      .mockResolvedValueOnce({
+        id: otherTenantId,
+        tenant_code: 'BETA',
+        schema_name: 'beta',
+      })
+      .mockResolvedValueOnce({
+        id: 'binding-2',
+        portal_user_id: userId,
+        tenant_id: otherTenantId,
+        entity_type: 'vendor_contact',
+        entity_id: 'vc-2',
+        status: 'active',
+      });
+
+    const req = makeReq({
+      cookies: { auth_token: token },
+      headers: { 'x-tenant-code': 'BETA' },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user.tenant_code).toBe('beta');
+    expect(req.user.schema_name).toBe('beta');
+    expect(req.user.entity_id).toBe('vc-2');
+    expect(req.user.home_tenant).toBe('acme');
+  });
+
+  test('returns 404 when x-tenant-code points at a tenant that does not exist', async () => {
+    const userId = '550e8400-e29b-41d4-a716-446655440000';
+    const homeTenantId = '660e8400-e29b-41d4-a716-446655440000';
+    const token = jwt.sign({ sub: userId, ph: null }, SECRET, { expiresIn: '15m' });
+
+    mockFindOneBy.mockResolvedValue({
+      id: userId,
+      email: 'admin@axerra.io',
+      status: 'active',
+    });
+
+    mockFindById.mockResolvedValue({
+      id: homeTenantId,
+      tenant_code: 'AXERRA',
+      schema_name: 'axerra',
+    });
+
+    // 1) home binding, 2) requested tenant lookup → none
+    mockOneOrNone
+      .mockResolvedValueOnce({
+        id: 'binding-1',
+        portal_user_id: userId,
+        tenant_id: homeTenantId,
+        entity_type: 'employee',
+        entity_id: 'emp-1',
+        status: 'active',
+      })
+      .mockResolvedValueOnce(null);
+
+    const req = makeReq({
+      cookies: { auth_token: token },
+      headers: { 'x-tenant-code': 'NOPE' },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Closes Task 13 of the import-dedup + multi-tenant-vendor plan — the verification step that ensures cross-tenant switching can only target tenants the user has an active `portal_user_tenants` binding to.

## What changed

`authRedis` previously had a soft fallback for `x-tenant-code`: schema/tenant_record would switch to the requested tenant but `activeBinding` silently fell back to the home binding. A vendor in tenant A could set `x-tenant-code: TENANT_B` and read TENANT_B's data through the home binding's permissions — a multi-tenant isolation gap.

The middleware now:
- Looks up the requested tenant (404 if it doesn't exist, was: silent fall-back to home).
- Looks up the matching `portal_user_tenants` binding for (user, requested_tenant). If none exists and the user's home tenant isn't the Axerra root, returns **403** with `No active binding to the requested tenant`.
- Axerra root users keep cross-tenant switching without a binding — that's the documented design for cross-tenant administration and impersonation. The escape-hatch reads `process.env.ROOT_TENANT_CODE` (default `axerra`), case-insensitive, same pattern as `requireRootTenant`.

## Tests

Three new unit tests in `tests/unit/authRedis.test.js`:
- Non-Axerra user with no binding to requested tenant → 403
- Non-Axerra user with binding to requested tenant → switches successfully (`entity_id` reflects the matched binding)
- Unknown `tenant_code` → 404

Existing Axerra-as-caller cross-tenant tests are unchanged — the escape-hatch preserves their behavior.

## Test plan

- [x] `npm -w apps/server run test:unit -- authRedis` — 138/138 pass (was 135 + 3 new)
- [x] `npm -w apps/server test` — 535/535 pass
- [x] `npm run lint` — clean (one pre-existing warning unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)