### PR TITLE
feat(server): bring tenants/* under rbac() enforcement (closes #57)

### DIFF
--- a/apps/server/scripts/setupAdmin.js
+++ b/apps/server/scripts/setupAdmin.js
@@ -144,80 +144,15 @@ async function main() {
   }
 
   // ── Link root super user to an employee record ──────────────
-  const rootEmail = process.env.ROOT_EMAIL;
-  if (rootEmail) {
-    const superUser = await db.oneOrNone(
-      'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
-      [rootEmail],
-    );
-
-    if (superUser && tenant) {
-      // Look for an existing binding for the root tenant. A bare binding
-      // (no entity_type yet) gets its entity link populated rather than
-      // a second binding being inserted.
-      const existingBinding = await db.oneOrNone(
-        `SELECT id, entity_type, entity_id FROM admin.portal_user_tenants
-         WHERE portal_user_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
-        [superUser.id, tenant.id],
-      );
-
-      if (!existingBinding || existingBinding.entity_type === null) {
-        logger.info('Linking root super user to employee record...');
-        const s = DB.pgp.as.name(tenantSchema);
-
-        // 1. Insert employee with super_user role
-        const employee = await db.one(
-          `INSERT INTO ${s}.employees
-             (tenant_id, first_name, last_name, is_app_user, roles, is_primary_contact)
-           VALUES ($1, 'System', 'Administrator', true, '{super_user}', true)
-           RETURNING id`,
-          [tenant.id],
-        );
-
-        // 2. Create polymorphic source record
-        const source = await db.one(
-          `INSERT INTO ${s}.sources (tenant_id, table_id, source_type, label)
-           VALUES ($1, $2, 'employee', 'System Administrator')
-           RETURNING id`,
-          [tenant.id, employee.id],
-        );
-
-        // 3. Link source back to employee
-        await db.none(`UPDATE ${s}.employees SET source_id = $1 WHERE id = $2`, [source.id, employee.id]);
-
-        // 3b. Create login email in the emails table
-        await db.one(
-          `INSERT INTO ${s}.emails
-             (tenant_id, source_id, email, label, is_primary, is_login)
-           VALUES ($1, $2, $3, 'work', true, true)
-           RETURNING id`,
-          [tenant.id, source.id, rootEmail],
-        );
-
-        // 4. Populate (or insert) the binding's entity link. A bare
-        // binding from a prior register call is updated in place to
-        // preserve the unique (portal_user_id, tenant_id) row.
-        if (existingBinding) {
-          await db.none(
-            `UPDATE admin.portal_user_tenants
-             SET entity_type = 'employee', entity_id = $1, status = 'active'
-             WHERE id = $2`,
-            [employee.id, existingBinding.id],
-          );
-        } else {
-          await db.none(
-            `INSERT INTO admin.portal_user_tenants (portal_user_id, tenant_id, entity_type, entity_id, status)
-             VALUES ($1, $2, 'employee', $3, 'active')`,
-            [superUser.id, tenant.id, employee.id],
-          );
-        }
-
-        logger.info(`Root super user bound to employee ${employee.id}`);
-      } else {
-        logger.info('Root super user already linked to entity, skipping.');
-      }
-    }
-  }
+  const { seedRootEntity } = await import('../src/services/seedRootEntity.js');
+  await seedRootEntity({
+    db,
+    pgp: DB.pgp,
+    logger,
+    tenantSchema,
+    rootEmail: process.env.ROOT_EMAIL,
+    includeLoginEmail: true,
+  });
 
   logger.info('Admin setup complete.');
   await db.$pool.end();

--- a/apps/server/src/lib/createRouter.js
+++ b/apps/server/src/lib/createRouter.js
@@ -55,6 +55,7 @@ export default function createRouter(controller, extendRoutes, options = {}) {
     disableImportXls = false,
     disableExportXls = false,
     disableGetArchived = false,
+    disablePing = false,
   } = options;
 
   // Ensure addAuditFields is included on mutation routes
@@ -97,10 +98,15 @@ export default function createRouter(controller, extendRoutes, options = {}) {
     router.get('/archived', ...safeGet, (req, res) => controller.getWhere(req, res));
   }
 
-  // Ping route (always enabled, no middleware)
-  router.get('/ping', (_req, res) => {
-    res.status(200).json({ message: 'pong' });
-  });
+  // Ping route — defaults to no middleware (cheap health check). Routers
+  // that need every endpoint gated (e.g. tenants/* under requireRootTenant)
+  // should pass disablePing: true so /ping doesn't leak the route's
+  // existence to non-Axerra users.
+  if (!disablePing) {
+    router.get('/ping', (_req, res) => {
+      res.status(200).json({ message: 'pong' });
+    });
+  }
 
   if (!disableGetById) {
     router.get('/:id', ...safeGet, (req, res) => controller.getById(req, res));

--- a/apps/server/src/services/seedRootEntity.js
+++ b/apps/server/src/services/seedRootEntity.js
@@ -56,7 +56,11 @@ export async function seedRootEntity({ db, pgp, logger, tenantSchema, rootEmail,
     [superUser.id, tenant.id],
   );
 
-  if (existingBinding && existingBinding.entity_type !== null) {
+  // A binding is only "linked" if BOTH entity_type AND entity_id are set.
+  // The portal_user_tenants schema doesn't enforce that pairing, so a
+  // partially-written row (entity_type set, entity_id NULL) from a
+  // failed earlier seed should be treated as unlinked and repaired.
+  if (existingBinding && existingBinding.entity_type !== null && existingBinding.entity_id !== null) {
     logger?.info?.('Root super user already linked to entity, skipping.');
     return null;
   }

--- a/apps/server/src/services/seedRootEntity.js
+++ b/apps/server/src/services/seedRootEntity.js
@@ -1,0 +1,118 @@
+/**
+ * @file seedRootEntity — link the Axerra root portal_user to a real employees row
+ * @module server/services/seedRootEntity
+ *
+ * Bridges admin.portal_users (auth identity) and the tenant-scoped employees
+ * table (RBAC source-of-truth via the entity → roles → policies chain). Used
+ * by both the production `setupAdmin` script and the test bootstrap so that
+ * `loadPermissions` resolves real caps for the root user instead of the
+ * empty-canon shortcut taken on bare bindings.
+ *
+ * Idempotent: if a binding already has its entity link populated, returns
+ * without changes. If a bare binding (entity_type IS NULL) exists, it's
+ * updated in place to preserve the unique (portal_user_id, tenant_id) row.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+/**
+ * @param {Object} opts
+ * @param {Object} opts.db         pg-promise database connection
+ * @param {Object} opts.pgp        pg-promise helpers (for as.name)
+ * @param {Object} opts.logger     winston-style logger
+ * @param {string} opts.tenantSchema  Tenant schema name (e.g. 'axerra')
+ * @param {string} opts.rootEmail     Email of the admin.portal_users row to bind
+ * @param {boolean} [opts.includeLoginEmail=true]
+ *   Insert a tenant-scoped emails row mirroring the login email. Defaults true
+ *   for production parity. Tests can pass false — rbac resolution doesn't
+ *   need it and the row would fight the test cleanup path.
+ * @returns {Promise<{employeeId: string, bindingId: string} | null>}
+ *   Returns the new IDs on first run, null if already linked.
+ */
+export async function seedRootEntity({ db, pgp, logger, tenantSchema, rootEmail, includeLoginEmail = true }) {
+  if (!rootEmail) return null;
+
+  const superUser = await db.oneOrNone(
+    'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+    [rootEmail],
+  );
+  if (!superUser) {
+    logger?.warn?.('seedRootEntity: portal_user not found', { email: rootEmail });
+    return null;
+  }
+
+  const tenant = await db.oneOrNone(
+    'SELECT id FROM admin.tenants WHERE schema_name = $1 AND deactivated_at IS NULL',
+    [tenantSchema],
+  );
+  if (!tenant) {
+    logger?.warn?.('seedRootEntity: tenant not found', { tenantSchema });
+    return null;
+  }
+
+  const existingBinding = await db.oneOrNone(
+    `SELECT id, entity_type, entity_id FROM admin.portal_user_tenants
+     WHERE portal_user_id = $1 AND tenant_id = $2 AND deactivated_at IS NULL`,
+    [superUser.id, tenant.id],
+  );
+
+  if (existingBinding && existingBinding.entity_type !== null) {
+    logger?.info?.('Root super user already linked to entity, skipping.');
+    return null;
+  }
+
+  logger?.info?.('Linking root super user to employee record...');
+  const s = pgp.as.name(tenantSchema);
+
+  const employee = await db.one(
+    `INSERT INTO ${s}.employees
+       (tenant_id, first_name, last_name, is_app_user, roles, is_primary_contact)
+     VALUES ($1, 'System', 'Administrator', true, '{super_user}', true)
+     RETURNING id`,
+    [tenant.id],
+  );
+
+  const source = await db.one(
+    `INSERT INTO ${s}.sources (tenant_id, table_id, source_type, label)
+     VALUES ($1, $2, 'employee', 'System Administrator')
+     RETURNING id`,
+    [tenant.id, employee.id],
+  );
+
+  await db.none(`UPDATE ${s}.employees SET source_id = $1 WHERE id = $2`, [source.id, employee.id]);
+
+  if (includeLoginEmail) {
+    await db.one(
+      `INSERT INTO ${s}.emails
+         (tenant_id, source_id, email, label, is_primary, is_login)
+       VALUES ($1, $2, $3, 'work', true, true)
+       RETURNING id`,
+      [tenant.id, source.id, rootEmail],
+    );
+  }
+
+  let bindingId;
+  if (existingBinding) {
+    const updated = await db.one(
+      `UPDATE admin.portal_user_tenants
+       SET entity_type = 'employee', entity_id = $1, status = 'active'
+       WHERE id = $2
+       RETURNING id`,
+      [employee.id, existingBinding.id],
+    );
+    bindingId = updated.id;
+  } else {
+    const inserted = await db.one(
+      `INSERT INTO admin.portal_user_tenants (portal_user_id, tenant_id, entity_type, entity_id, status)
+       VALUES ($1, $2, 'employee', $3, 'active')
+       RETURNING id`,
+      [superUser.id, tenant.id, employee.id],
+    );
+    bindingId = inserted.id;
+  }
+
+  logger?.info?.(`Root super user bound to employee ${employee.id}`);
+  return { employeeId: employee.id, bindingId };
+}
+
+export default seedRootEntity;

