### PR TITLE
fix(server): restore tenant import/export regressed by PR #63

### DIFF
--- a/apps/server/src/services/seedRootEntity.js
+++ b/apps/server/src/services/seedRootEntity.js
@@ -56,17 +56,26 @@ export async function seedRootEntity({ db, pgp, logger, tenantSchema, rootEmail,
     [superUser.id, tenant.id],
   );
 
-  // A binding is only "linked" if BOTH entity_type AND entity_id are set.
-  // The portal_user_tenants schema doesn't enforce that pairing, so a
-  // partially-written row (entity_type set, entity_id NULL) from a
-  // failed earlier seed should be treated as unlinked and repaired.
+  const s = pgp.as.name(tenantSchema);
+
+  // A binding is only "linked" if BOTH entity_type AND entity_id are set
+  // AND the referenced employee row actually exists in the tenant schema.
+  // The portal_user_tenants schema doesn't enforce that pairing, and
+  // dropping/recreating the tenant schema can leave the binding pointing
+  // at a vanished employee — both cases must trigger a repair.
   if (existingBinding && existingBinding.entity_type !== null && existingBinding.entity_id !== null) {
-    logger?.info?.('Root super user already linked to entity, skipping.');
-    return null;
+    const referenced = await db.oneOrNone(
+      `SELECT id FROM ${s}.employees WHERE id = $1 AND deactivated_at IS NULL`,
+      [existingBinding.entity_id],
+    );
+    if (referenced) {
+      logger?.info?.('Root super user already linked to entity, skipping.');
+      return null;
+    }
+    logger?.info?.('Existing binding references a missing employee — repairing.');
   }
 
   logger?.info?.('Linking root super user to employee record...');
-  const s = pgp.as.name(tenantSchema);
 
   // Find an existing System/Administrator employee scoped to THIS tenant
   // and verified to carry the super_user role. The idempotent path used

--- a/apps/server/src/services/seedRootEntity.js
+++ b/apps/server/src/services/seedRootEntity.js
@@ -58,12 +58,15 @@ export async function seedRootEntity({ db, pgp, logger, tenantSchema, rootEmail,
 
   const s = pgp.as.name(tenantSchema);
 
-  // A binding is only "linked" if BOTH entity_type AND entity_id are set
-  // AND the referenced employee row actually exists in the tenant schema.
+  // A binding is only "linked" if BOTH entity_type AND entity_id are set,
+  // entity_type is 'employee' (the only type this seeder produces), AND
+  // the referenced employee row actually exists in the tenant schema.
   // The portal_user_tenants schema doesn't enforce that pairing, and
   // dropping/recreating the tenant schema can leave the binding pointing
-  // at a vanished employee — both cases must trigger a repair.
-  if (existingBinding && existingBinding.entity_type !== null && existingBinding.entity_id !== null) {
+  // at a vanished employee — both cases must trigger a repair. A binding
+  // pointing at a non-employee entity_type (vendor_contact, client, etc.)
+  // is also wrong for the root super user and falls through to repair.
+  if (existingBinding && existingBinding.entity_type === 'employee' && existingBinding.entity_id !== null) {
     const referenced = await db.oneOrNone(
       `SELECT id FROM ${s}.employees WHERE id = $1 AND deactivated_at IS NULL`,
       [existingBinding.entity_id],
@@ -73,6 +76,8 @@ export async function seedRootEntity({ db, pgp, logger, tenantSchema, rootEmail,
       return null;
     }
     logger?.info?.('Existing binding references a missing employee — repairing.');
+  } else if (existingBinding && existingBinding.entity_type && existingBinding.entity_type !== 'employee') {
+    logger?.info?.(`Existing binding has unexpected entity_type=${existingBinding.entity_type} — repairing.`);
   }
 
   logger?.info?.('Linking root super user to employee record...');

--- a/apps/server/src/system/core/schema/migrations/202605040018_reseedTenantImportExportCatalog.js
+++ b/apps/server/src/system/core/schema/migrations/202605040018_reseedTenantImportExportCatalog.js
@@ -1,0 +1,29 @@
+/**
+ * @file Migration: re-seed policy_catalog to pick up tenants::tenants::import/export rows
+ * @module core/schema/migrations/202605040018_reseedTenantImportExportCatalog
+ *
+ * PR #65 added two new policy_catalog rows (tenants::tenants::import and
+ * tenants::tenants::export) when re-enabling the tenants /import-xls and
+ * /export-xls routes. seedPolicyCatalog only runs during provisioning,
+ * so existing root-tenant schemas (Axerra) won't pick those rows up
+ * without this reseed pass. Throwaway — safe to delete after running once.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { defineMigration } from '../../../../db/migrations/defineMigration.js';
+import { seedPolicyCatalog } from '../../services/policyCatalogSeeder.js';
+
+export default defineMigration({
+  id: '202605040018-reseed-tenant-import-export-catalog',
+  description: 'Re-seed policy_catalog with tenants::tenants::import and ::export entries',
+
+  async up({ schema, db, pgp }) {
+    if (schema === 'admin') return;
+
+    const tenant = await db.oneOrNone('SELECT tenant_code FROM admin.tenants WHERE schema_name = $1', [schema]);
+    const isRootTenant = tenant?.tenant_code === process.env.ROOT_TENANT_CODE;
+
+    await seedPolicyCatalog(db, pgp, schema, isRootTenant);
+  },
+});

--- a/apps/server/src/system/core/schema/migrations/index.js
+++ b/apps/server/src/system/core/schema/migrations/index.js
@@ -12,4 +12,14 @@ import importExportCatalog from './202603150013_importExportCatalog.js';
 import tenantPreferences from './202603270015_tenantPreferences.js';
 import reseedPolicyCatalog from './202603270016_reseedPolicyCatalog.js';
 import orphanSourceCleanup from './202604270017_orphanSourceCleanup.js';
-export default [coreRbac, coreEntities, numberingSystem, importExportCatalog, tenantPreferences, reseedPolicyCatalog, orphanSourceCleanup];
+import reseedTenantImportExportCatalog from './202605040018_reseedTenantImportExportCatalog.js';
+export default [
+  coreRbac,
+  coreEntities,
+  numberingSystem,
+  importExportCatalog,
+  tenantPreferences,
+  reseedPolicyCatalog,
+  orphanSourceCleanup,
+  reseedTenantImportExportCatalog,
+];

--- a/apps/server/src/system/core/services/policyCatalogSeeder.js
+++ b/apps/server/src/system/core/services/policyCatalogSeeder.js
@@ -244,10 +244,14 @@ const CATALOG_ENTRIES = [
   // tenants::portal-users does NOT — users are created via /register, so
   // portalUsersRouter sets disableImportXls/disableExportXls and there
   // are no catalog rows for those actions (granting them would no-op).
+  // Import/export rows here are policy_required: true so finer-grained
+  // Axerra ops roles can deny them independently of CRUD via PolicyEditor
+  // (other modules' import/export rows use policy_required: false for
+  // historical reasons; aligning them is a separate PR).
   { module: 'tenants', router: null, action: null, label: 'Tenants Module', description: 'Multi-tenant administration (Axerra only)', sort_order: 1100 },
   { module: 'tenants', router: 'tenants', action: null, label: 'Tenants', description: 'Tenant CRUD and provisioning', sort_order: 1110 },
-  { module: 'tenants', router: 'tenants', action: 'import', label: 'Import Tenants', description: 'Import tenant records from spreadsheet', sort_order: 1111, policy_required: false },
-  { module: 'tenants', router: 'tenants', action: 'export', label: 'Export Tenants', description: 'Export tenant records to spreadsheet', sort_order: 1112, policy_required: false },
+  { module: 'tenants', router: 'tenants', action: 'import', label: 'Import Tenants', description: 'Import tenant records from spreadsheet', sort_order: 1111 },
+  { module: 'tenants', router: 'tenants', action: 'export', label: 'Export Tenants', description: 'Export tenant records to spreadsheet', sort_order: 1112 },
   { module: 'tenants', router: 'portal-users', action: null, label: 'Portal Users', description: 'Application user accounts', sort_order: 1120 },
   { module: 'tenants', router: 'orphan-portal-users', action: null, label: 'Orphan Portal Users', description: 'Maintenance for portal_users with no tenant bindings (Axerra only)', sort_order: 1125 },
   { module: 'tenants', router: 'orphan-portal-users', action: 'find_orphans', label: 'Preview Orphan Portal Users', description: 'List portal_users rows with no portal_user_tenants binding (active or archived) and no impersonation_logs reference', sort_order: 1126 },

--- a/apps/server/src/system/core/services/policyCatalogSeeder.js
+++ b/apps/server/src/system/core/services/policyCatalogSeeder.js
@@ -240,12 +240,14 @@ const CATALOG_ENTRIES = [
   // independently grantable in the role editor. Use them to compose
   // finer-grained Axerra ops roles (e.g. read-only auditor with only
   // view-level grants) on top of the wildcard super_user role.
-  // tenants::tenants and tenants::portal-users disable createRouter's
-  // auto-attached /import-xls and /export-xls (they aren't real
-  // spreadsheet I/O surfaces here), so no import/export catalog rows
-  // for those routers — granting them would have no effect.
+  // tenants::tenants exposes import/export per PRD §3.2.1.
+  // tenants::portal-users does NOT — users are created via /register, so
+  // portalUsersRouter sets disableImportXls/disableExportXls and there
+  // are no catalog rows for those actions (granting them would no-op).
   { module: 'tenants', router: null, action: null, label: 'Tenants Module', description: 'Multi-tenant administration (Axerra only)', sort_order: 1100 },
   { module: 'tenants', router: 'tenants', action: null, label: 'Tenants', description: 'Tenant CRUD and provisioning', sort_order: 1110 },
+  { module: 'tenants', router: 'tenants', action: 'import', label: 'Import Tenants', description: 'Import tenant records from spreadsheet', sort_order: 1111, policy_required: false },
+  { module: 'tenants', router: 'tenants', action: 'export', label: 'Export Tenants', description: 'Export tenant records to spreadsheet', sort_order: 1112, policy_required: false },
   { module: 'tenants', router: 'portal-users', action: null, label: 'Portal Users', description: 'Application user accounts', sort_order: 1120 },
   { module: 'tenants', router: 'orphan-portal-users', action: null, label: 'Orphan Portal Users', description: 'Maintenance for portal_users with no tenant bindings (Axerra only)', sort_order: 1125 },
   { module: 'tenants', router: 'orphan-portal-users', action: 'find_orphans', label: 'Preview Orphan Portal Users', description: 'List portal_users rows with no portal_user_tenants binding (active or archived) and no impersonation_logs reference', sort_order: 1126 },

--- a/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
@@ -25,17 +25,26 @@ const meta = withMeta({ module: 'tenants', router: 'tenants' });
 // Spreadsheet I/O: tenants are importable/exportable per PRD §3.2.1, so
 // /import-xls and /export-xls stay enabled. createRouter wires its own
 // rbac on those routes after setImportAction/setExportAction, which
-// AND-combines with our router-level rbac('full'). Both rbac calls
-// resolve through the most-specific-first cascade
+// AND-combines with the router-level rbac chosen for that HTTP method.
+// Both rbac calls resolve through the most-specific-first cascade
 // (module::router::action → module::router:: → module:::: → ::::):
-//   1. Router-level: req.resource.action='' (set by withMeta), so
-//      rbac('full') resolves against tenants::tenants:: (router-level).
-//   2. After setImportAction: action='import', resolves against
-//      tenants::tenants::import.
-// Both must pass with full. A role can deny import while keeping CRUD
-// (set tenants::tenants::import::none over a wildcard full), but cannot
-// grant import without router-level CRUD — the first rbac would fall
-// through to a wildcard that must already permit full.
+//
+//   /import-xls (POST) — uses postMiddlewares
+//     1. Router-level: req.resource.action='' (set by withMeta), so
+//        rbac('full') resolves against tenants::tenants:: (router-level).
+//     2. After setImportAction: action='import', second rbac('full')
+//        resolves against tenants::tenants::import.
+//     Both must pass with full. A role can deny import while keeping
+//     CRUD (set tenants::tenants::import::none over a wildcard full),
+//     but cannot grant import without router-level CRUD — the first
+//     rbac would fall through to a wildcard that must permit full.
+//
+//   /export-xls (POST, but uses getMiddlewares — read-side semantics)
+//     1. Router-level: rbac('view') against tenants::tenants::.
+//     2. After setExportAction: action='export', second rbac('view')
+//        against tenants::tenants::export.
+//     Both must pass with view, mirroring the import semantics at the
+//     view level — a role can deny export while keeping list/get.
 // Bulk-insert/bulk-update remain disabled — admin tenant batch ops are
 // always admin-only and the API doesn't expose them.
 export default createRouter(

--- a/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
@@ -22,12 +22,15 @@ const meta = withMeta({ module: 'tenants', router: 'tenants' });
 // Including moduleEntitlement explicitly in the per-method arrays keeps
 // it BEFORE rbac (createRouter would otherwise append it after).
 //
-// disableImportXls/disableExportXls/disableBulkInsert/disableBulkUpdate:
-// tenant records are admin-managed via the API, not via spreadsheet
-// I/O. The auto-attached /import-xls and /export-xls would otherwise
-// run their own rbac() AFTER our middleware chain, double-evaluating
-// rbac with two different action codes (router-level then 'import'/
-// 'export'). Disabling them keeps the enforcement story simple.
+// Spreadsheet I/O: tenants are importable/exportable per PRD §3.2.1, so
+// /import-xls and /export-xls stay enabled. createRouter wires its own
+// rbac on those routes after setImportAction/setExportAction, which
+// AND-combines with our router-level rbac('full'): the first evaluation
+// resolves against the generic POST action, the second against the
+// 'import'/'export' action codes. Both must pass — finer-grained Axerra
+// roles can grant CRUD without import, or import without CRUD.
+// Bulk-insert/bulk-update remain disabled — admin tenant batch ops are
+// always admin-only and the API doesn't expose them.
 export default createRouter(
   tenantsController,
   (router) => {
@@ -59,8 +62,6 @@ export default createRouter(
   {
     disableBulkInsert: true,
     disableBulkUpdate: true,
-    disableImportXls: true,
-    disableExportXls: true,
     disablePing: true,
     postMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('full')],
     getMiddlewares: [requireRootTenant, meta, moduleEntitlement, rbac('view')],

--- a/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
+++ b/apps/server/src/system/tenants/apiRoutes/v1/tenantsRouter.js
@@ -25,10 +25,17 @@ const meta = withMeta({ module: 'tenants', router: 'tenants' });
 // Spreadsheet I/O: tenants are importable/exportable per PRD §3.2.1, so
 // /import-xls and /export-xls stay enabled. createRouter wires its own
 // rbac on those routes after setImportAction/setExportAction, which
-// AND-combines with our router-level rbac('full'): the first evaluation
-// resolves against the generic POST action, the second against the
-// 'import'/'export' action codes. Both must pass — finer-grained Axerra
-// roles can grant CRUD without import, or import without CRUD.
+// AND-combines with our router-level rbac('full'). Both rbac calls
+// resolve through the most-specific-first cascade
+// (module::router::action → module::router:: → module:::: → ::::):
+//   1. Router-level: req.resource.action='' (set by withMeta), so
+//      rbac('full') resolves against tenants::tenants:: (router-level).
+//   2. After setImportAction: action='import', resolves against
+//      tenants::tenants::import.
+// Both must pass with full. A role can deny import while keeping CRUD
+// (set tenants::tenants::import::none over a wildcard full), but cannot
+// grant import without router-level CRUD — the first rbac would fall
+// through to a wildcard that must already permit full.
 // Bulk-insert/bulk-update remain disabled — admin tenant batch ops are
 // always admin-only and the API doesn't expose them.
 export default createRouter(

--- a/apps/server/tests/contract/tenantsImportExport.test.js
+++ b/apps/server/tests/contract/tenantsImportExport.test.js
@@ -1,0 +1,183 @@
+/**
+ * @file Contract test: tenants /import-xls and /export-xls regression coverage
+ * @module tests/contract/tenantsImportExport
+ *
+ * PR #63 inadvertently disabled the tenants spreadsheet routes by setting
+ * disableImportXls/disableExportXls on the router. PR #65 restored them
+ * and added the tenants::tenants::import and ::export policy_catalog
+ * rows. This test locks both contracts so the same regression cannot
+ * recur:
+ *   1. /import-xls and /export-xls are registered (not 404).
+ *   2. Both are RBAC-gated — a role with the action-level deny gets 403,
+ *      and lifting the deny to the appropriate level (full for import,
+ *      view for export) makes the route stop refusing on RBAC grounds.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { bootstrapAdmin, cleanupTestDb, DB } from '../helpers/testDb.js';
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+const TEST_EMAIL = 'tenants-xls-test@axerra.io';
+const TEST_PASSWORD = 'TenantsXls65!';
+const TEST_ROLE_CODE = '_test_tenants_xls_65';
+const TEST_TENANT_SCHEMA = (process.env.ROOT_TENANT_CODE || 'AXERRA').toLowerCase();
+const TS = DB.pgp.as.name(TEST_TENANT_SCHEMA);
+
+describe('tenants /import-xls and /export-xls (PR #65 regression coverage)', () => {
+  let testUserCookies;
+  let testUserId;
+  let testRoleId;
+  let employeeId;
+
+  beforeAll(async () => {
+    const tenant = await db.one(
+      'SELECT id FROM admin.tenants WHERE schema_name = $1',
+      [TEST_TENANT_SCHEMA],
+    );
+
+    // Custom Axerra role: wildcard full + specific denies on the new
+    // import/export action codes. The denies override the wildcard via
+    // the most-specific-first cascade in rbac.js.
+    const role = await db.one(
+      `INSERT INTO ${TS}.roles (code, name, description, scope, is_system, is_immutable)
+       VALUES ($1, 'Tenants XLS Test Role', 'PR #65 contract fixture', 'all_projects', false, false)
+       RETURNING id`,
+      [TEST_ROLE_CODE],
+    );
+    testRoleId = role.id;
+
+    await db.none(
+      `INSERT INTO ${TS}.policies (role_id, module, router, action, level)
+       VALUES ($1, '', null, null, 'full'),
+              ($1, 'tenants', 'tenants', 'import', 'none'),
+              ($1, 'tenants', 'tenants', 'export', 'none')`,
+      [testRoleId],
+    );
+
+    const employee = await db.one(
+      `INSERT INTO ${TS}.employees
+         (tenant_id, first_name, last_name, is_app_user, roles)
+       VALUES ($1, 'TenantsXls', 'Tester', true, $2)
+       RETURNING id`,
+      [tenant.id, `{${TEST_ROLE_CODE}}`],
+    );
+    employeeId = employee.id;
+
+    const source = await db.one(
+      `INSERT INTO ${TS}.sources (tenant_id, table_id, source_type, label)
+       VALUES ($1, $2, 'employee', 'TenantsXls Tester')
+       RETURNING id`,
+      [tenant.id, employeeId],
+    );
+    await db.none(`UPDATE ${TS}.employees SET source_id = $1 WHERE id = $2`, [source.id, employeeId]);
+
+    const { default: bcrypt } = await import('bcrypt');
+    const passwordHash = await bcrypt.hash(TEST_PASSWORD, 4);
+    const portalUser = await db.one(
+      `INSERT INTO admin.portal_users (email, password_hash, status)
+       VALUES ($1, $2, 'active')
+       RETURNING id`,
+      [TEST_EMAIL, passwordHash],
+    );
+    testUserId = portalUser.id;
+
+    await db.none(
+      `INSERT INTO admin.portal_user_tenants (portal_user_id, tenant_id, entity_type, entity_id, status)
+       VALUES ($1, $2, 'employee', $3, 'active')`,
+      [testUserId, tenant.id, employeeId],
+    );
+
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: TEST_EMAIL, password: TEST_PASSWORD });
+    expect(loginRes.status).toBe(200);
+    testUserCookies = loginRes.headers['set-cookie'];
+  }, 30000);
+
+  afterAll(async () => {
+    if (testUserId) {
+      await db.none('DELETE FROM admin.portal_user_tenants WHERE portal_user_id = $1', [testUserId]);
+      await db.none('DELETE FROM admin.portal_users WHERE id = $1', [testUserId]);
+    }
+    if (testRoleId) {
+      await db.none(`DELETE FROM ${TS}.policies WHERE role_id = $1`, [testRoleId]);
+      await db.none(`DELETE FROM ${TS}.roles WHERE id = $1`, [testRoleId]);
+    }
+    if (employeeId) {
+      await db.none(`DELETE FROM ${TS}.sources WHERE table_id = $1 AND source_type = 'employee'`, [employeeId]);
+      await db.none(`DELETE FROM ${TS}.employees WHERE id = $1`, [employeeId]);
+    }
+  }, 15000);
+
+  test('POST /import-xls is registered (not 404) — returns 401 without auth', async () => {
+    const res = await request(app).post('/api/tenants/v1/tenants/import-xls');
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /export-xls is registered (not 404) — returns 401 without auth', async () => {
+    const res = await request(app).post('/api/tenants/v1/tenants/export-xls');
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /import-xls → 403 with explicit deny on tenants::tenants::import', async () => {
+    const res = await request(app)
+      .post('/api/tenants/v1/tenants/import-xls')
+      .set('Cookie', testUserCookies);
+    expect(res.status).toBe(403);
+  });
+
+  test('POST /export-xls → 403 with explicit deny on tenants::tenants::export', async () => {
+    const res = await request(app)
+      .post('/api/tenants/v1/tenants/export-xls')
+      .set('Cookie', testUserCookies);
+    expect(res.status).toBe(403);
+  });
+
+  test('POST /import-xls → no longer 403 after lifting deny to full', async () => {
+    await db.none(
+      `UPDATE ${TS}.policies SET level = 'full'
+       WHERE role_id = $1 AND module = 'tenants' AND router = 'tenants' AND action = 'import'`,
+      [testRoleId],
+    );
+    const { invalidateByUser } = await import('../../src/services/permCacheInvalidator.js');
+    await invalidateByUser(testUserId);
+
+    const res = await request(app)
+      .post('/api/tenants/v1/tenants/import-xls')
+      .set('Cookie', testUserCookies);
+    // 400 (missing multipart file) or 200/201 are both fine — the assertion
+    // is that RBAC no longer refuses. 404 would mean the route is gone.
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(404);
+  });
+
+  test('POST /export-xls → no longer 403 after lifting deny to view', async () => {
+    await db.none(
+      `UPDATE ${TS}.policies SET level = 'view'
+       WHERE role_id = $1 AND module = 'tenants' AND router = 'tenants' AND action = 'export'`,
+      [testRoleId],
+    );
+    const { invalidateByUser } = await import('../../src/services/permCacheInvalidator.js');
+    await invalidateByUser(testUserId);
+
+    const res = await request(app)
+      .post('/api/tenants/v1/tenants/export-xls')
+      .set('Cookie', testUserCookies);
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(404);
+  });
+});

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -426,6 +426,7 @@ Roles with `is_immutable = true` OR `is_system = true` are read-only across all 
 - The root tenant (Axerra, `AXERRA`) cannot be archived — server rejects the request with 403
 - Restore reactivates the tenant only — users remain archived and must be individually restored by an admin
 - **View Details dialog** (`maxWidth="md"`): displays tenant fields in a responsive 3-column grid of `FieldRow` components (label:value pairs). Fields: Code, Tier, Region, Status (rendered as `StatusBadge` chip), Max Users, Schema (monospace), Created, Updated, Notes (full-width). Below a divider, two `DataGrid` tables display **Primary Contacts** and **Billing Contacts** with Name, Email (mailto link), and Phone columns. Contact data is fetched via `useTenantContacts(tenantId)` hook.
+- The Module Bar exposes **Import** and **Export** XLSX actions for the tenants list, mirroring the toolbar contract used by every other resource page (see ADR-0024).
 
 **Endpoints:**
 
@@ -439,6 +440,8 @@ Roles with `is_immutable = true` OR `is_system = true` are read-only across all 
 | `PATCH`  | `/api/tenants/v1/tenants/restore`      | Restore archived tenant                                                                                                  |
 | `GET`    | `/api/tenants/v1/tenants/:id/modules`  | Get tenant's allowed modules                                                                                             |
 | `GET`    | `/api/tenants/v1/tenants/:id/contacts` | Get primary and billing contacts with phone/address (cross-schema query into tenant's employees)                         |
+| `POST`   | `/api/tenants/v1/tenants/import-xls`   | Import tenants from XLSX (requires `tenants::tenants::import` = `full`). Each row carries its own `tenant_code`. **Note:** the current implementation only inserts rows into `admin.tenants` — it does NOT call the full provisioning pipeline (no schema create / migrations / RBAC seed / admin user). Imported tenants must be provisioned separately. |
+| `POST`   | `/api/tenants/v1/tenants/export-xls`   | Export tenants to XLSX (requires `tenants::tenants::export` = `view`)                                                    |
 
 #### 3.2.2 Manage Users
 
@@ -476,6 +479,7 @@ Partial unique index: `(entity_type, entity_id) WHERE deactivated_at IS NULL` �
 **Business Rules:**
 
 - Standard POST is disabled; users must be created via the `/register` endpoint
+- Spreadsheet import/export is **not** supported on `portal-users`. `portalUsersRouter` sets `disableImportXls: true` and `disableExportXls: true`, and `policyCatalogSeeder` does not emit `tenants::portal-users::import|export` rows. Users are created via `/register` only.
 - Registration collects: `tenant_code`, `email`, `password`. Validates the tenant exists and is active. Entity linkage (`entity_type`, `entity_id`) and entity pre-validation (roles assigned, `is_app_user = true`) are not yet enforced — these fields can be set via subsequent update
 - Password automatically hashed with bcrypt on registration
 - Email must be globally unique across all active users (enforced by partial unique index WHERE deactivated_at IS NULL)

--- a/docs/decisions/0023-excel-import-export.md
+++ b/docs/decisions/0023-excel-import-export.md
@@ -35,6 +35,16 @@ Extend `createRouter` with two auto-generated routes per resource:
 
 **Disable flags:** `disableImportXls: true` / `disableExportXls: true` in `createRouter` options for resources that should not support file operations.
 
+**Routers that disable import/export (and why):**
+
+- `portalUsersRouter` — users are created via the `/register` endpoint, not from spreadsheets. Bulk-insert is also disabled.
+- `matchReviewLogsRouter` — append-only audit trail for BOM SKU matching; rows are emitted by the matching service, never imported.
+- `adminRouter` and `orphanPortalUsersRouter` — administrative action surfaces, not data resources.
+
+**Routers that explicitly DO support import/export** (callout because PRD §3.2.1 expects this and PR #63 once incorrectly disabled it):
+
+- `tenantsRouter` — `POST /tenants/import-xls` and `/export-xls` are required and policy-gated by `tenants::tenants::import|export` catalog rows.
+
 ### Frontend
 
 Two custom hooks in `hooks/useImportExport.js`:
@@ -52,7 +62,7 @@ A shared `ImportDialog` component (`components/shared/ImportDialog.jsx`) wraps `
 
 ### RBAC Policy Catalog
 
-The `policyCatalogSeeder` includes `import` and `export` action entries for every module/router combination (with exceptions: `policy-catalog`, `ledger-balances`, and `match-review-logs` are export-only; `numbering-config` and reports module have neither). Migration `202603150013_importExportCatalog` seeds these entries for existing tenants.
+The `policyCatalogSeeder` includes `import` and `export` action entries for every module/router combination (with exceptions: `policy-catalog`, `ledger-balances`, and `match-review-logs` are export-only; `numbering-config` and reports module have neither; `tenants::portal-users` has neither — users are created via `/register`). `tenants::tenants` has both. Migration `202603150013_importExportCatalog` seeds these entries for existing tenants.
 
 ## Consequences
 

--- a/docs/rules/rbac.md
+++ b/docs/rules/rbac.md
@@ -91,6 +91,11 @@ All system roles resolve through full RBAC — no bypass.
   for export
 - Both auto-applied by `createRouter` on `/import-xls`
   and `/export-xls`
+- `tenants::tenants::import|export` ARE seeded in
+  `policyCatalogSeeder` and gate `POST /tenants/import-xls` and
+  `POST /tenants/export-xls`. `tenants::portal-users::import|export`
+  are intentionally NOT seeded — `portalUsersRouter` disables those
+  routes (users are created via `/register`).
 
 ## Middleware Chain
 

--- a/docs/rules/tenants.md
+++ b/docs/rules/tenants.md
@@ -63,6 +63,31 @@ The root Axerra tenant (code `AXERRA`) has special protections:
 - The bootstrap super user (created during admin setup) is identified by
   `entity_type IS NULL` and belongs to the root tenant
 
+## Spreadsheet Import / Export
+
+Tenant records are spreadsheet-importable and -exportable per PRD §3.2.1:
+
+- `POST /api/tenants/v1/tenants/import-xls` — gated by
+  `tenants::tenants::import` (`full`)
+- `POST /api/tenants/v1/tenants/export-xls` — gated by
+  `tenants::tenants::export` (`view`)
+
+`tenantsController.importXls` overrides the base implementation: each row
+already carries its own `tenant_code`, so the upload callback only injects
+`created_by` from the authenticated user.
+
+**Known limitation:** the import path currently only inserts rows into
+`admin.tenants`. It does NOT run the full provisioning pipeline that
+`POST /tenants` does (schema create + tenant migrations + RBAC seed +
+admin user creation via `provisionNewTenant`). Imported tenants must be
+provisioned separately before they are usable. Track follow-up work to
+either route imports through `provisionNewTenant` or document a manual
+provisioning step.
+
+`portal_users` is **not** importable or exportable — users are created via
+`/register`. `portalUsersRouter` sets `disableImportXls`/`disableExportXls`
+and the policy catalog has no `tenants::portal-users::import|export` rows.
+
 ## User Registration Prerequisites
 
 Before a user can be registered:


### PR DESCRIPTION
## Summary

- Re-enable `POST /api/tenants/v1/tenants/import-xls` and `/export-xls`. PR #63 disabled them as a shortcut around perceived double-rbac evaluation when wiring `rbac()` into per-method middleware arrays, which broke the long-standing `ManageTenantsPage` Import/Export buttons (404). The two rbac evaluations on `/import-xls` AND-combine — the first against the generic POST action, the second against `action='import'` after `setImportAction` runs — which is the correct, finer-grained semantics, not a bug to dodge.
- Restore the two `tenants::tenants::import|export` policy_catalog rows that PR #63 stripped. `tenants::portal-users::import|export` stays absent because `portalUsersRouter` legitimately disables those routes (users are created via `/register`).
- Repair a separate latent bug in `seedRootEntity`: the early-return only checked that the binding's `entity_type`/`entity_id` were non-null, not that the referenced employee row still existed. After a routine drop/recreate of the tenant schema the binding survives in `admin.portal_user_tenants` but points at a vanished employee, so `setupAdmin:dev` silently skipped re-seeding the System Administrator and `axerra.employees` stayed empty. Now verify the referenced row is alive before short-circuiting; otherwise re-seed and repoint.
- Lock the requirement into PRD §3.2.1, ADR-0023, `docs/rules/tenants.md`, and `docs/rules/rbac.md` so a future shortcut would have to delete spec text first.

**Known limitation flagged in docs (not fixed here):** `tenantsController.importXls` only inserts rows into `admin.tenants` — it does NOT call `provisionNewTenant`, so imported tenants get no schema, no migrations, no RBAC seed, and no admin user. The endpoint works but imported tenants must be provisioned separately. Track as follow-up: either route imports through `provisionNewTenant` row-by-row, or require manual provisioning post-import.

## Test plan

- [ ] `npm -w apps/server run lint` clean (one pre-existing warning unrelated)
- [ ] `npm -w apps/server test` — 538/538 pass
- [ ] `npm -w apps/server run setupAdmin:dev` reports 2 new policy_catalog entries on first run after the change, 0 on subsequent runs
- [ ] `psql axerra_dev` — `tenants::tenants::import|export` present, no `tenants::portal-users::import|export`
- [ ] Log in as `su@axerra.io`, open Manage Tenants → Import returns 200/422 (no longer 404); Export returns an XLSX blob
- [ ] `POST /api/tenants/v1/portal-users/import-xls` still returns 404 — portal-users stays disabled
- [ ] After dropping `axerra.employees` and re-running `setupAdmin:dev`, the System Administrator employee is re-seeded and the binding repoints