### PR TITLE
fix(server): make Reset Password an explicit RBAC grant

### DIFF
--- a/apps/client/src/pages/Tenant/PolicyEditor.jsx
+++ b/apps/client/src/pages/Tenant/PolicyEditor.jsx
@@ -272,53 +272,97 @@ export default function PolicyEditor({ roleId, readOnly = false, actionsContaine
               {/* Router rows (with nested router-action sub-rows) */}
               {visibleRouters.map(([routerName, rtr]) => {
                 const routerKey = policyKey(moduleName, routerName, null);
-                return (
-                  <Box key={routerName}>
+                const hasActions = rtr.actions && rtr.actions.size > 0;
+
+                const actionRows = hasActions ? [...rtr.actions.entries()].map(([actionName, act]) => {
+                  const actionKey = policyKey(moduleName, routerName, actionName);
+                  return (
                     <Box
+                      key={actionName}
                       sx={{
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'space-between',
                         py: 0.5,
-                        px: 1,
+                        pl: 4,
+                        pr: 1,
                         '&:hover': { bgcolor: 'action.hover' },
                         borderRadius: 0.5,
                       }}
                     >
-                      <Typography variant="body2">{rtr.label}</Typography>
-                      {rtr.grantable !== false && (
-                        <LevelSelector
-                          value={resolveLevel(edits, routerKey, routerKey, moduleKey)}
-                          onChange={(val) => handleChange(routerKey, val)}
-                          disabled={readOnly}
-                        />
-                      )}
+                      <Typography variant="body2" color="text.secondary">{act.label}</Typography>
+                      <LevelSelector
+                        value={resolveLevel(edits, actionKey, routerKey, moduleKey)}
+                        onChange={(val) => handleChange(actionKey, val)}
+                        disabled={readOnly}
+                      />
                     </Box>
-                    {rtr.actions && [...rtr.actions.entries()].map(([actionName, act]) => {
-                      const actionKey = policyKey(moduleName, routerName, actionName);
-                      return (
-                        <Box
-                          key={actionName}
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'space-between',
-                            py: 0.5,
-                            pl: 4,
-                            pr: 1,
-                            '&:hover': { bgcolor: 'action.hover' },
-                            borderRadius: 0.5,
-                          }}
-                        >
-                          <Typography variant="body2" color="text.secondary">{act.label}</Typography>
-                          <LevelSelector
-                            value={resolveLevel(edits, actionKey, routerKey, moduleKey)}
-                            onChange={(val) => handleChange(actionKey, val)}
-                            disabled={readOnly}
-                          />
+                  );
+                }) : null;
+
+                if (hasActions) {
+                  return (
+                    <Accordion
+                      key={routerName}
+                      defaultExpanded={false}
+                      disableGutters
+                      elevation={0}
+                      sx={{
+                        bgcolor: 'transparent',
+                        '&::before': { display: 'none' },
+                      }}
+                    >
+                      <AccordionSummary
+                        expandIcon={<ExpandMoreIcon />}
+                        sx={{
+                          minHeight: 0,
+                          px: 1,
+                          '& .MuiAccordionSummary-content': { my: 0.5 },
+                          '&:hover': { bgcolor: 'action.hover' },
+                          borderRadius: 0.5,
+                        }}
+                      >
+                        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', pr: 1 }}>
+                          <Typography variant="body2">{rtr.label}</Typography>
+                          {rtr.grantable !== false && (
+                            <Box onClick={(e) => e.stopPropagation()}>
+                              <LevelSelector
+                                value={resolveLevel(edits, routerKey, routerKey, moduleKey)}
+                                onChange={(val) => handleChange(routerKey, val)}
+                                disabled={readOnly}
+                              />
+                            </Box>
+                          )}
                         </Box>
-                      );
-                    })}
+                      </AccordionSummary>
+                      <AccordionDetails sx={{ pt: 0, pb: 0 }}>
+                        {actionRows}
+                      </AccordionDetails>
+                    </Accordion>
+                  );
+                }
+
+                return (
+                  <Box
+                    key={routerName}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      py: 0.5,
+                      px: 1,
+                      '&:hover': { bgcolor: 'action.hover' },
+                      borderRadius: 0.5,
+                    }}
+                  >
+                    <Typography variant="body2">{rtr.label}</Typography>
+                    {rtr.grantable !== false && (
+                      <LevelSelector
+                        value={resolveLevel(edits, routerKey, routerKey, moduleKey)}
+                        onChange={(val) => handleChange(routerKey, val)}
+                        disabled={readOnly}
+                      />
+                    )}
                   </Box>
                 );
               })}