--- a/apps/server/src/services/seedRootEntity.js
+++ b/apps/server/src/services/seedRootEntity.js
@@ -64,31 +64,49 @@ export async function seedRootEntity({ db, pgp, logger, tenantSchema, rootEmail,
   logger?.info?.('Linking root super user to employee record...');
   const s = pgp.as.name(tenantSchema);
 
-  const employee = await db.one(
-    `INSERT INTO ${s}.employees
-       (tenant_id, first_name, last_name, is_app_user, roles, is_primary_contact)
-     VALUES ($1, 'System', 'Administrator', true, '{super_user}', true)
-     RETURNING id`,
-    [tenant.id],
+  // Find an existing System/Administrator employee (idempotent path used
+  // by the test bootstrap, where the axerra schema persists across the
+  // admin truncation between test files but the binding is recreated).
+  // If found, reuse it and just rebind. Otherwise create a fresh one.
+  const existingEmployee = await db.oneOrNone(
+    `SELECT id FROM ${s}.employees
+     WHERE first_name = 'System' AND last_name = 'Administrator'
+       AND deactivated_at IS NULL
+     ORDER BY created_at ASC
+     LIMIT 1`,
   );
 
-  const source = await db.one(
-    `INSERT INTO ${s}.sources (tenant_id, table_id, source_type, label)
-     VALUES ($1, $2, 'employee', 'System Administrator')
-     RETURNING id`,
-    [tenant.id, employee.id],
-  );
-
-  await db.none(`UPDATE ${s}.employees SET source_id = $1 WHERE id = $2`, [source.id, employee.id]);
-
-  if (includeLoginEmail) {
-    await db.one(
-      `INSERT INTO ${s}.emails
-         (tenant_id, source_id, email, label, is_primary, is_login)
-       VALUES ($1, $2, $3, 'work', true, true)
+  let employee;
+  if (existingEmployee) {
+    employee = existingEmployee;
+    logger?.info?.(`Reusing existing System Administrator employee ${employee.id}`);
+  } else {
+    employee = await db.one(
+      `INSERT INTO ${s}.employees
+         (tenant_id, first_name, last_name, is_app_user, roles, is_primary_contact)
+       VALUES ($1, 'System', 'Administrator', true, '{super_user}', true)
        RETURNING id`,
-      [tenant.id, source.id, rootEmail],
+      [tenant.id],
     );
+
+    const source = await db.one(
+      `INSERT INTO ${s}.sources (tenant_id, table_id, source_type, label)
+       VALUES ($1, $2, 'employee', 'System Administrator')
+       RETURNING id`,
+      [tenant.id, employee.id],
+    );
+
+    await db.none(`UPDATE ${s}.employees SET source_id = $1 WHERE id = $2`, [source.id, employee.id]);
+
+    if (includeLoginEmail) {
+      await db.one(
+        `INSERT INTO ${s}.emails
+           (tenant_id, source_id, email, label, is_primary, is_login)
+         VALUES ($1, $2, $3, 'work', true, true)
+         RETURNING id`,
+        [tenant.id, source.id, rootEmail],
+      );
+    }
   }
 
   let bindingId;

--- a/apps/server/src/services/seedRootEntity.js
+++ b/apps/server/src/services/seedRootEntity.js
@@ -64,21 +64,36 @@ export async function seedRootEntity({ db, pgp, logger, tenantSchema, rootEmail,
   logger?.info?.('Linking root super user to employee record...');
   const s = pgp.as.name(tenantSchema);
 
-  // Find an existing System/Administrator employee (idempotent path used
-  // by the test bootstrap, where the axerra schema persists across the
-  // admin truncation between test files but the binding is recreated).
-  // If found, reuse it and just rebind. Otherwise create a fresh one.
+  // Find an existing System/Administrator employee scoped to THIS tenant
+  // and verified to carry the super_user role. The idempotent path used
+  // by the test bootstrap is: axerra schema persists across the admin
+  // truncation between test files but the binding is recreated. The
+  // tenant_id and roles checks ensure we never bind to an unrelated
+  // employee that happens to share the System/Administrator name.
   const existingEmployee = await db.oneOrNone(
     `SELECT id FROM ${s}.employees
      WHERE first_name = 'System' AND last_name = 'Administrator'
+       AND tenant_id = $1
+       AND 'super_user' = ANY(roles)
        AND deactivated_at IS NULL
      ORDER BY created_at ASC
      LIMIT 1`,
+    [tenant.id],
   );
 
   let employee;
   if (existingEmployee) {
     employee = existingEmployee;
+    // Defensive re-assert that the role is present and the row is the
+    // primary contact — protects against a partial seed from an earlier
+    // failed run.
+    await db.none(
+      `UPDATE ${s}.employees
+       SET roles = ARRAY(SELECT DISTINCT unnest(roles || '{super_user}')),
+           is_primary_contact = true
+       WHERE id = $1`,
+      [employee.id],
+    );
     logger?.info?.(`Reusing existing System Administrator employee ${employee.id}`);
   } else {
     employee = await db.one(

--- a/apps/server/src/system/core/services/policyCatalogSeeder.js
+++ b/apps/server/src/system/core/services/policyCatalogSeeder.js
@@ -240,13 +240,13 @@ const CATALOG_ENTRIES = [
   // independently grantable in the role editor. Use them to compose
   // finer-grained Axerra ops roles (e.g. read-only auditor with only
   // view-level grants) on top of the wildcard super_user role.
+  // tenants::tenants and tenants::portal-users disable createRouter's
+  // auto-attached /import-xls and /export-xls (they aren't real
+  // spreadsheet I/O surfaces here), so no import/export catalog rows
+  // for those routers — granting them would have no effect.
   { module: 'tenants', router: null, action: null, label: 'Tenants Module', description: 'Multi-tenant administration (Axerra only)', sort_order: 1100 },
   { module: 'tenants', router: 'tenants', action: null, label: 'Tenants', description: 'Tenant CRUD and provisioning', sort_order: 1110 },
-  { module: 'tenants', router: 'tenants', action: 'import', label: 'Import Tenants', description: 'Import tenant records from spreadsheet', sort_order: 1111 },
-  { module: 'tenants', router: 'tenants', action: 'export', label: 'Export Tenants', description: 'Export tenant records to spreadsheet', sort_order: 1112 },
   { module: 'tenants', router: 'portal-users', action: null, label: 'Portal Users', description: 'Application user accounts', sort_order: 1120 },
-  { module: 'tenants', router: 'portal-users', action: 'import', label: 'Import Portal Users', description: 'Import portal user records from spreadsheet', sort_order: 1121 },
-  { module: 'tenants', router: 'portal-users', action: 'export', label: 'Export Portal Users', description: 'Export portal user records to spreadsheet', sort_order: 1122 },
   { module: 'tenants', router: 'orphan-portal-users', action: null, label: 'Orphan Portal Users', description: 'Maintenance for portal_users with no tenant bindings (Axerra only)', sort_order: 1125 },
   { module: 'tenants', router: 'orphan-portal-users', action: 'find_orphans', label: 'Preview Orphan Portal Users', description: 'List portal_users rows with no portal_user_tenants binding (active or archived) and no impersonation_logs reference', sort_order: 1126 },
   { module: 'tenants', router: 'orphan-portal-users', action: 'cleanup_orphans', label: 'Clean Up Orphan Portal Users', description: 'Hard-delete a single orphan portal_user. Requires Preview Orphan Portal Users — the UI gates cleanup on a successful preview.', sort_order: 1127 },

--- a/apps/server/src/system/core/services/policyCatalogSeeder.js
+++ b/apps/server/src/system/core/services/policyCatalogSeeder.js
@@ -235,24 +235,25 @@ const CATALOG_ENTRIES = [
   { module: 'reports', router: 'margin-analysis', action: null, label: 'Margin Analysis', description: 'Cross-project margin comparison and trending', sort_order: 1070 },
 
   // ── Tenants (Axerra admin scope) ───────────────────────────────
+  // Tenants module routes are gated first by `requireRootTenant` (Axerra
+  // membership) and then by `rbac()`, so the action-level rows below are
+  // independently grantable in the role editor. Use them to compose
+  // finer-grained Axerra ops roles (e.g. read-only auditor with only
+  // view-level grants) on top of the wildcard super_user role.
   { module: 'tenants', router: null, action: null, label: 'Tenants Module', description: 'Multi-tenant administration (Axerra only)', sort_order: 1100 },
   { module: 'tenants', router: 'tenants', action: null, label: 'Tenants', description: 'Tenant CRUD and provisioning', sort_order: 1110 },
-  { module: 'tenants', router: 'tenants', action: 'import', label: 'Import Tenants', description: 'Import tenant records from spreadsheet', sort_order: 1111, policy_required: false },
-  { module: 'tenants', router: 'tenants', action: 'export', label: 'Export Tenants', description: 'Export tenant records to spreadsheet', sort_order: 1112, policy_required: false },
+  { module: 'tenants', router: 'tenants', action: 'import', label: 'Import Tenants', description: 'Import tenant records from spreadsheet', sort_order: 1111 },
+  { module: 'tenants', router: 'tenants', action: 'export', label: 'Export Tenants', description: 'Export tenant records to spreadsheet', sort_order: 1112 },
   { module: 'tenants', router: 'portal-users', action: null, label: 'Portal Users', description: 'Application user accounts', sort_order: 1120 },
-  { module: 'tenants', router: 'portal-users', action: 'import', label: 'Import Portal Users', description: 'Import portal user records from spreadsheet', sort_order: 1121, policy_required: false },
-  { module: 'tenants', router: 'portal-users', action: 'export', label: 'Export Portal Users', description: 'Export portal user records to spreadsheet', sort_order: 1122, policy_required: false },
-  // Decorative catalog entries — the tenants/* router convention enforces
-  // Axerra-only via requireRootTenant, not via rbac(), so these rows
-  // document the action codes for tooling but are not independently grantable.
-  { module: 'tenants', router: 'orphan-portal-users', action: null, label: 'Orphan Portal Users', description: 'Maintenance for portal_users with no tenant bindings (Axerra only — gated by requireRootTenant, not rbac)', sort_order: 1125, policy_required: false },
-  { module: 'tenants', router: 'orphan-portal-users', action: 'find_orphans', label: 'Preview Orphan Portal Users', description: 'List portal_users rows with no portal_user_tenants binding (active or archived) and no impersonation_logs reference. Decorative — enforcement is requireRootTenant.', sort_order: 1126, policy_required: false },
-  { module: 'tenants', router: 'orphan-portal-users', action: 'cleanup_orphans', label: 'Clean Up Orphan Portal Users', description: 'Hard-delete a single orphan portal_user. Decorative — enforcement is requireRootTenant.', sort_order: 1127, policy_required: false },
+  { module: 'tenants', router: 'portal-users', action: 'import', label: 'Import Portal Users', description: 'Import portal user records from spreadsheet', sort_order: 1121 },
+  { module: 'tenants', router: 'portal-users', action: 'export', label: 'Export Portal Users', description: 'Export portal user records to spreadsheet', sort_order: 1122 },
+  { module: 'tenants', router: 'orphan-portal-users', action: null, label: 'Orphan Portal Users', description: 'Maintenance for portal_users with no tenant bindings (Axerra only)', sort_order: 1125 },
+  { module: 'tenants', router: 'orphan-portal-users', action: 'find_orphans', label: 'Preview Orphan Portal Users', description: 'List portal_users rows with no portal_user_tenants binding (active or archived) and no impersonation_logs reference', sort_order: 1126 },
+  { module: 'tenants', router: 'orphan-portal-users', action: 'cleanup_orphans', label: 'Clean Up Orphan Portal Users', description: 'Hard-delete a single orphan portal_user. Requires Preview Orphan Portal Users — the UI gates cleanup on a successful preview.', sort_order: 1127 },
   { module: 'tenants', router: 'admin', action: null, label: 'Admin Operations', description: 'Schema listing, impersonation', sort_order: 1130 },
-  { module: 'tenants', router: 'admin', action: 'import', label: 'Import Admin', description: 'Import admin operation records from spreadsheet', sort_order: 1131, policy_required: false },
-  { module: 'tenants', router: 'admin', action: 'export', label: 'Export Admin', description: 'Export admin operation records to spreadsheet', sort_order: 1132, policy_required: false },
+  { module: 'tenants', router: 'admin', action: 'list_schemas', label: 'List Tenant Schemas', description: 'Enumerate all provisioned tenant schemas (Axerra only)', sort_order: 1131 },
+  { module: 'tenants', router: 'admin', action: 'impersonate', label: 'Impersonate User', description: 'Begin an impersonation session as another portal_user. Exit and status checks are always allowed within an active session.', sort_order: 1132 },
   { module: 'tenants', router: 'match-review-logs', action: null, label: 'Match Review Logs', description: 'BOM vendor SKU matching audit trail', sort_order: 1140 },
-  { module: 'tenants', router: 'match-review-logs', action: 'export', label: 'Export Match Review Logs', description: 'Export match review log records to spreadsheet', sort_order: 1142, policy_required: false },
 ];
 
 /**

--- a/apps/server/src/system/tenants/apiRoutes/v1/adminRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/adminRouter.js
@@ -2,11 +2,24 @@
  * @file Tenants admin router — schema listing, impersonation per PRD §3.2.3
  * @module tenants/apiRoutes/v1/adminRouter
  *
+ * Enforcement:
+ *   - GET /schemas, POST /impersonate: requireRootTenant + rbac().
+ *     Catalog rows tenants::admin::list_schemas (view) and ::impersonate
+ *     (full) are independently grantable so finer-grained Axerra ops
+ *     roles can hold one without the other.
+ *   - POST /exit-impersonation, GET /impersonation-status: no rbac.
+ *     Exit is an escape hatch — anyone in an impersonated session must
+ *     always be able to exit. Status reads only the caller's own
+ *     session state and leaks no data beyond that.
+ *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
 
 import { Router } from 'express';
 import { requireRootTenant } from '../../../../middleware/requireRootTenant.js';
+import { moduleEntitlement } from '../../../../middleware/moduleEntitlement.js';
+import { rbac } from '../../../../middleware/rbac.js';
+import { withMeta } from '../../../../middleware/withMeta.js';
 import {
   getAllSchemas,
   startImpersonation,
@@ -16,8 +29,22 @@ import {
 
 const router = Router();
 
-router.get('/schemas', requireRootTenant, getAllSchemas);
-router.post('/impersonate', requireRootTenant, startImpersonation);
+router.get(
+  '/schemas',
+  requireRootTenant,
+  withMeta({ module: 'tenants', router: 'admin', action: 'list_schemas' }),
+  moduleEntitlement,
+  rbac('view'),
+  getAllSchemas,
+);
+router.post(
+  '/impersonate',
+  requireRootTenant,
+  withMeta({ module: 'tenants', router: 'admin', action: 'impersonate' }),
+  moduleEntitlement,
+  rbac('full'),
+  startImpersonation,
+);
 router.post('/exit-impersonation', endImpersonation);
 router.get('/impersonation-status', getImpersonationStatus);
 

--- a/apps/server/src/system/tenants/apiRoutes/v1/matchReviewLogsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/matchReviewLogsRouter.js
@@ -9,7 +9,14 @@
 
 import createRouter from '../../../../lib/createRouter.js';
 import matchReviewLogsController from '../../controllers/matchReviewLogsController.js';
+import { requireRootTenant } from '../../../../middleware/requireRootTenant.js';
+import { rbac } from '../../../../middleware/rbac.js';
+import { withMeta } from '../../../../middleware/withMeta.js';
 
+const meta = withMeta({ module: 'tenants', router: 'match-review-logs' });
+
+// Read-only audit log surface. requireRootTenant + view-level rbac;
+// no mutations.
 export default createRouter(matchReviewLogsController, null, {
   disablePost: true,
   disablePut: true,
@@ -18,4 +25,5 @@ export default createRouter(matchReviewLogsController, null, {
   disableBulkInsert: true,
   disableBulkUpdate: true,
   disableImportXls: true,
+  getMiddlewares: [requireRootTenant, meta, rbac('view')],
 });

--- a/apps/server/src/system/tenants/apiRoutes/v1/matchReviewLogsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/matchReviewLogsRouter.js
@@ -9,14 +9,23 @@
 
 import createRouter from '../../../../lib/createRouter.js';
 import matchReviewLogsController from '../../controllers/matchReviewLogsController.js';
+import { moduleEntitlement } from '../../../../middleware/moduleEntitlement.js';
 import { requireRootTenant } from '../../../../middleware/requireRootTenant.js';
 import { rbac } from '../../../../middleware/rbac.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
 
 const meta = withMeta({ module: 'tenants', router: 'match-review-logs' });
 
-// Read-only audit log surface. requireRootTenant + view-level rbac;
-// no mutations.
+// Read-only audit log surface. requireRootTenant → meta →
+// moduleEntitlement → rbac('view'); no mutations.
+//
+// disableExportXls: createRouter would otherwise auto-attach POST
+// /export-xls and run its OWN rbac() pass after this middleware chain
+// — that double-evaluates rbac with two different action codes
+// (router-level then 'export'). Audit-log download isn't a current
+// product requirement; leaving it disabled keeps the enforcement
+// story simple. Re-enable here only after refactoring createRouter
+// to set the action code BEFORE the per-method middleware chain.
 export default createRouter(matchReviewLogsController, null, {
   disablePost: true,
   disablePut: true,
@@ -25,5 +34,6 @@ export default createRouter(matchReviewLogsController, null, {
   disableBulkInsert: true,
   disableBulkUpdate: true,
   disableImportXls: true,
-  getMiddlewares: [requireRootTenant, meta, rbac('view')],
+  disableExportXls: true,
+  getMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('view')],
 });

--- a/apps/server/src/system/tenants/apiRoutes/v1/matchReviewLogsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/matchReviewLogsRouter.js
@@ -35,5 +35,6 @@ export default createRouter(matchReviewLogsController, null, {
   disableBulkUpdate: true,
   disableImportXls: true,
   disableExportXls: true,
+  disablePing: true,
   getMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('view')],
 });

--- a/apps/server/src/system/tenants/apiRoutes/v1/orphanPortalUsersRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/orphanPortalUsersRouter.js
@@ -6,22 +6,18 @@
  *   GET  /orphans/preview   → list orphan portal_users
  *   POST /orphans/cleanup   → hard-delete one orphan by id
  *
- * Two-layer enforcement, in order:
+ * Three-layer enforcement, in order:
  *   1. requireRootTenant — only Axerra-tenant users may reach these routes.
  *   2. rejectImpersonation — even an Axerra user must be in a direct (non-
  *      impersonated) session. Without this an Axerra admin could hit these
  *      destructive routes from an impersonated tenant-user-shaped session
  *      and the audit log wouldn't distinguish the two contexts.
- *
- * The `tenants/*` router convention enforces Axerra-only via tenant
- * membership rather than role-based rbac() — every other tenants/*
- * route does the same. The `tenants::orphan-portal-users::*` catalog
- * entries are seeded (with `policy_required: false`) so the action codes
- * are discoverable in role tooling, but they aren't independently
- * grantable; enforcement on these routes is tenant-membership based.
- * Wiring rbac across the tenants/* surface is a coordinated change that
- * also needs the platform-deploy role provisioning of the Axerra root
- * user (and the test bootstrap) — out of scope for this PR.
+ *   3. rbac() — the role's policy on
+ *      `tenants::orphan-portal-users::find_orphans|cleanup_orphans` is
+ *      consulted, so the policy-catalog entries seeded for these actions
+ *      are actually enforced. The Axerra system roles (super_user,
+ *      support) seed wildcard `'::::'` policy and pass; finer-grained
+ *      Axerra ops roles can deny specific actions independently.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
@@ -29,9 +25,9 @@
 import { Router } from 'express';
 import { findOrphans, cleanupOrphan } from '../../controllers/orphanPortalUsersController.js';
 import { requireRootTenant } from '../../../../middleware/requireRootTenant.js';
+import { moduleEntitlement } from '../../../../middleware/moduleEntitlement.js';
+import { rbac } from '../../../../middleware/rbac.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
-
-const meta = withMeta({ module: 'tenants', router: 'orphan-portal-users' });
 
 /**
  * Reject the request when the caller is in an impersonated session.
@@ -54,7 +50,9 @@ router.get(
   '/orphans/preview',
   requireRootTenant,
   rejectImpersonation,
-  meta,
+  withMeta({ module: 'tenants', router: 'orphan-portal-users', action: 'find_orphans' }),
+  moduleEntitlement,
+  rbac('view'),
   findOrphans,
 );
 
@@ -62,7 +60,9 @@ router.post(
   '/orphans/cleanup',
   requireRootTenant,
   rejectImpersonation,
-  meta,
+  withMeta({ module: 'tenants', router: 'orphan-portal-users', action: 'cleanup_orphans' }),
+  moduleEntitlement,
+  rbac('full'),
   cleanupOrphan,
 );
 

--- a/apps/server/src/system/tenants/apiRoutes/v1/portalUsersRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/portalUsersRouter.js
@@ -11,15 +11,20 @@
 import portalUsersController from '../../controllers/portalUsersController.js';
 import createRouter from '../../../../lib/createRouter.js';
 import { addAuditFields } from '../../../../middleware/addAuditFields.js';
+import { moduleEntitlement } from '../../../../middleware/moduleEntitlement.js';
 import { requireRootTenant } from '../../../../middleware/requireRootTenant.js';
 import { rbac } from '../../../../middleware/rbac.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
 
 const meta = withMeta({ module: 'tenants', router: 'portal-users' });
 
-// Three-layer enforcement: requireRootTenant + meta + rbac. Standard
-// POST is disabled (use /register). The /register custom route is a
-// 'full'-level mutation since it provisions a new portal_user.
+// Per-method middleware order: requireRootTenant → withMeta →
+// moduleEntitlement → rbac. Standard POST is disabled (use /register).
+// disableBulkInsert/disableBulkUpdate/disableImportXls/disableExportXls:
+// portal_users are auth-side records, not data-import surfaces — the
+// auto-attached endpoints would bypass requireRootTenant since
+// disablePost only affects POST /, leaving POST /bulk-insert and
+// POST /import-xls live with no per-method middleware applied.
 export default createRouter(
   portalUsersController,
   (router) => {
@@ -27,6 +32,7 @@ export default createRouter(
       '/register',
       requireRootTenant,
       meta,
+      moduleEntitlement,
       rbac('full'),
       addAuditFields,
       (req, res) => portalUsersController.register(req, res),
@@ -34,9 +40,13 @@ export default createRouter(
   },
   {
     disablePost: true,
-    getMiddlewares: [requireRootTenant, meta, rbac('view')],
-    putMiddlewares: [requireRootTenant, meta, rbac('full')],
-    deleteMiddlewares: [requireRootTenant, meta, rbac('full')],
-    patchMiddlewares: [requireRootTenant, meta, rbac('full')],
+    disableBulkInsert: true,
+    disableBulkUpdate: true,
+    disableImportXls: true,
+    disableExportXls: true,
+    getMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('view')],
+    putMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
+    deleteMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
+    patchMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
   },
 );

--- a/apps/server/src/system/tenants/apiRoutes/v1/portalUsersRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/portalUsersRouter.js
@@ -44,6 +44,7 @@ export default createRouter(
     disableBulkUpdate: true,
     disableImportXls: true,
     disableExportXls: true,
+    disablePing: true,
     getMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('view')],
     putMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
     deleteMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],

--- a/apps/server/src/system/tenants/apiRoutes/v1/portalUsersRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/portalUsersRouter.js
@@ -18,8 +18,14 @@ import { withMeta } from '../../../../middleware/withMeta.js';
 
 const meta = withMeta({ module: 'tenants', router: 'portal-users' });
 
-// Per-method middleware order: requireRootTenant → withMeta →
-// moduleEntitlement → rbac. Standard POST is disabled (use /register).
+// Per-method middleware order, reading routes:
+//   requireRootTenant → withMeta → moduleEntitlement → rbac → handler
+// On mutation routes (PUT/DELETE/PATCH) createRouter prepends
+// addAuditFields, so the effective chain becomes:
+//   addAuditFields → requireRootTenant → withMeta → moduleEntitlement → rbac → handler
+//
+// Standard POST is disabled (use /register, which assembles its own
+// chain explicitly with addAuditFields in last position).
 // disableBulkInsert/disableBulkUpdate/disableImportXls/disableExportXls:
 // portal_users are auth-side records, not data-import surfaces — the
 // auto-attached endpoints would bypass requireRootTenant since

--- a/apps/server/src/system/tenants/apiRoutes/v1/portalUsersRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/portalUsersRouter.js
@@ -12,12 +12,14 @@ import portalUsersController from '../../controllers/portalUsersController.js';
 import createRouter from '../../../../lib/createRouter.js';
 import { addAuditFields } from '../../../../middleware/addAuditFields.js';
 import { requireRootTenant } from '../../../../middleware/requireRootTenant.js';
+import { rbac } from '../../../../middleware/rbac.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
 
 const meta = withMeta({ module: 'tenants', router: 'portal-users' });
 
-// Note: RBAC enforcement deferred to Phase 5 (no role_members exist yet).
-// requireRootTenant gates all routes to Axerra users only.
+// Three-layer enforcement: requireRootTenant + meta + rbac. Standard
+// POST is disabled (use /register). The /register custom route is a
+// 'full'-level mutation since it provisions a new portal_user.
 export default createRouter(
   portalUsersController,
   (router) => {
@@ -25,15 +27,16 @@ export default createRouter(
       '/register',
       requireRootTenant,
       meta,
+      rbac('full'),
       addAuditFields,
       (req, res) => portalUsersController.register(req, res),
     );
   },
   {
     disablePost: true,
-    getMiddlewares: [requireRootTenant, meta],
-    putMiddlewares: [requireRootTenant, meta],
-    deleteMiddlewares: [requireRootTenant, meta],
-    patchMiddlewares: [requireRootTenant, meta],
+    getMiddlewares: [requireRootTenant, meta, rbac('view')],
+    putMiddlewares: [requireRootTenant, meta, rbac('full')],
+    deleteMiddlewares: [requireRootTenant, meta, rbac('full')],
+    patchMiddlewares: [requireRootTenant, meta, rbac('full')],
   },
 );

--- a/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
@@ -8,12 +8,15 @@
 import tenantsController from '../../controllers/tenantsController.js';
 import createRouter from '../../../../lib/createRouter.js';
 import { requireRootTenant } from '../../../../middleware/requireRootTenant.js';
+import { rbac } from '../../../../middleware/rbac.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
 
 const meta = withMeta({ module: 'tenants', router: 'tenants' });
 
-// requireRootTenant gates all routes to Axerra users only.
-// RBAC not applied — access control relies on requireRootTenant + moduleEntitlement.
+// Three-layer enforcement: requireRootTenant gates Axerra membership,
+// withMeta sets the resource for rbac, and rbac() consults the
+// tenants::tenants policy (cascades up to tenants:: and the ::::
+// wildcard). Custom routes use view-level rbac since they're reads.
 export default createRouter(
   tenantsController,
   (router) => {
@@ -21,26 +24,29 @@ export default createRouter(
       '/:id/modules',
       requireRootTenant,
       meta,
+      rbac('view'),
       (req, res) => tenantsController.getAllowedModules(req, res),
     );
     router.get(
       '/:id/contacts',
       requireRootTenant,
       meta,
+      rbac('view'),
       (req, res) => tenantsController.getContacts(req, res),
     );
     router.get(
       '/:id/company',
       requireRootTenant,
       meta,
+      rbac('view'),
       (req, res) => tenantsController.getCompany(req, res),
     );
   },
   {
-    postMiddlewares: [requireRootTenant, meta],
-    getMiddlewares: [requireRootTenant, meta],
-    putMiddlewares: [requireRootTenant, meta],
-    deleteMiddlewares: [requireRootTenant, meta],
-    patchMiddlewares: [requireRootTenant, meta],
+    postMiddlewares: [requireRootTenant, meta, rbac('full')],
+    getMiddlewares: [requireRootTenant, meta, rbac('view')],
+    putMiddlewares: [requireRootTenant, meta, rbac('full')],
+    deleteMiddlewares: [requireRootTenant, meta, rbac('full')],
+    patchMiddlewares: [requireRootTenant, meta, rbac('full')],
   },
 );

--- a/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
@@ -7,16 +7,23 @@
 
 import tenantsController from '../../controllers/tenantsController.js';
 import createRouter from '../../../../lib/createRouter.js';
+import { moduleEntitlement } from '../../../../middleware/moduleEntitlement.js';
 import { requireRootTenant } from '../../../../middleware/requireRootTenant.js';
 import { rbac } from '../../../../middleware/rbac.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
 
 const meta = withMeta({ module: 'tenants', router: 'tenants' });
 
-// Three-layer enforcement: requireRootTenant gates Axerra membership,
-// withMeta sets the resource for rbac, and rbac() consults the
-// tenants::tenants policy (cascades up to tenants:: and the ::::
-// wildcard). Custom routes use view-level rbac since they're reads.
+// Per-method middleware order: requireRootTenant → withMeta →
+// moduleEntitlement → rbac. Including moduleEntitlement explicitly
+// keeps it BEFORE rbac (createRouter would otherwise append it after).
+//
+// disableImportXls/disableExportXls/disableBulkInsert/disableBulkUpdate:
+// tenant records are admin-managed via the API, not via spreadsheet
+// I/O. The auto-attached /import-xls and /export-xls would otherwise
+// run their own rbac() AFTER our middleware chain, double-evaluating
+// rbac with two different action codes (router-level then 'import'/
+// 'export'). Disabling them keeps the enforcement story simple.
 export default createRouter(
   tenantsController,
   (router) => {
@@ -24,6 +31,7 @@ export default createRouter(
       '/:id/modules',
       requireRootTenant,
       meta,
+      moduleEntitlement,
       rbac('view'),
       (req, res) => tenantsController.getAllowedModules(req, res),
     );
@@ -31,6 +39,7 @@ export default createRouter(
       '/:id/contacts',
       requireRootTenant,
       meta,
+      moduleEntitlement,
       rbac('view'),
       (req, res) => tenantsController.getContacts(req, res),
     );
@@ -38,15 +47,20 @@ export default createRouter(
       '/:id/company',
       requireRootTenant,
       meta,
+      moduleEntitlement,
       rbac('view'),
       (req, res) => tenantsController.getCompany(req, res),
     );
   },
   {
-    postMiddlewares: [requireRootTenant, meta, rbac('full')],
-    getMiddlewares: [requireRootTenant, meta, rbac('view')],
-    putMiddlewares: [requireRootTenant, meta, rbac('full')],
-    deleteMiddlewares: [requireRootTenant, meta, rbac('full')],
-    patchMiddlewares: [requireRootTenant, meta, rbac('full')],
+    disableBulkInsert: true,
+    disableBulkUpdate: true,
+    disableImportXls: true,
+    disableExportXls: true,
+    postMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
+    getMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('view')],
+    putMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
+    deleteMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
+    patchMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
   },
 );

--- a/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
@@ -57,6 +57,7 @@ export default createRouter(
     disableBulkUpdate: true,
     disableImportXls: true,
     disableExportXls: true,
+    disablePing: true,
     postMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
     getMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('view')],
     putMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],

--- a/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
@@ -14,9 +14,13 @@ import { withMeta } from '../../../../middleware/withMeta.js';
 
 const meta = withMeta({ module: 'tenants', router: 'tenants' });
 
-// Per-method middleware order: requireRootTenant → withMeta →
-// moduleEntitlement → rbac. Including moduleEntitlement explicitly
-// keeps it BEFORE rbac (createRouter would otherwise append it after).
+// Per-method middleware order, reading routes:
+//   requireRootTenant → withMeta → moduleEntitlement → rbac → handler
+// On mutation routes (POST/PUT/DELETE/PATCH) createRouter prepends
+// addAuditFields, so the effective chain becomes:
+//   addAuditFields → requireRootTenant → withMeta → moduleEntitlement → rbac → handler
+// Including moduleEntitlement explicitly in the per-method arrays keeps
+// it BEFORE rbac (createRouter would otherwise append it after).
 //
 // disableImportXls/disableExportXls/disableBulkInsert/disableBulkUpdate:
 // tenant records are admin-managed via the API, not via spreadsheet

--- a/apps/server/tests/contract/tenantsRbacEnforcement.test.js
+++ b/apps/server/tests/contract/tenantsRbacEnforcement.test.js
@@ -15,7 +15,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import request from 'supertest';
-import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+import { bootstrapAdmin, cleanupTestDb, DB } from '../helpers/testDb.js';
 
 let db;
 beforeAll(async () => {
@@ -33,6 +33,10 @@ const TEST_EMAIL = 'rbac57-test@axerra.io';
 const TEST_PASSWORD = 'RbacTest57!';
 const TEST_ROLE_CODE = '_test_rbac_57';
 const TEST_TENANT_SCHEMA = (process.env.ROOT_TENANT_CODE || 'AXERRA').toLowerCase();
+// Quote the schema identifier safely (matches the convention in other
+// contract tests). Avoids accidental breakage if ROOT_TENANT_CODE ever
+// resolves to a value that needs escaping.
+const TS = DB.pgp.as.name(TEST_TENANT_SCHEMA);
 
 describe('RBAC enforcement on tenants/* routes (issue #57)', () => {
   let testUserCookies;
@@ -51,7 +55,7 @@ describe('RBAC enforcement on tenants/* routes (issue #57)', () => {
     // resolution cascade (module::router::action → module::router::
     // → module:::: → ::::).
     const role = await db.one(
-      `INSERT INTO ${TEST_TENANT_SCHEMA}.roles (code, name, description, scope, is_system, is_immutable)
+      `INSERT INTO ${TS}.roles (code, name, description, scope, is_system, is_immutable)
        VALUES ($1, 'RBAC Test Role', 'Issue #57 contract test fixture', 'all_projects', false, false)
        RETURNING id`,
       [TEST_ROLE_CODE],
@@ -59,7 +63,7 @@ describe('RBAC enforcement on tenants/* routes (issue #57)', () => {
     testRoleId = role.id;
 
     await db.none(
-      `INSERT INTO ${TEST_TENANT_SCHEMA}.policies (role_id, module, router, action, level)
+      `INSERT INTO ${TS}.policies (role_id, module, router, action, level)
        VALUES ($1, '', null, null, 'view'),
               ($1, 'tenants', 'admin', 'list_schemas', 'none')`,
       [testRoleId],
@@ -67,7 +71,7 @@ describe('RBAC enforcement on tenants/* routes (issue #57)', () => {
 
     // Test employee carrying the custom role
     const employee = await db.one(
-      `INSERT INTO ${TEST_TENANT_SCHEMA}.employees
+      `INSERT INTO ${TS}.employees
          (tenant_id, first_name, last_name, is_app_user, roles)
        VALUES ($1, 'RBAC57', 'Tester', true, $2)
        RETURNING id`,
@@ -76,13 +80,13 @@ describe('RBAC enforcement on tenants/* routes (issue #57)', () => {
     employeeId = employee.id;
 
     const source = await db.one(
-      `INSERT INTO ${TEST_TENANT_SCHEMA}.sources (tenant_id, table_id, source_type, label)
+      `INSERT INTO ${TS}.sources (tenant_id, table_id, source_type, label)
        VALUES ($1, $2, 'employee', 'RBAC57 Tester')
        RETURNING id`,
       [tenant.id, employeeId],
     );
     await db.none(
-      `UPDATE ${TEST_TENANT_SCHEMA}.employees SET source_id = $1 WHERE id = $2`,
+      `UPDATE ${TS}.employees SET source_id = $1 WHERE id = $2`,
       [source.id, employeeId],
     );
 
@@ -115,15 +119,15 @@ describe('RBAC enforcement on tenants/* routes (issue #57)', () => {
       await db.none('DELETE FROM admin.portal_users WHERE id = $1', [testUserId]);
     }
     if (testRoleId) {
-      await db.none(`DELETE FROM ${TEST_TENANT_SCHEMA}.policies WHERE role_id = $1`, [testRoleId]);
-      await db.none(`DELETE FROM ${TEST_TENANT_SCHEMA}.roles WHERE id = $1`, [testRoleId]);
+      await db.none(`DELETE FROM ${TS}.policies WHERE role_id = $1`, [testRoleId]);
+      await db.none(`DELETE FROM ${TS}.roles WHERE id = $1`, [testRoleId]);
     }
     if (employeeId) {
       await db.none(
-        `DELETE FROM ${TEST_TENANT_SCHEMA}.sources WHERE table_id = $1 AND source_type = 'employee'`,
+        `DELETE FROM ${TS}.sources WHERE table_id = $1 AND source_type = 'employee'`,
         [employeeId],
       );
-      await db.none(`DELETE FROM ${TEST_TENANT_SCHEMA}.employees WHERE id = $1`, [employeeId]);
+      await db.none(`DELETE FROM ${TS}.employees WHERE id = $1`, [employeeId]);
     }
   }, 15000);
 
@@ -136,7 +140,7 @@ describe('RBAC enforcement on tenants/* routes (issue #57)', () => {
 
   test('GET /admin/schemas → 200 after lifting the deny to view', async () => {
     await db.none(
-      `UPDATE ${TEST_TENANT_SCHEMA}.policies SET level = 'view'
+      `UPDATE ${TS}.policies SET level = 'view'
        WHERE role_id = $1 AND module = 'tenants' AND router = 'admin' AND action = 'list_schemas'`,
       [testRoleId],
     );

--- a/apps/server/tests/contract/tenantsRbacEnforcement.test.js
+++ b/apps/server/tests/contract/tenantsRbacEnforcement.test.js
@@ -1,0 +1,165 @@
+/**
+ * @file Contract test for rbac enforcement on tenants/* routes (issue #57)
+ * @module tests/contract/tenantsRbacEnforcement
+ *
+ * After Step 4, the tenants/* router surface consults rbac() on the
+ * resource action codes. This test locks the contract: a custom Axerra
+ * role with a specific deny on `tenants::admin::list_schemas` is
+ * actually denied at the route layer (403), and lifting the deny to
+ * 'view' makes the same call succeed (200). Pairs with the catalog
+ * flip in step 3 — the rows are now grantable in PolicyEditor and
+ * honored by the API.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+const TEST_EMAIL = 'rbac57-test@axerra.io';
+const TEST_PASSWORD = 'RbacTest57!';
+const TEST_ROLE_CODE = '_test_rbac_57';
+const TEST_TENANT_SCHEMA = (process.env.ROOT_TENANT_CODE || 'AXERRA').toLowerCase();
+
+describe('RBAC enforcement on tenants/* routes (issue #57)', () => {
+  let testUserCookies;
+  let testUserId;
+  let testRoleId;
+  let employeeId;
+
+  beforeAll(async () => {
+    const tenant = await db.one(
+      'SELECT id FROM admin.tenants WHERE schema_name = $1',
+      [TEST_TENANT_SCHEMA],
+    );
+
+    // Custom Axerra role: wildcard view + specific deny on list_schemas.
+    // The deny overrides the wildcard via rbac.js's most-specific-first
+    // resolution cascade (module::router::action → module::router::
+    // → module:::: → ::::).
+    const role = await db.one(
+      `INSERT INTO ${TEST_TENANT_SCHEMA}.roles (code, name, description, scope, is_system, is_immutable)
+       VALUES ($1, 'RBAC Test Role', 'Issue #57 contract test fixture', 'all_projects', false, false)
+       RETURNING id`,
+      [TEST_ROLE_CODE],
+    );
+    testRoleId = role.id;
+
+    await db.none(
+      `INSERT INTO ${TEST_TENANT_SCHEMA}.policies (role_id, module, router, action, level)
+       VALUES ($1, '', null, null, 'view'),
+              ($1, 'tenants', 'admin', 'list_schemas', 'none')`,
+      [testRoleId],
+    );
+
+    // Test employee carrying the custom role
+    const employee = await db.one(
+      `INSERT INTO ${TEST_TENANT_SCHEMA}.employees
+         (tenant_id, first_name, last_name, is_app_user, roles)
+       VALUES ($1, 'RBAC57', 'Tester', true, $2)
+       RETURNING id`,
+      [tenant.id, `{${TEST_ROLE_CODE}}`],
+    );
+    employeeId = employee.id;
+
+    const source = await db.one(
+      `INSERT INTO ${TEST_TENANT_SCHEMA}.sources (tenant_id, table_id, source_type, label)
+       VALUES ($1, $2, 'employee', 'RBAC57 Tester')
+       RETURNING id`,
+      [tenant.id, employeeId],
+    );
+    await db.none(
+      `UPDATE ${TEST_TENANT_SCHEMA}.employees SET source_id = $1 WHERE id = $2`,
+      [source.id, employeeId],
+    );
+
+    const { default: bcrypt } = await import('bcrypt');
+    const passwordHash = await bcrypt.hash(TEST_PASSWORD, 4);
+    const portalUser = await db.one(
+      `INSERT INTO admin.portal_users (email, password_hash, status)
+       VALUES ($1, $2, 'active')
+       RETURNING id`,
+      [TEST_EMAIL, passwordHash],
+    );
+    testUserId = portalUser.id;
+
+    await db.none(
+      `INSERT INTO admin.portal_user_tenants (portal_user_id, tenant_id, entity_type, entity_id, status)
+       VALUES ($1, $2, 'employee', $3, 'active')`,
+      [testUserId, tenant.id, employeeId],
+    );
+
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: TEST_EMAIL, password: TEST_PASSWORD });
+    expect(loginRes.status).toBe(200);
+    testUserCookies = loginRes.headers['set-cookie'];
+  }, 30000);
+
+  afterAll(async () => {
+    if (testUserId) {
+      await db.none('DELETE FROM admin.portal_user_tenants WHERE portal_user_id = $1', [testUserId]);
+      await db.none('DELETE FROM admin.portal_users WHERE id = $1', [testUserId]);
+    }
+    if (testRoleId) {
+      await db.none(`DELETE FROM ${TEST_TENANT_SCHEMA}.policies WHERE role_id = $1`, [testRoleId]);
+      await db.none(`DELETE FROM ${TEST_TENANT_SCHEMA}.roles WHERE id = $1`, [testRoleId]);
+    }
+    if (employeeId) {
+      await db.none(
+        `DELETE FROM ${TEST_TENANT_SCHEMA}.sources WHERE table_id = $1 AND source_type = 'employee'`,
+        [employeeId],
+      );
+      await db.none(`DELETE FROM ${TEST_TENANT_SCHEMA}.employees WHERE id = $1`, [employeeId]);
+    }
+  }, 15000);
+
+  test('GET /admin/schemas → 403 when role has explicit deny on tenants::admin::list_schemas', async () => {
+    const res = await request(app)
+      .get('/api/tenants/v1/admin/schemas')
+      .set('Cookie', testUserCookies);
+    expect(res.status).toBe(403);
+  });
+
+  test('GET /admin/schemas → 200 after lifting the deny to view', async () => {
+    await db.none(
+      `UPDATE ${TEST_TENANT_SCHEMA}.policies SET level = 'view'
+       WHERE role_id = $1 AND module = 'tenants' AND router = 'admin' AND action = 'list_schemas'`,
+      [testRoleId],
+    );
+
+    // Cache invalidation — authRedis would otherwise serve the stale
+    // 'none' grant from Redis until the 15-min TTL.
+    const { invalidateByUser } = await import('../../src/services/permCacheInvalidator.js');
+    await invalidateByUser(testUserId);
+
+    const res = await request(app)
+      .get('/api/tenants/v1/admin/schemas')
+      .set('Cookie', testUserCookies);
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /admin/impersonate → 403 because view-only on a full-required action', async () => {
+    // Same user, still wildcard 'view' + view on list_schemas. The
+    // impersonate route requires 'full', so the wildcard view doesn't
+    // satisfy it and the route 403s.
+    const res = await request(app)
+      .post('/api/tenants/v1/admin/impersonate')
+      .set('Cookie', testUserCookies)
+      .send({ target_user_id: '00000000-0000-0000-0000-000000000000' });
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/server/tests/helpers/testDb.js
+++ b/apps/server/tests/helpers/testDb.js
@@ -256,19 +256,26 @@ export async function cleanupTestDb() {
   }
 
   if (adminReady) {
-    // Admin schema persists — truncate all admin tables (FK-safe) and
-    // clear migration history for non-protected schemas. Tables + types
-    // remain intact. The root tenant schema (axerra) is preserved as-is
-    // so its seeded roles/policies and the System Administrator employee
-    // survive across test files; reseedAdmin → seedRootEntity rebinds
-    // to that existing employee on the next bootstrapAdmin call.
+    // Admin schema persists — truncate all admin tables EXCEPT
+    // admin.tenants (FK-safe via CASCADE on the truncated tables).
+    // Then DELETE the non-root tenant rows from admin.tenants.
+    //
+    // Why: the root tenant row's UUID must stay stable across the
+    // cleanup → reseed cycle. axerra.employees.tenant_id (preserved
+    // because the root tenant schema persists) points at that UUID;
+    // if we truncated and re-inserted admin.tenants we'd get a fresh
+    // UUID and seedRootEntity's tenant-scoped reuse query would never
+    // find the existing System Administrator row, leaking duplicate
+    // employees on every test file.
+    const rootTenantCode = process.env.ROOT_TENANT_CODE || 'AXERRA';
     const adminTables = await db.manyOrNone(
-      "SELECT table_name FROM information_schema.tables WHERE table_schema = 'admin' AND table_type = 'BASE TABLE'",
+      "SELECT table_name FROM information_schema.tables WHERE table_schema = 'admin' AND table_type = 'BASE TABLE' AND table_name != 'tenants'",
     );
     if (adminTables.length) {
       const tableList = adminTables.map((r) => `admin.${DB.pgp.as.name(r.table_name)}`).join(', ');
       await db.none(`TRUNCATE ${tableList} CASCADE`);
     }
+    await db.none('DELETE FROM admin.tenants WHERE tenant_code != $1', [rootTenantCode]);
     await db.none(
       "DELETE FROM pgschemata.migrations WHERE schema_name NOT IN ('admin', $1)",
       [rootSchema],

--- a/apps/server/tests/helpers/testDb.js
+++ b/apps/server/tests/helpers/testDb.js
@@ -114,10 +114,12 @@ async function reseedAdmin(db) {
     userId = inserted.id;
   }
 
-  // Bind the root super user to the root tenant. Tests don't create the
-  // backing employees row (setupAdmin.js does that in real envs), so the
-  // binding's entity link stays NULL — entity_type/entity_id are
-  // nullable on portal_user_tenants for exactly this pre-link case.
+  // Insert a bare binding first so seedRootEntity can update it in place
+  // (preserving the unique (portal_user_id, tenant_id) row). On re-runs
+  // after admin-table truncation, the binding has been wiped — recreate
+  // it bare. The axerra tenant schema is preserved across runs (see
+  // cleanupTestDb), so seedRootEntity will rebind to the existing
+  // System Administrator employee instead of creating a duplicate.
   const existingBinding = await db.oneOrNone(
     `SELECT id FROM admin.portal_user_tenants WHERE portal_user_id = $1 AND deactivated_at IS NULL`,
     [userId],
@@ -130,6 +132,20 @@ async function reseedAdmin(db) {
       [userId, tenant.id],
     );
   }
+
+  // Link the root super user to a real employee row + super_user role
+  // (which seeds wildcard '::::full' caps via systemRoleSeeder on first
+  // axerra provision). Required so loadPermissions returns real caps
+  // for any rbac()-protected route — see issue #57.
+  const { seedRootEntity } = await import('../../src/services/seedRootEntity.js');
+  await seedRootEntity({
+    db,
+    pgp: DB.pgp,
+    logger,
+    tenantSchema: rootTenantCode.toLowerCase(),
+    rootEmail,
+    includeLoginEmail: false,
+  });
 }
 
 // ── Public API ────────────────────────────────────────────────────────
@@ -189,10 +205,21 @@ export async function bootstrapAdmin() {
     },
   });
 
-  // Bootstrap migration creates the auth-only portal_users row. The root
-  // tenant binding lives on portal_user_tenants; in real deploys
-  // setupAdmin.js writes it after creating the admin employee. Tests don't
-  // run setupAdmin, so seed the binding here directly (matches reseedAdmin).
+  // Provision the axerra tenant schema (runs all tenant migrations and
+  // seeds system roles via tenantProvisioning → seedSystemRoles). Without
+  // this, loadPermissions short-circuits to empty caps on the root user's
+  // bare binding, and any rbac()-enforced route 403s every test that logs
+  // in as root. The schema is preserved across cleanupTestDb calls so
+  // we only pay the provisioning cost once per test-suite run.
+  const rootTenantCode = process.env.ROOT_TENANT_CODE || 'AXERRA';
+  const tenantSchema = rootTenantCode.toLowerCase();
+  const { provisionTenant } = await import('../../src/services/tenantProvisioning.js');
+  await provisionTenant({ schemaName: tenantSchema, tenantCode: rootTenantCode });
+
+  // reseedAdmin handles admin.portal_users + binding + seedRootEntity.
+  // Bootstrap migration created the auth-only portal_users row; in real
+  // deploys setupAdmin.js writes the binding + entity link after the
+  // employee is created. Tests run reseedAdmin which now does both.
   await reseedAdmin(db);
 
   adminReady = true;
@@ -211,13 +238,18 @@ export async function bootstrapAdmin() {
  */
 export async function cleanupTestDb() {
   const db = await initTestDb();
+  const rootSchema = (process.env.ROOT_TENANT_CODE || 'AXERRA').toLowerCase();
 
-  // Drop any test-created tenant schemas (provisioned during tests)
+  // Drop any test-created tenant schemas (provisioned during tests).
+  // Protect: admin (auth-side), pgschemata (migrator), and the root
+  // tenant schema (axerra) which we provision once in bootstrapAdmin
+  // and reuse across tests for rbac role/policy seeding.
+  const protectedSchemas = ['public', 'admin', 'pgschemata', 'pg_catalog', 'information_schema', 'pg_toast', rootSchema];
   const testSchemas = await db.manyOrNone(
     `SELECT schema_name FROM information_schema.schemata
-     WHERE schema_name NOT IN ('public', 'admin', 'pgschemata', 'pg_catalog',
-                                'information_schema', 'pg_toast')
+     WHERE schema_name NOT IN ($1:csv)
        AND schema_name NOT LIKE 'pg_%'`,
+    [protectedSchemas],
   );
   for (const row of testSchemas) {
     await db.none(`DROP SCHEMA IF EXISTS ${db.$config.pgp.as.name(row.schema_name)} CASCADE`);
@@ -225,7 +257,11 @@ export async function cleanupTestDb() {
 
   if (adminReady) {
     // Admin schema persists — truncate all admin tables (FK-safe) and
-    // clear non-admin migration history. Tables + types remain intact.
+    // clear migration history for non-protected schemas. Tables + types
+    // remain intact. The root tenant schema (axerra) is preserved as-is
+    // so its seeded roles/policies and the System Administrator employee
+    // survive across test files; reseedAdmin → seedRootEntity rebinds
+    // to that existing employee on the next bootstrapAdmin call.
     const adminTables = await db.manyOrNone(
       "SELECT table_name FROM information_schema.tables WHERE table_schema = 'admin' AND table_type = 'BASE TABLE'",
     );
@@ -233,11 +269,15 @@ export async function cleanupTestDb() {
       const tableList = adminTables.map((r) => `admin.${DB.pgp.as.name(r.table_name)}`).join(', ');
       await db.none(`TRUNCATE ${tableList} CASCADE`);
     }
-    await db.none("DELETE FROM pgschemata.migrations WHERE schema_name != 'admin'");
+    await db.none(
+      "DELETE FROM pgschemata.migrations WHERE schema_name NOT IN ('admin', $1)",
+      [rootSchema],
+    );
   } else {
     // First run: full reset (handles stale state from a previous test run)
     await db.none('DROP SCHEMA IF EXISTS admin CASCADE');
     await db.none('DROP SCHEMA IF EXISTS pgschemata CASCADE');
+    await db.none(`DROP SCHEMA IF EXISTS ${db.$config.pgp.as.name(rootSchema)} CASCADE`);
   }
 }
 

--- a/apps/server/tests/helpers/testDb.js
+++ b/apps/server/tests/helpers/testDb.js
@@ -76,18 +76,16 @@ async function getCachedPasswordHash() {
 }
 
 /**
- * Re-seed the root tenant and super user into an existing (but empty)
- * admin schema. Called by bootstrapAdmin when adminReady is true.
+ * Idempotently insert the root tenant row into admin.tenants. Used both
+ * before provisionTenant (so its numberingConfig/tenantPreferences seeders
+ * find the tenant by schema_name) and inside reseedAdmin.
  */
-async function reseedAdmin(db) {
+async function ensureRootTenantRow(db) {
   const rootTenantCode = process.env.ROOT_TENANT_CODE || 'AXERRA';
   const rootCompany = process.env.ROOT_COMPANY || 'Axerra LLC';
   const rootSchema = rootTenantCode.toLowerCase();
-  const rootEmail = process.env.ROOT_EMAIL || 'admin@axerra.io';
-  const passwordHash = await getCachedPasswordHash();
 
   const existingTenant = await db.oneOrNone('SELECT id FROM admin.tenants WHERE tenant_code = $1', [rootTenantCode]);
-
   if (!existingTenant) {
     await db.none(
       `INSERT INTO admin.tenants (tenant_code, company, schema_name, status, tier, allowed_modules)
@@ -95,6 +93,18 @@ async function reseedAdmin(db) {
       [rootTenantCode, rootCompany, rootSchema, JSON.stringify([])],
     );
   }
+}
+
+/**
+ * Re-seed the root tenant and super user into an existing (but empty)
+ * admin schema. Called by bootstrapAdmin when adminReady is true.
+ */
+async function reseedAdmin(db) {
+  const rootTenantCode = process.env.ROOT_TENANT_CODE || 'AXERRA';
+  const rootEmail = process.env.ROOT_EMAIL || 'admin@axerra.io';
+  const passwordHash = await getCachedPasswordHash();
+
+  await ensureRootTenantRow(db);
 
   const tenant = await db.one('SELECT id FROM admin.tenants WHERE tenant_code = $1', [rootTenantCode]);
 
@@ -204,6 +214,14 @@ export async function bootstrapAdmin() {
       }
     },
   });
+
+  // Insert the root admin.tenants row BEFORE provisionTenant runs.
+  // Otherwise tenantProvisioning's numberingConfigSeeder and
+  // tenantPreferencesSeeder look up admin.tenants by schema_name, find
+  // nothing, and silently skip the seed — leaving the root schema
+  // missing those rows on the initial bootstrap. (reseedAdmin's call
+  // is idempotent, so this prepass doesn't conflict.)
+  await ensureRootTenantRow(db);
 
   // Provision the axerra tenant schema (runs all tenant migrations and
   // seeds system roles via tenantProvisioning → seedSystemRoles). Without


### PR DESCRIPTION
## Summary

Closes #57 — wires `rbac()` enforcement across the entire `apps/server/src/system/tenants/*` router surface so the policy_catalog rows seeded for those endpoints actually gate access. Previously the catalog rows were `policy_required: false` (decorative), and granting/denying e.g. `tenants::admin::impersonate` on an Axerra role had no effect on whether the route ran.

The change is structured as 5 commits, each a green-tests checkpoint.

## What changed

### Step 1 — Extract `seedRootEntity` helper (commit `613ca69`)
Move setupAdmin's "link root super_user to employee" block (~70 lines) into `apps/server/src/services/seedRootEntity.js`. Both setupAdmin and (next commit) testDb call it. No behavior change.

### Step 2 — Test bootstrap provisions axerra + assigns role (commit `6828038`)
The empty-caps gap in tests:
- Previously `bootstrapAdmin` only created `admin` and `pgschemata` schemas. The axerra tenant schema was never provisioned in tests — root user's binding pointed at a `tenants` row whose `schema_name = 'axerra'` but the schema didn't exist. `loadPermissions` short-circuited to empty caps.
- Now `bootstrapAdmin` calls `provisionTenant({ schemaName: 'axerra' })` on first run (runs all tenant migrations and seeds system roles via `seedSystemRoles`) then `seedRootEntity` to link the root portal_user to a real System Administrator employee.
- The axerra schema is preserved across `cleanupTestDb` calls (added to the protected list); the System Administrator employee survives so subsequent reseeds rebind to it instead of creating duplicates.

### Step 3 — Catalog flip + new action rows (commit `2db59a3`)
- All `tenants::*` action-level rows flipped from `policy_required: false` to `true`. They now appear in PolicyEditor as independently grantable.
- New rows: `tenants::admin::list_schemas` (view) and `tenants::admin::impersonate` (full).
- Decorative wording dropped.

### Step 4 — Wire `rbac()` across all 5 routers (commit `c2206ee`)
| Router | Routes | Wiring |
|---|---|---|
| `orphanPortalUsersRouter` | 2 | action-scoped meta + rbac |
| `adminRouter` | 4 | meta + rbac on `/schemas` (view) and `/impersonate` (full); `/exit-impersonation` and `/impersonation-status` skip rbac (escape hatch + own-session read) |
| `tenantsRouter` | 9 | per-method rbac via createRouter middleware arrays |
| `portalUsersRouter` | 6 | per-method rbac; custom `/register` gets `full` |
| `matchReviewLogsRouter` | 2 | added requireRootTenant + meta + rbac (was: no middleware at all) |

Behavior change: a finer-grained Axerra role (e.g. denying `tenants::admin::impersonate`) is now actually denied. Seeded `super_user` role keeps wildcard `'::::full'` so its callers continue to pass unchanged.

### Step 5 — Contract test locks the contract (commit `9a5e9db`)
`apps/server/tests/contract/tenantsRbacEnforcement.test.js` exercises the grant/deny chain end-to-end:
- 403 when a custom Axerra role has explicit deny on `tenants::admin::list_schemas`
- 200 after lifting the deny to view (with `invalidateByUser` to skip the 15-min Redis cache TTL)
- 403 on POST `/admin/impersonate` for a view-only role (proves the level cascade works for full-required routes)

## Out of scope

- Refactoring `requireRootTenant` itself or moving Axerra access off `home_tenant`.
- Wiring `rbac()` on the standard CRUD verbs of every `core/*` router (createRouter currently only attaches rbac to `/import-xls` and `/export-xls`). Same gap exists across the codebase; closing it for tenants/* now and leaving core/* for a future pass.

## Test plan

- [x] `npm -w apps/server test` — 538/538 pass (was 535, +3 new)
- [x] `npm run lint` — clean (one pre-existing warning unrelated to this PR)
- [x] Manual smoke: `npm -w apps/server run setupAdmin:dev` reseeds the dev DB; root login still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)