--- a/apps/server/src/middleware/rbac.js
+++ b/apps/server/src/middleware/rbac.js
@@ -12,16 +12,38 @@
  */
 
 import logger from '../lib/logger.js';
+import { CATALOG_ENTRIES } from '../system/core/services/policyCatalogSeeder.js';
 
 const LEVEL_ORDER = { none: 0, view: 1, full: 2 };
 
 /**
+ * Action addresses that require an exact-match policy grant — no fallback
+ * to router/module/wildcard. Derived from the policy catalog: any
+ * router-scoped action with `policy_required: true` (the default).
+ *
+ * Catalog rows with `policy_required: false` represent capabilities that
+ * are intentionally not independently grantable; they continue to use the
+ * regular fallback resolver and inherit from broader grants.
+ */
+export const EXACT_MATCH_KEYS = new Set(
+  CATALOG_ENTRIES
+    .filter((e) => e.router && e.action && e.policy_required !== false)
+    .map((e) => `${e.module}::${e.router}::${e.action}`),
+);
+
+/**
  * Resolve the effective permission level from a capabilities map.
- * Checks most-specific key first, falling back to broader grants:
+ *
+ * For most addresses, checks most-specific key first and falls back:
  *   module::router::action → module::router:: → module:::: → :::: (wildcard)
  *
  * The final '::::' fallback matches the empty-module wildcard policy seeded
  * for admin/super_user roles, ensuring they pass without per-module entries.
+ *
+ * For addresses in EXACT_MATCH_KEYS (catalog `policy_required: true` actions),
+ * only the exact key is consulted — broader grants do not satisfy the check.
+ * This keeps sensitive actions (e.g. password resets) out of router-level
+ * CRUD grants.
  *
  * @param {object} caps Capabilities map from permission canon
  * @param {string} moduleName
@@ -30,8 +52,12 @@ const LEVEL_ORDER = { none: 0, view: 1, full: 2 };
  * @returns {string} Resolved level: 'none', 'view', or 'full'
  */
 export function resolveLevel(caps, moduleName, routerName, actionName) {
+  const exactKey = `${moduleName}::${routerName}::${actionName}`;
+  if (EXACT_MATCH_KEYS.has(exactKey)) {
+    return caps[exactKey] || 'none';
+  }
   const keys = [
-    `${moduleName}::${routerName}::${actionName}`,
+    exactKey,
     `${moduleName}::${routerName}::`,
     `${moduleName}::::`,
     '::::',

--- a/apps/server/src/system/core/services/policyCatalogSeeder.js
+++ b/apps/server/src/system/core/services/policyCatalogSeeder.js
@@ -24,19 +24,20 @@ import logger from '../../../lib/logger.js';
 // tenant_id, tenant_code, source_id, audit fields, deactivated_at)
 // ────────────────────────────────────────────────────────────────────
 
-const CATALOG_ENTRIES = [
+export const CATALOG_ENTRIES = [
   // ── Core ────────────────────────────────────────────────────────
   { module: 'core', router: null, action: null, label: 'Admin Module', description: 'Entity management and RBAC configuration', sort_order: 100 },
-  { module: 'core', router: null, action: 'reset-password', label: 'Reset Password', description: 'Reset any app-user password', sort_order: 101 },
   { module: 'core', router: 'vendors', action: null, label: 'Vendors', description: 'Vendor company records', sort_order: 110, available_fields: ['name', 'code', 'payment_term_id', 'is_active', 'notes'] },
   { module: 'core', router: 'vendors', action: 'import', label: 'Import Vendors', description: 'Import vendor records from spreadsheet', sort_order: 111, policy_required: false },
   { module: 'core', router: 'vendors', action: 'export', label: 'Export Vendors', description: 'Export vendor records to spreadsheet', sort_order: 112, policy_required: false },
   { module: 'core', router: 'clients', action: null, label: 'Clients', description: 'Client company records', sort_order: 120, available_fields: ['name', 'code', 'roles', 'is_app_user', 'is_active'] },
   { module: 'core', router: 'clients', action: 'import', label: 'Import Clients', description: 'Import client records from spreadsheet', sort_order: 121, policy_required: false },
   { module: 'core', router: 'clients', action: 'export', label: 'Export Clients', description: 'Export client records to spreadsheet', sort_order: 122, policy_required: false },
+  { module: 'core', router: 'clients', action: 'reset-password', label: 'Reset Password', description: 'Reset password for a client app-user', sort_order: 123 },
   { module: 'core', router: 'employees', action: null, label: 'Employees', description: 'Employee records', sort_order: 130, available_fields: ['first_name', 'last_name', 'code', 'position', 'department', 'is_app_user', 'roles', 'is_primary_contact', 'is_billing_contact'] },
   { module: 'core', router: 'employees', action: 'import', label: 'Import Employees', description: 'Import employee records from spreadsheet', sort_order: 131, policy_required: false },
   { module: 'core', router: 'employees', action: 'export', label: 'Export Employees', description: 'Export employee records to spreadsheet', sort_order: 132, policy_required: false },
+  { module: 'core', router: 'employees', action: 'reset-password', label: 'Reset Password', description: 'Reset password for an employee app-user', sort_order: 133 },
   { module: 'core', router: 'contacts', action: null, label: 'Contacts', description: 'Miscellaneous contacts / payees', sort_order: 140, available_fields: ['name', 'code', 'is_active'] },
   { module: 'core', router: 'contacts', action: 'import', label: 'Import Contacts', description: 'Import contact records from spreadsheet', sort_order: 141, policy_required: false },
   { module: 'core', router: 'contacts', action: 'export', label: 'Export Contacts', description: 'Export contact records to spreadsheet', sort_order: 142, policy_required: false },
@@ -60,6 +61,7 @@ const CATALOG_ENTRIES = [
   { module: 'core', router: 'vendor-contacts', action: null, label: 'Vendor Contacts', description: 'Individual contacts associated with vendors', sort_order: 183, policy_required: false, available_fields: ['first_name', 'last_name', 'position', 'department', 'is_app_user', 'roles'] },
   { module: 'core', router: 'vendor-contacts', action: 'import', label: 'Import Vendor Contacts', description: 'Import vendor contact records from spreadsheet', sort_order: 184, policy_required: false },
   { module: 'core', router: 'vendor-contacts', action: 'export', label: 'Export Vendor Contacts', description: 'Export vendor contact records to spreadsheet', sort_order: 185, policy_required: false },
+  { module: 'core', router: 'vendor-contacts', action: 'reset-password', label: 'Reset Password', description: 'Reset password for a vendor-contact app-user', sort_order: 186 },
   { module: 'core', router: 'companies', action: null, label: 'Companies', description: 'Company entities for intercompany accounting', sort_order: 186, available_fields: ['code', 'name', 'is_active'] },
   { module: 'core', router: 'companies', action: 'import', label: 'Import Companies', description: 'Import company records from spreadsheet', sort_order: 187, policy_required: false },
   { module: 'core', router: 'companies', action: 'export', label: 'Export Companies', description: 'Export company records to spreadsheet', sort_order: 188, policy_required: false },

--- a/apps/server/src/system/core/services/systemRoleSeeder.js
+++ b/apps/server/src/system/core/services/systemRoleSeeder.js
@@ -16,9 +16,25 @@
  */
 
 import logger from '../../../lib/logger.js';
+import { CATALOG_ENTRIES } from './policyCatalogSeeder.js';
 
 /** Modules where support role gets 'none' instead of 'full'. */
 const FINANCIAL_MODULES = ['accounting', 'ap', 'ar'];
+
+/**
+ * Action addresses that require an explicit policy grant — they bypass
+ * the wildcard `::::` fallback (see EXACT_MATCH_KEYS in rbac middleware).
+ * Derived from the catalog: any router-action row where policy_required
+ * is not explicitly false. System roles that should retain full access
+ * must enumerate these explicitly.
+ */
+const EXACT_MATCH_POLICIES = CATALOG_ENTRIES
+  .filter((e) => e.router && e.action && e.policy_required !== false)
+  .map((e) => ({ module: e.module, router: e.router, action: e.action, level: 'full' }));
+
+/** Tenants-module exact-match policies are Axerra-only. */
+const EXACT_MATCH_TENANT_SCOPED = EXACT_MATCH_POLICIES.filter((p) => p.module !== 'tenants');
+const EXACT_MATCH_ROOT_ONLY = EXACT_MATCH_POLICIES;
 
 /**
  * System role definitions.
@@ -36,7 +52,10 @@ function getSystemRoleDefinitions(isRootTenant) {
     is_system: true,
     is_immutable: true,
     scope: 'all_projects',
-    policies: [{ module: '', router: null, action: null, level: 'full' }],
+    policies: [
+      { module: '', router: null, action: null, level: 'full' },
+      ...EXACT_MATCH_TENANT_SCOPED,
+    ],
   });
 
   // vendor_contact — seeded in all tenants; portal access for vendor contact people
@@ -80,7 +99,10 @@ function getSystemRoleDefinitions(isRootTenant) {
       is_system: true,
       is_immutable: true,
       scope: 'all_projects',
-      policies: [{ module: '', router: null, action: null, level: 'full' }],
+      policies: [
+        { module: '', router: null, action: null, level: 'full' },
+        ...EXACT_MATCH_ROOT_ONLY,
+      ],
     });
 
     // support — Axerra only
@@ -93,6 +115,7 @@ function getSystemRoleDefinitions(isRootTenant) {
       scope: 'all_projects',
       policies: [
         { module: '', router: null, action: null, level: 'full' },
+        ...EXACT_MATCH_ROOT_ONLY,
         // Override financial modules to none
         ...FINANCIAL_MODULES.map((mod) => ({ module: mod, router: null, action: null, level: 'none' })),
       ],

--- a/apps/server/tests/unit/rbac.test.js
+++ b/apps/server/tests/unit/rbac.test.js
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { rbac, resolveLevel } from '../../src/middleware/rbac.js';
+import { rbac, resolveLevel, EXACT_MATCH_KEYS } from '../../src/middleware/rbac.js';
 
 describe('resolveLevel', () => {
   it('returns exact match for module::router::action', () => {
@@ -65,6 +65,40 @@ describe('resolveLevel', () => {
     const caps = { '::::': 'full' };
     expect(resolveLevel(caps, 'core', 'vendors', 'import')).toBe('full');
     expect(resolveLevel(caps, 'core', 'vendors', 'export')).toBe('full');
+  });
+
+  // ── Exact-match (policy_required) actions ─────────────────────
+
+  it('registers reset-password addresses as exact-match', () => {
+    expect(EXACT_MATCH_KEYS.has('core::employees::reset-password')).toBe(true);
+    expect(EXACT_MATCH_KEYS.has('core::clients::reset-password')).toBe(true);
+    expect(EXACT_MATCH_KEYS.has('core::vendor-contacts::reset-password')).toBe(true);
+  });
+
+  it('exact-match action ignores router-level grant', () => {
+    const caps = { 'core::employees::': 'full' };
+    expect(resolveLevel(caps, 'core', 'employees', 'reset-password')).toBe('none');
+  });
+
+  it('exact-match action ignores module-level grant', () => {
+    const caps = { 'core::::': 'full' };
+    expect(resolveLevel(caps, 'core', 'clients', 'reset-password')).toBe('none');
+  });
+
+  it('exact-match action ignores wildcard grant', () => {
+    const caps = { '::::': 'full' };
+    expect(resolveLevel(caps, 'core', 'vendor-contacts', 'reset-password')).toBe('none');
+  });
+
+  it('exact-match action requires exact key', () => {
+    const caps = { 'core::employees::reset-password': 'full' };
+    expect(resolveLevel(caps, 'core', 'employees', 'reset-password')).toBe('full');
+  });
+
+  it('exact-match does not affect non-listed actions', () => {
+    expect(EXACT_MATCH_KEYS.has('core::employees::')).toBe(false);
+    const caps = { 'core::employees::': 'full' };
+    expect(resolveLevel(caps, 'core', 'employees', 'create')).toBe('full');
   });
 });
 
@@ -264,5 +298,45 @@ describe('rbac middleware', () => {
     await rbac()(req, res, next);
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(403);
+  });
+
+  // ── Exact-match (reset-password) endpoint enforcement ─────────
+
+  it('denies reset-password when role only has router-level full', async () => {
+    const req = makeReq(
+      'POST',
+      { caps: { 'core::employees::': 'full' } },
+      { module: 'core', router: 'employees', action: 'reset-password' },
+    );
+    const res = makeRes();
+    const next = vi.fn();
+    await rbac('full')(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('denies reset-password when role only has wildcard ::::', async () => {
+    const req = makeReq(
+      'POST',
+      { caps: { '::::': 'full' } },
+      { module: 'core', router: 'clients', action: 'reset-password' },
+    );
+    const res = makeRes();
+    const next = vi.fn();
+    await rbac('full')(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('allows reset-password when role has the exact action grant', async () => {
+    const req = makeReq(
+      'POST',
+      { caps: { 'core::vendor-contacts::reset-password': 'full' } },
+      { module: 'core', router: 'vendor-contacts', action: 'reset-password' },
+    );
+    const res = makeRes();
+    const next = vi.fn();
+    await rbac('full')(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- The Reset Password toggle in the Policy Editor was a no-op: catalog row was at `core::null::reset-password`, but the three actual endpoints (employees, clients, vendor-contacts) checked router-scoped addresses, which fell back to router-level grants. Granting `Employees: full` implicitly granted password resets — CRUD and password reset could not be separated.
- Catalog now exposes `core::{employees,clients,vendor-contacts}::reset-password` rows; the dead `core::null::reset-password` row is removed.
- `rbac.resolveLevel` now skips the broader-grant fallback for any router-action address with `policy_required !== false` (derived from `CATALOG_ENTRIES` at module load). This also closes a pre-existing gap where wildcard `::::` was implicitly satisfying other sensitive actions (sources find/cleanup orphans, tenants import/export, orphan-portal-users find/cleanup, admin list_schemas/impersonate).
- System role seeder is catalog-driven too: `admin` / `super_user` / `support` pick up explicit `full` grants for the relevant exact-match keys, so existing seeded behavior is preserved.
- PolicyEditor: routers with action sub-rows (the new Reset Password toggles, the orphan find/cleanup pairs) now render as collapsible accordions, matching the module-level open/close pattern.

## Test plan

- [x] `npm run lint` clean
- [x] `npm -w apps/server run test:unit` (147 ✓, including 12 new exact-match cases)
- [x] `npm -w apps/server run test:contract` (285 ✓)
- [x] `npm -w apps/server run test:integration` (86 ✓)
- [x] `npm -w apps/server run test:rbac` (35 ✓)
- [x] Manual smoke in PolicyEditor: chevron expands/collapses Reset Password under Clients / Employees / Vendor Contacts
- [ ] After merge, fresh tenants get the new catalog rows + role grants automatically; no migration required