### PR TITLE
fix(server): RBAC import/export cleanup

### DIFF
--- a/apps/client/src/pages/Tenant/PolicyEditor.jsx
+++ b/apps/client/src/pages/Tenant/PolicyEditor.jsx
@@ -33,9 +33,24 @@ function policyKey(module, router, action) {
   return `${module}::${router || ''}::${action || ''}`;
 }
 
-/** Cascade: action → router → module → root → '' */
+/** Cascade: action → router → module → root → '' (used for module + router headings). */
 function resolveLevel(edits, key, routerKey, moduleKey) {
   return edits[key] ?? edits[routerKey] ?? edits[moduleKey] ?? edits[ROOT_KEY] ?? '';
+}
+
+/**
+ * Exact-match resolution — used for action rows.
+ *
+ * Mirrors `rbac.resolveLevel()` on the server: any action address whose
+ * catalog row is `policy_required !== false` requires an exact-match
+ * policy grant; broader grants do NOT satisfy it. `buildCatalogTree`
+ * only emits `policy_required !== false` rows into the action maps, so
+ * every rendered action row uses this resolver. Displaying the cascade
+ * here would lie — the user would see Export = F inherited from
+ * Vendors:F while the endpoint returns 403.
+ */
+function resolveExact(edits, key) {
+  return edits[key] ?? '';
 }
 
 /**
@@ -261,7 +276,7 @@ export default function PolicyEditor({ roleId, readOnly = false, actionsContaine
                   >
                     <Typography variant="body2" color="text.secondary">{act.label}</Typography>
                     <LevelSelector
-                      value={resolveLevel(edits, actionKey, actionKey, moduleKey)}
+                      value={resolveExact(edits, actionKey)}
                       onChange={(val) => handleChange(actionKey, val)}
                       disabled={readOnly}
                     />
@@ -292,7 +307,7 @@ export default function PolicyEditor({ roleId, readOnly = false, actionsContaine
                     >
                       <Typography variant="body2" color="text.secondary">{act.label}</Typography>
                       <LevelSelector
-                        value={resolveLevel(edits, actionKey, routerKey, moduleKey)}
+                        value={resolveExact(edits, actionKey)}
                         onChange={(val) => handleChange(actionKey, val)}
                         disabled={readOnly}
                       />

--- a/apps/server/src/modules/accounting/apiRoutes/v1/journalEntryLinesRouter.js
+++ b/apps/server/src/modules/accounting/apiRoutes/v1/journalEntryLinesRouter.js
@@ -17,4 +17,6 @@ export default createRouter(journalEntryLinesController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/modules/activities/apiRoutes/v1/deliverableAssignmentsRouter.js
+++ b/apps/server/src/modules/activities/apiRoutes/v1/deliverableAssignmentsRouter.js
@@ -17,4 +17,6 @@ export default createRouter(deliverableAssignmentsController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/modules/ap/apiRoutes/v1/apInvoiceLinesRouter.js
+++ b/apps/server/src/modules/ap/apiRoutes/v1/apInvoiceLinesRouter.js
@@ -17,4 +17,6 @@ export default createRouter(apInvoiceLinesController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/modules/ar/apiRoutes/v1/arInvoiceLinesRouter.js
+++ b/apps/server/src/modules/ar/apiRoutes/v1/arInvoiceLinesRouter.js
@@ -17,4 +17,6 @@ export default createRouter(arInvoiceLinesController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/modules/projects/apiRoutes/v1/costItemsRouter.js
+++ b/apps/server/src/modules/projects/apiRoutes/v1/costItemsRouter.js
@@ -17,4 +17,6 @@ export default createRouter(costItemsController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/modules/projects/apiRoutes/v1/templateChangeOrdersRouter.js
+++ b/apps/server/src/modules/projects/apiRoutes/v1/templateChangeOrdersRouter.js
@@ -17,4 +17,6 @@ export default createRouter(templateChangeOrdersController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/modules/projects/apiRoutes/v1/templateCostItemsRouter.js
+++ b/apps/server/src/modules/projects/apiRoutes/v1/templateCostItemsRouter.js
@@ -17,4 +17,6 @@ export default createRouter(templateCostItemsController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/modules/projects/apiRoutes/v1/templateTasksRouter.js
+++ b/apps/server/src/modules/projects/apiRoutes/v1/templateTasksRouter.js
@@ -17,4 +17,6 @@ export default createRouter(templateTasksController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/modules/projects/apiRoutes/v1/templateUnitsRouter.js
+++ b/apps/server/src/modules/projects/apiRoutes/v1/templateUnitsRouter.js
@@ -17,4 +17,6 @@ export default createRouter(templateUnitsController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/system/core/apiRoutes/v1/addressesRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/addressesRouter.js
@@ -17,4 +17,6 @@ export default createRouter(addressesController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/system/core/apiRoutes/v1/emailsRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/emailsRouter.js
@@ -17,4 +17,6 @@ export default createRouter(emailsController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/system/core/apiRoutes/v1/fieldGroupDefinitionsRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/fieldGroupDefinitionsRouter.js
@@ -17,4 +17,6 @@ export default createRouter(fieldGroupDefinitionsController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/system/core/apiRoutes/v1/fieldGroupGrantsRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/fieldGroupGrantsRouter.js
@@ -30,5 +30,7 @@ export default createRouter(
     putMiddlewares: [meta],
     deleteMiddlewares: [meta],
     patchMiddlewares: [meta],
+    disableImportXls: true,
+    disableExportXls: true,
   },
 );

--- a/apps/server/src/system/core/apiRoutes/v1/phoneNumbersRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/phoneNumbersRouter.js
@@ -17,4 +17,6 @@ export default createRouter(phoneNumbersController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/system/core/apiRoutes/v1/policiesRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/policiesRouter.js
@@ -24,5 +24,7 @@ export default createRouter(
     putMiddlewares: [meta],
     deleteMiddlewares: [meta],
     patchMiddlewares: [meta],
+    disableImportXls: true,
+    disableExportXls: true,
   },
 );

--- a/apps/server/src/system/core/apiRoutes/v1/policyCatalogRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/policyCatalogRouter.js
@@ -27,4 +27,5 @@ export default createRouter(policyCatalogController, null, {
   disableBulkInsert: true,
   disableBulkUpdate: true,
   disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/system/core/apiRoutes/v1/rolesRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/rolesRouter.js
@@ -17,4 +17,6 @@ export default createRouter(rolesController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/system/core/apiRoutes/v1/sourcesRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/sourcesRouter.js
@@ -41,5 +41,7 @@ export default createRouter(
     putMiddlewares: [meta],
     deleteMiddlewares: [meta],
     patchMiddlewares: [meta],
+    disableImportXls: true,
+    disableExportXls: true,
   },
 );

--- a/apps/server/src/system/core/apiRoutes/v1/stateFiltersRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/stateFiltersRouter.js
@@ -24,5 +24,7 @@ export default createRouter(
     putMiddlewares: [meta],
     deleteMiddlewares: [meta],
     patchMiddlewares: [meta],
+    disableImportXls: true,
+    disableExportXls: true,
   },
 );

--- a/apps/server/src/system/core/apiRoutes/v1/taxIdentifiersRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/taxIdentifiersRouter.js
@@ -17,4 +17,6 @@ export default createRouter(taxIdentifiersController, null, {
   putMiddlewares: [meta],
   deleteMiddlewares: [meta],
   patchMiddlewares: [meta],
+  disableImportXls: true,
+  disableExportXls: true,
 });

--- a/apps/server/src/system/core/services/policyCatalogSeeder.js
+++ b/apps/server/src/system/core/services/policyCatalogSeeder.js
@@ -15,10 +15,23 @@ import logger from '../../../lib/logger.js';
 // Three tiers:
 //   1. Module-level  (router=null, action=null) — one per module
 //   2. Router-level  (action=null)              — one per router
-//   3. Action-level  (action='import'|'export') — per-table RBAC grants
+//   3. Action-level  (action='import'|'export'|'reset-password'|…)
 //
 // sort_order convention: module = X00, routers = X10/X20/…,
-//   import = router+1, export = router+2
+//   import = router+1, export = router+2, custom action = router+3+
+//
+// policy_required semantics (see rbac.js EXACT_MATCH_KEYS):
+//   - true (default): independently grantable; rbac middleware requires
+//     an exact-match policy at this address (no fallback to router/
+//     module/wildcard).
+//   - false: not independently grantable; UI hides the toggle and
+//     runtime falls back to broader grants (covered by router-level
+//     CRUD).
+//
+// Import actions use policy_required: false — CREATE/UPDATE at the
+// router level already gates them.
+// Export actions use policy_required: true (default) — independently
+// grantable for compliance/sensitivity gating.
 //
 // available_fields: user-facing columns per resource (excludes id,
 // tenant_id, tenant_code, source_id, audit fields, deactivated_at)
@@ -29,66 +42,51 @@ export const CATALOG_ENTRIES = [
   { module: 'core', router: null, action: null, label: 'Admin Module', description: 'Entity management and RBAC configuration', sort_order: 100 },
   { module: 'core', router: 'vendors', action: null, label: 'Vendors', description: 'Vendor company records', sort_order: 110, available_fields: ['name', 'code', 'payment_term_id', 'is_active', 'notes'] },
   { module: 'core', router: 'vendors', action: 'import', label: 'Import Vendors', description: 'Import vendor records from spreadsheet', sort_order: 111, policy_required: false },
-  { module: 'core', router: 'vendors', action: 'export', label: 'Export Vendors', description: 'Export vendor records to spreadsheet', sort_order: 112, policy_required: false },
+  { module: 'core', router: 'vendors', action: 'export', label: 'Export Vendors', description: 'Export vendor records to spreadsheet', sort_order: 112 },
   { module: 'core', router: 'clients', action: null, label: 'Clients', description: 'Client company records', sort_order: 120, available_fields: ['name', 'code', 'roles', 'is_app_user', 'is_active'] },
   { module: 'core', router: 'clients', action: 'import', label: 'Import Clients', description: 'Import client records from spreadsheet', sort_order: 121, policy_required: false },
-  { module: 'core', router: 'clients', action: 'export', label: 'Export Clients', description: 'Export client records to spreadsheet', sort_order: 122, policy_required: false },
+  { module: 'core', router: 'clients', action: 'export', label: 'Export Clients', description: 'Export client records to spreadsheet', sort_order: 122 },
   { module: 'core', router: 'clients', action: 'reset-password', label: 'Reset Password', description: 'Reset password for a client app-user', sort_order: 123 },
   { module: 'core', router: 'employees', action: null, label: 'Employees', description: 'Employee records', sort_order: 130, available_fields: ['first_name', 'last_name', 'code', 'position', 'department', 'is_app_user', 'roles', 'is_primary_contact', 'is_billing_contact'] },
   { module: 'core', router: 'employees', action: 'import', label: 'Import Employees', description: 'Import employee records from spreadsheet', sort_order: 131, policy_required: false },
-  { module: 'core', router: 'employees', action: 'export', label: 'Export Employees', description: 'Export employee records to spreadsheet', sort_order: 132, policy_required: false },
+  { module: 'core', router: 'employees', action: 'export', label: 'Export Employees', description: 'Export employee records to spreadsheet', sort_order: 132 },
   { module: 'core', router: 'employees', action: 'reset-password', label: 'Reset Password', description: 'Reset password for an employee app-user', sort_order: 133 },
   { module: 'core', router: 'contacts', action: null, label: 'Contacts', description: 'Miscellaneous contacts / payees', sort_order: 140, available_fields: ['name', 'code', 'is_active'] },
   { module: 'core', router: 'contacts', action: 'import', label: 'Import Contacts', description: 'Import contact records from spreadsheet', sort_order: 141, policy_required: false },
-  { module: 'core', router: 'contacts', action: 'export', label: 'Export Contacts', description: 'Export contact records to spreadsheet', sort_order: 142, policy_required: false },
+  { module: 'core', router: 'contacts', action: 'export', label: 'Export Contacts', description: 'Export contact records to spreadsheet', sort_order: 142 },
+  // sources, addresses, phone-numbers, tax-identifiers, emails:
+  // import/export disabled at the router level (sub-records of parent
+  // entities; importing standalone creates orphans). Catalog rows for
+  // import/export intentionally absent.
   { module: 'core', router: 'sources', action: null, label: 'Sources', description: 'Polymorphic source registry', sort_order: 150, policy_required: false, available_fields: ['table_id', 'source_type', 'label'] },
-  { module: 'core', router: 'sources', action: 'import', label: 'Import Sources', description: 'Import source records from spreadsheet', sort_order: 151, policy_required: false },
-  { module: 'core', router: 'sources', action: 'export', label: 'Export Sources', description: 'Export source records to spreadsheet', sort_order: 152, policy_required: false },
   { module: 'core', router: 'sources', action: 'find_orphans', label: 'Preview Orphan Sources', description: 'List polymorphic sources rows whose owning entity has been hard-deleted', sort_order: 153 },
   { module: 'core', router: 'sources', action: 'cleanup_orphans', label: 'Clean Up Orphan Sources', description: 'Hard-delete orphaned polymorphic sources rows in the caller tenant schema. Requires Preview Orphan Sources — the UI gates cleanup on a successful preview.', sort_order: 154 },
   { module: 'core', router: 'addresses', action: null, label: 'Addresses', description: 'Addresses linked to entities', sort_order: 160, policy_required: false, available_fields: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'] },
-  { module: 'core', router: 'addresses', action: 'import', label: 'Import Addresses', description: 'Import address records from spreadsheet', sort_order: 161, policy_required: false },
-  { module: 'core', router: 'addresses', action: 'export', label: 'Export Addresses', description: 'Export address records to spreadsheet', sort_order: 162, policy_required: false },
   { module: 'core', router: 'phone-numbers', action: null, label: 'Phone Numbers', description: 'Phone numbers linked to entities', sort_order: 170, policy_required: false, available_fields: ['phone_type', 'phone_number', 'is_primary'] },
-  { module: 'core', router: 'phone-numbers', action: 'import', label: 'Import Phone Numbers', description: 'Import phone number records from spreadsheet', sort_order: 171, policy_required: false },
-  { module: 'core', router: 'phone-numbers', action: 'export', label: 'Export Phone Numbers', description: 'Export phone number records to spreadsheet', sort_order: 172, policy_required: false },
   { module: 'core', router: 'tax-identifiers', action: null, label: 'Tax Identifiers', description: 'Tax IDs linked to entities via sources', sort_order: 175, policy_required: false, available_fields: ['country_code', 'tax_type', 'tax_value'] },
-  { module: 'core', router: 'tax-identifiers', action: 'import', label: 'Import Tax Identifiers', description: 'Import tax identifier records from spreadsheet', sort_order: 176, policy_required: false },
-  { module: 'core', router: 'tax-identifiers', action: 'export', label: 'Export Tax Identifiers', description: 'Export tax identifier records to spreadsheet', sort_order: 177, policy_required: false },
   { module: 'core', router: 'emails', action: null, label: 'Emails', description: 'Emails linked to entities via sources', sort_order: 178, policy_required: false, available_fields: ['email', 'label', 'is_primary', 'is_login'] },
-  { module: 'core', router: 'emails', action: 'import', label: 'Import Emails', description: 'Import email records from spreadsheet', sort_order: 179, policy_required: false },
-  { module: 'core', router: 'emails', action: 'export', label: 'Export Emails', description: 'Export email records to spreadsheet', sort_order: 180, policy_required: false },
   { module: 'core', router: 'vendor-contacts', action: null, label: 'Vendor Contacts', description: 'Individual contacts associated with vendors', sort_order: 183, policy_required: false, available_fields: ['first_name', 'last_name', 'position', 'department', 'is_app_user', 'roles'] },
   { module: 'core', router: 'vendor-contacts', action: 'import', label: 'Import Vendor Contacts', description: 'Import vendor contact records from spreadsheet', sort_order: 184, policy_required: false },
-  { module: 'core', router: 'vendor-contacts', action: 'export', label: 'Export Vendor Contacts', description: 'Export vendor contact records to spreadsheet', sort_order: 185, policy_required: false },
+  { module: 'core', router: 'vendor-contacts', action: 'export', label: 'Export Vendor Contacts', description: 'Export vendor contact records to spreadsheet', sort_order: 185 },
   { module: 'core', router: 'vendor-contacts', action: 'reset-password', label: 'Reset Password', description: 'Reset password for a vendor-contact app-user', sort_order: 186 },
   { module: 'core', router: 'companies', action: null, label: 'Companies', description: 'Company entities for intercompany accounting', sort_order: 186, available_fields: ['code', 'name', 'is_active'] },
   { module: 'core', router: 'companies', action: 'import', label: 'Import Companies', description: 'Import company records from spreadsheet', sort_order: 187, policy_required: false },
-  { module: 'core', router: 'companies', action: 'export', label: 'Export Companies', description: 'Export company records to spreadsheet', sort_order: 188, policy_required: false },
+  { module: 'core', router: 'companies', action: 'export', label: 'Export Companies', description: 'Export company records to spreadsheet', sort_order: 188 },
   { module: 'core', router: 'payment-terms', action: null, label: 'Payment Terms', description: 'Standardised vendor payment terms', sort_order: 189, available_fields: ['label', 'term', 'units', 'is_active'] },
+  // roles, policies, state-filters, field-group-*, policy-catalog:
+  // UI-managed config — spreadsheet I/O disabled at the router level.
   { module: 'core', router: 'roles', action: null, label: 'Roles', description: 'RBAC role definitions', sort_order: 190, available_fields: ['code', 'name', 'description', 'is_system', 'is_immutable', 'scope'] },
-  { module: 'core', router: 'roles', action: 'import', label: 'Import Roles', description: 'Import role definitions from spreadsheet', sort_order: 191, policy_required: false },
-  { module: 'core', router: 'roles', action: 'export', label: 'Export Roles', description: 'Export role definitions to spreadsheet', sort_order: 192, policy_required: false },
   { module: 'core', router: 'policies', action: null, label: 'Policies', description: 'Permission grants per role', sort_order: 200, policy_required: false, available_fields: ['role_id', 'module', 'router', 'action', 'level'] },
-  { module: 'core', router: 'policies', action: 'import', label: 'Import Policies', description: 'Import policy grants from spreadsheet', sort_order: 201, policy_required: false },
-  { module: 'core', router: 'policies', action: 'export', label: 'Export Policies', description: 'Export policy grants to spreadsheet', sort_order: 202, policy_required: false },
   { module: 'core', router: 'policy-catalog', action: null, label: 'Policy Catalog', description: 'Read-only permission discovery catalog', sort_order: 210, policy_required: false },
-  { module: 'core', router: 'policy-catalog', action: 'export', label: 'Export Policy Catalog', description: 'Export policy catalog to spreadsheet', sort_order: 212, policy_required: false },
   { module: 'core', router: 'state-filters', action: null, label: 'State Filters', description: 'Layer 3 status visibility filters', sort_order: 220, available_fields: ['role_id', 'module', 'router', 'visible_statuses'] },
-  { module: 'core', router: 'state-filters', action: 'import', label: 'Import State Filters', description: 'Import state filter records from spreadsheet', sort_order: 221, policy_required: false },
-  { module: 'core', router: 'state-filters', action: 'export', label: 'Export State Filters', description: 'Export state filter records to spreadsheet', sort_order: 222, policy_required: false },
   { module: 'core', router: 'field-group-definitions', action: null, label: 'Field Group Definitions', description: 'Layer 4 named column groups', sort_order: 230, available_fields: ['module', 'router', 'group_name', 'columns', 'is_default'] },
-  { module: 'core', router: 'field-group-definitions', action: 'import', label: 'Import Field Group Definitions', description: 'Import field group definitions from spreadsheet', sort_order: 231, policy_required: false },
-  { module: 'core', router: 'field-group-definitions', action: 'export', label: 'Export Field Group Definitions', description: 'Export field group definitions to spreadsheet', sort_order: 232, policy_required: false },
   { module: 'core', router: 'field-group-grants', action: null, label: 'Field Group Grants', description: 'Layer 4 field group assignments to roles', sort_order: 240, available_fields: ['role_id', 'field_group_id'] },
-  { module: 'core', router: 'field-group-grants', action: 'import', label: 'Import Field Group Grants', description: 'Import field group grants from spreadsheet', sort_order: 241, policy_required: false },
-  { module: 'core', router: 'field-group-grants', action: 'export', label: 'Export Field Group Grants', description: 'Export field group grants to spreadsheet', sort_order: 242, policy_required: false },
   { module: 'core', router: 'project-members', action: null, label: 'Project Members', description: 'Layer 2 user-to-project assignments', sort_order: 250, available_fields: ['project_id', 'user_id', 'role'] },
   { module: 'core', router: 'project-members', action: 'import', label: 'Import Project Members', description: 'Import project member records from spreadsheet', sort_order: 251, policy_required: false },
-  { module: 'core', router: 'project-members', action: 'export', label: 'Export Project Members', description: 'Export project member records to spreadsheet', sort_order: 252, policy_required: false },
+  { module: 'core', router: 'project-members', action: 'export', label: 'Export Project Members', description: 'Export project member records to spreadsheet', sort_order: 252 },
   { module: 'core', router: 'company-members', action: null, label: 'Company Members', description: 'Layer 2 user-to-company assignments', sort_order: 260, available_fields: ['company_id', 'user_id'] },
   { module: 'core', router: 'company-members', action: 'import', label: 'Import Company Members', description: 'Import company member records from spreadsheet', sort_order: 261, policy_required: false },
-  { module: 'core', router: 'company-members', action: 'export', label: 'Export Company Members', description: 'Export company member records to spreadsheet', sort_order: 262, policy_required: false },
+  { module: 'core', router: 'company-members', action: 'export', label: 'Export Company Members', description: 'Export company member records to spreadsheet', sort_order: 262 },
   { module: 'core', router: 'numbering-config', action: null, label: 'Numbering Config', description: 'Auto-numbering format configuration per entity type', sort_order: 270 },
   { module: 'core', router: 'tenant-preferences', action: null, label: 'Tenant Preferences', description: 'Tenant-level UI preferences (e.g. default page size)', sort_order: 280 },
 
@@ -96,135 +94,125 @@ export const CATALOG_ENTRIES = [
   { module: 'projects', router: null, action: null, label: 'Projects Module', description: 'Project structure, tasks, cost items, and templates', sort_order: 300 },
   { module: 'projects', router: 'projects', action: null, label: 'Projects', description: 'Project header records', sort_order: 310, valid_statuses: ['planning', 'budgeting', 'released', 'on_hold', 'complete'], available_fields: ['company_id', 'address_id', 'project_code', 'name', 'description', 'notes', 'status', 'contract_amount'] },
   { module: 'projects', router: 'projects', action: 'import', label: 'Import Projects', description: 'Import project records from spreadsheet', sort_order: 311, policy_required: false },
-  { module: 'projects', router: 'projects', action: 'export', label: 'Export Projects', description: 'Export project records to spreadsheet', sort_order: 312, policy_required: false },
+  { module: 'projects', router: 'projects', action: 'export', label: 'Export Projects', description: 'Export project records to spreadsheet', sort_order: 312 },
   { module: 'projects', router: 'project-clients', action: null, label: 'Project Clients', description: 'Client assignments per project', sort_order: 320, policy_required: false, available_fields: ['project_id', 'client_id', 'role'] },
   { module: 'projects', router: 'project-clients', action: 'import', label: 'Import Project Clients', description: 'Import project client assignments from spreadsheet', sort_order: 321, policy_required: false },
-  { module: 'projects', router: 'project-clients', action: 'export', label: 'Export Project Clients', description: 'Export project client assignments to spreadsheet', sort_order: 322, policy_required: false },
+  { module: 'projects', router: 'project-clients', action: 'export', label: 'Export Project Clients', description: 'Export project client assignments to spreadsheet', sort_order: 322 },
   { module: 'projects', router: 'units', action: null, label: 'Units', description: 'Project units / phases', sort_order: 330, valid_statuses: ['draft', 'released', 'complete'], available_fields: ['project_id', 'template_unit_id', 'version_used', 'name', 'unit_code', 'status'] },
   { module: 'projects', router: 'units', action: 'import', label: 'Import Units', description: 'Import unit records from spreadsheet', sort_order: 331, policy_required: false },
-  { module: 'projects', router: 'units', action: 'export', label: 'Export Units', description: 'Export unit records to spreadsheet', sort_order: 332, policy_required: false },
+  { module: 'projects', router: 'units', action: 'export', label: 'Export Units', description: 'Export unit records to spreadsheet', sort_order: 332 },
   { module: 'projects', router: 'task-groups', action: null, label: 'Task Groups', description: 'Task grouping containers', sort_order: 340, available_fields: ['code', 'name', 'description', 'sort_order'] },
   { module: 'projects', router: 'task-groups', action: 'import', label: 'Import Task Groups', description: 'Import task group records from spreadsheet', sort_order: 341, policy_required: false },
-  { module: 'projects', router: 'task-groups', action: 'export', label: 'Export Task Groups', description: 'Export task group records to spreadsheet', sort_order: 342, policy_required: false },
+  { module: 'projects', router: 'task-groups', action: 'export', label: 'Export Task Groups', description: 'Export task group records to spreadsheet', sort_order: 342 },
   { module: 'projects', router: 'tasks-master', action: null, label: 'Tasks Master', description: 'Master task definitions', sort_order: 350, available_fields: ['code', 'task_group_code', 'name', 'default_duration_days'] },
   { module: 'projects', router: 'tasks-master', action: 'import', label: 'Import Tasks Master', description: 'Import master task definitions from spreadsheet', sort_order: 351, policy_required: false },
-  { module: 'projects', router: 'tasks-master', action: 'export', label: 'Export Tasks Master', description: 'Export master task definitions to spreadsheet', sort_order: 352, policy_required: false },
+  { module: 'projects', router: 'tasks-master', action: 'export', label: 'Export Tasks Master', description: 'Export master task definitions to spreadsheet', sort_order: 352 },
   { module: 'projects', router: 'tasks', action: null, label: 'Tasks', description: 'Project tasks', sort_order: 360, valid_statuses: ['pending', 'in_progress', 'complete', 'on_hold'], available_fields: ['unit_id', 'task_code', 'name', 'duration_days', 'status', 'parent_task_id'] },
   { module: 'projects', router: 'tasks', action: 'import', label: 'Import Tasks', description: 'Import task records from spreadsheet', sort_order: 361, policy_required: false },
-  { module: 'projects', router: 'tasks', action: 'export', label: 'Export Tasks', description: 'Export task records to spreadsheet', sort_order: 362, policy_required: false },
+  { module: 'projects', router: 'tasks', action: 'export', label: 'Export Tasks', description: 'Export task records to spreadsheet', sort_order: 362 },
+  // cost-items: line/sub-record of tasks — spreadsheet I/O disabled.
   { module: 'projects', router: 'cost-items', action: null, label: 'Cost Items', description: 'Budget line items per task', sort_order: 370, policy_required: false, available_fields: ['task_id', 'item_code', 'description', 'cost_class', 'cost_source', 'quantity', 'unit_cost'] },
-  { module: 'projects', router: 'cost-items', action: 'import', label: 'Import Cost Items', description: 'Import cost item records from spreadsheet', sort_order: 371, policy_required: false },
-  { module: 'projects', router: 'cost-items', action: 'export', label: 'Export Cost Items', description: 'Export cost item records to spreadsheet', sort_order: 372, policy_required: false },
   { module: 'projects', router: 'change-orders', action: null, label: 'Change Orders', description: 'Scope and cost change orders', sort_order: 380, valid_statuses: ['draft', 'submitted', 'approved', 'rejected'], available_fields: ['unit_id', 'co_number', 'title', 'reason', 'status', 'total_amount'] },
   { module: 'projects', router: 'change-orders', action: 'import', label: 'Import Change Orders', description: 'Import change order records from spreadsheet', sort_order: 381, policy_required: false },
-  { module: 'projects', router: 'change-orders', action: 'export', label: 'Export Change Orders', description: 'Export change order records to spreadsheet', sort_order: 382, policy_required: false },
+  { module: 'projects', router: 'change-orders', action: 'export', label: 'Export Change Orders', description: 'Export change order records to spreadsheet', sort_order: 382 },
+  // template-* tables: blueprints managed in UI; imported with parent.
+  // Spreadsheet I/O disabled at router level.
   { module: 'projects', router: 'template-units', action: null, label: 'Template Units', description: 'Reusable unit blueprints', sort_order: 390, valid_statuses: ['draft', 'active'], available_fields: ['name', 'version', 'status'] },
-  { module: 'projects', router: 'template-units', action: 'import', label: 'Import Template Units', description: 'Import template unit records from spreadsheet', sort_order: 391, policy_required: false },
-  { module: 'projects', router: 'template-units', action: 'export', label: 'Export Template Units', description: 'Export template unit records to spreadsheet', sort_order: 392, policy_required: false },
   { module: 'projects', router: 'template-tasks', action: null, label: 'Template Tasks', description: 'Reusable task blueprints', sort_order: 400, policy_required: false, available_fields: ['template_unit_id', 'task_code', 'name', 'duration_days', 'parent_code'] },
-  { module: 'projects', router: 'template-tasks', action: 'import', label: 'Import Template Tasks', description: 'Import template task records from spreadsheet', sort_order: 401, policy_required: false },
-  { module: 'projects', router: 'template-tasks', action: 'export', label: 'Export Template Tasks', description: 'Export template task records to spreadsheet', sort_order: 402, policy_required: false },
   { module: 'projects', router: 'template-cost-items', action: null, label: 'Template Cost Items', description: 'Reusable cost item blueprints', sort_order: 410, policy_required: false, available_fields: ['template_task_id', 'item_code', 'description', 'cost_class', 'cost_source', 'quantity', 'unit_cost'] },
-  { module: 'projects', router: 'template-cost-items', action: 'import', label: 'Import Template Cost Items', description: 'Import template cost item records from spreadsheet', sort_order: 411, policy_required: false },
-  { module: 'projects', router: 'template-cost-items', action: 'export', label: 'Export Template Cost Items', description: 'Export template cost item records to spreadsheet', sort_order: 412, policy_required: false },
   { module: 'projects', router: 'template-change-orders', action: null, label: 'Template Change Orders', description: 'Reusable change order blueprints', sort_order: 420, policy_required: false, available_fields: ['template_unit_id', 'co_number', 'title', 'reason', 'total_amount'] },
-  { module: 'projects', router: 'template-change-orders', action: 'import', label: 'Import Template Change Orders', description: 'Import template change order records from spreadsheet', sort_order: 421, policy_required: false },
-  { module: 'projects', router: 'template-change-orders', action: 'export', label: 'Export Template Change Orders', description: 'Export template change order records to spreadsheet', sort_order: 422, policy_required: false },
 
   // ── Activities ──────────────────────────────────────────────────
   { module: 'activities', router: null, action: null, label: 'Activities Module', description: 'Categories, deliverables, budgets, and cost tracking', sort_order: 500 },
   { module: 'activities', router: 'categories', action: null, label: 'Categories', description: 'Activity cost categories', sort_order: 510, available_fields: ['code', 'name', 'type'] },
   { module: 'activities', router: 'categories', action: 'import', label: 'Import Categories', description: 'Import category records from spreadsheet', sort_order: 511, policy_required: false },
-  { module: 'activities', router: 'categories', action: 'export', label: 'Export Categories', description: 'Export category records to spreadsheet', sort_order: 512, policy_required: false },
+  { module: 'activities', router: 'categories', action: 'export', label: 'Export Categories', description: 'Export category records to spreadsheet', sort_order: 512 },
   { module: 'activities', router: 'activities', action: null, label: 'Activities', description: 'Activity records', sort_order: 520, available_fields: ['category_id', 'code', 'name', 'is_active'] },
   { module: 'activities', router: 'activities', action: 'import', label: 'Import Activities', description: 'Import activity records from spreadsheet', sort_order: 521, policy_required: false },
-  { module: 'activities', router: 'activities', action: 'export', label: 'Export Activities', description: 'Export activity records to spreadsheet', sort_order: 522, policy_required: false },
+  { module: 'activities', router: 'activities', action: 'export', label: 'Export Activities', description: 'Export activity records to spreadsheet', sort_order: 522 },
   { module: 'activities', router: 'deliverables', action: null, label: 'Deliverables', description: 'Project deliverables', sort_order: 530, valid_statuses: ['pending', 'released', 'finished', 'canceled'], available_fields: ['name', 'description', 'status', 'start_date', 'end_date'] },
   { module: 'activities', router: 'deliverables', action: 'import', label: 'Import Deliverables', description: 'Import deliverable records from spreadsheet', sort_order: 531, policy_required: false },
-  { module: 'activities', router: 'deliverables', action: 'export', label: 'Export Deliverables', description: 'Export deliverable records to spreadsheet', sort_order: 532, policy_required: false },
+  { module: 'activities', router: 'deliverables', action: 'export', label: 'Export Deliverables', description: 'Export deliverable records to spreadsheet', sort_order: 532 },
+  // deliverable-assignments: line/sub-record — spreadsheet I/O disabled.
   { module: 'activities', router: 'deliverable-assignments', action: null, label: 'Deliverable Assignments', description: 'Employee assignments to deliverables', sort_order: 540, policy_required: false, available_fields: ['deliverable_id', 'project_id', 'employee_id', 'notes'] },
-  { module: 'activities', router: 'deliverable-assignments', action: 'import', label: 'Import Deliverable Assignments', description: 'Import deliverable assignment records from spreadsheet', sort_order: 541, policy_required: false },
-  { module: 'activities', router: 'deliverable-assignments', action: 'export', label: 'Export Deliverable Assignments', description: 'Export deliverable assignment records to spreadsheet', sort_order: 542, policy_required: false },
   { module: 'activities', router: 'budgets', action: null, label: 'Budgets', description: 'Deliverable-activity budget allocations', sort_order: 550, valid_statuses: ['draft', 'submitted', 'approved', 'locked', 'rejected'], available_fields: ['deliverable_id', 'activity_id', 'budgeted_amount', 'version', 'is_current', 'status', 'submitted_by', 'submitted_at', 'approved_by', 'approved_at'] },
   { module: 'activities', router: 'budgets', action: 'import', label: 'Import Budgets', description: 'Import budget records from spreadsheet', sort_order: 551, policy_required: false },
-  { module: 'activities', router: 'budgets', action: 'export', label: 'Export Budgets', description: 'Export budget records to spreadsheet', sort_order: 552, policy_required: false },
+  { module: 'activities', router: 'budgets', action: 'export', label: 'Export Budgets', description: 'Export budget records to spreadsheet', sort_order: 552 },
   { module: 'activities', router: 'cost-lines', action: null, label: 'Cost Lines', description: 'Individual cost entries per deliverable', sort_order: 560, valid_statuses: ['draft', 'submitted', 'approved', 'change_order'], available_fields: ['company_id', 'deliverable_id', 'vendor_id', 'activity_id', 'budget_id', 'tenant_sku', 'source_type', 'quantity', 'unit_price', 'markup_pct', 'status'] },
   { module: 'activities', router: 'cost-lines', action: 'import', label: 'Import Cost Lines', description: 'Import cost line records from spreadsheet', sort_order: 561, policy_required: false },
-  { module: 'activities', router: 'cost-lines', action: 'export', label: 'Export Cost Lines', description: 'Export cost line records to spreadsheet', sort_order: 562, policy_required: false },
+  { module: 'activities', router: 'cost-lines', action: 'export', label: 'Export Cost Lines', description: 'Export cost line records to spreadsheet', sort_order: 562 },
   { module: 'activities', router: 'actual-costs', action: null, label: 'Actual Costs', description: 'Confirmed expenditures', sort_order: 570, valid_statuses: ['pending', 'approved', 'rejected'], available_fields: ['activity_id', 'project_id', 'amount', 'currency', 'reference', 'approval_status', 'incurred_on'] },
   { module: 'activities', router: 'actual-costs', action: 'import', label: 'Import Actual Costs', description: 'Import actual cost records from spreadsheet', sort_order: 571, policy_required: false },
-  { module: 'activities', router: 'actual-costs', action: 'export', label: 'Export Actual Costs', description: 'Export actual cost records to spreadsheet', sort_order: 572, policy_required: false },
+  { module: 'activities', router: 'actual-costs', action: 'export', label: 'Export Actual Costs', description: 'Export actual cost records to spreadsheet', sort_order: 572 },
   { module: 'activities', router: 'vendor-parts', action: null, label: 'Vendor Parts', description: 'Vendor SKU links to cost lines', sort_order: 580, available_fields: ['vendor_id', 'vendor_sku', 'tenant_sku', 'unit_cost', 'currency', 'markup_pct', 'is_active'] },
   { module: 'activities', router: 'vendor-parts', action: 'import', label: 'Import Vendor Parts', description: 'Import vendor part records from spreadsheet', sort_order: 581, policy_required: false },
-  { module: 'activities', router: 'vendor-parts', action: 'export', label: 'Export Vendor Parts', description: 'Export vendor part records to spreadsheet', sort_order: 582, policy_required: false },
+  { module: 'activities', router: 'vendor-parts', action: 'export', label: 'Export Vendor Parts', description: 'Export vendor part records to spreadsheet', sort_order: 582 },
 
   // ── BOM ─────────────────────────────────────────────────────────
   { module: 'bom', router: null, action: null, label: 'BOM Module', description: 'Bill of Materials — SKU catalog and vendor pricing', sort_order: 600 },
   { module: 'bom', router: 'catalog-skus', action: null, label: 'Catalog SKUs', description: 'Internal product catalog', sort_order: 610, available_fields: ['catalog_sku', 'description', 'description_normalized', 'category', 'sub_category', 'model'] },
   { module: 'bom', router: 'catalog-skus', action: 'import', label: 'Import Catalog SKUs', description: 'Import catalog SKU records from spreadsheet', sort_order: 611, policy_required: false },
-  { module: 'bom', router: 'catalog-skus', action: 'export', label: 'Export Catalog SKUs', description: 'Export catalog SKU records to spreadsheet', sort_order: 612, policy_required: false },
+  { module: 'bom', router: 'catalog-skus', action: 'export', label: 'Export Catalog SKUs', description: 'Export catalog SKU records to spreadsheet', sort_order: 612 },
   { module: 'bom', router: 'vendor-skus', action: null, label: 'Vendor SKUs', description: 'Vendor-submitted SKU descriptions with embeddings', sort_order: 620, available_fields: ['vendor_id', 'vendor_sku', 'description', 'description_normalized', 'catalog_sku_id', 'confidence', 'model'] },
   { module: 'bom', router: 'vendor-skus', action: 'import', label: 'Import Vendor SKUs', description: 'Import vendor SKU records from spreadsheet', sort_order: 621, policy_required: false },
-  { module: 'bom', router: 'vendor-skus', action: 'export', label: 'Export Vendor SKUs', description: 'Export vendor SKU records to spreadsheet', sort_order: 622, policy_required: false },
+  { module: 'bom', router: 'vendor-skus', action: 'export', label: 'Export Vendor SKUs', description: 'Export vendor SKU records to spreadsheet', sort_order: 622 },
   { module: 'bom', router: 'vendor-pricing', action: null, label: 'Vendor Pricing', description: 'Price history per vendor SKU', sort_order: 630, policy_required: false, available_fields: ['vendor_sku_id', 'unit_price', 'unit', 'effective_date'] },
   { module: 'bom', router: 'vendor-pricing', action: 'import', label: 'Import Vendor Pricing', description: 'Import vendor pricing records from spreadsheet', sort_order: 631, policy_required: false },
-  { module: 'bom', router: 'vendor-pricing', action: 'export', label: 'Export Vendor Pricing', description: 'Export vendor pricing records to spreadsheet', sort_order: 632, policy_required: false },
+  { module: 'bom', router: 'vendor-pricing', action: 'export', label: 'Export Vendor Pricing', description: 'Export vendor pricing records to spreadsheet', sort_order: 632 },
 
   // ── AP ──────────────────────────────────────────────────────────
   { module: 'ap', router: null, action: null, label: 'AP Module', description: 'Accounts payable — vendor invoices and payments', sort_order: 700 },
   { module: 'ap', router: 'ap-invoices', action: null, label: 'AP Invoices', description: 'Vendor invoices', sort_order: 710, valid_statuses: ['open', 'approved', 'paid', 'voided'], available_fields: ['company_id', 'vendor_id', 'project_id', 'invoice_number', 'invoice_date', 'due_date', 'total_amount', 'currency', 'status', 'notes'] },
   { module: 'ap', router: 'ap-invoices', action: 'import', label: 'Import AP Invoices', description: 'Import AP invoice records from spreadsheet', sort_order: 711, policy_required: false },
-  { module: 'ap', router: 'ap-invoices', action: 'export', label: 'Export AP Invoices', description: 'Export AP invoice records to spreadsheet', sort_order: 712, policy_required: false },
+  { module: 'ap', router: 'ap-invoices', action: 'export', label: 'Export AP Invoices', description: 'Export AP invoice records to spreadsheet', sort_order: 712 },
+  // ap-invoice-lines: line/sub-record — spreadsheet I/O disabled.
   { module: 'ap', router: 'ap-invoice-lines', action: null, label: 'AP Invoice Lines', description: 'Line items on vendor invoices', sort_order: 720, policy_required: false, available_fields: ['invoice_id', 'description', 'amount', 'account_id', 'cost_line_id', 'activity_id'] },
-  { module: 'ap', router: 'ap-invoice-lines', action: 'import', label: 'Import AP Invoice Lines', description: 'Import AP invoice line records from spreadsheet', sort_order: 721, policy_required: false },
-  { module: 'ap', router: 'ap-invoice-lines', action: 'export', label: 'Export AP Invoice Lines', description: 'Export AP invoice line records to spreadsheet', sort_order: 722, policy_required: false },
   { module: 'ap', router: 'payments', action: null, label: 'Payments', description: 'Vendor payments', sort_order: 730, available_fields: ['vendor_id', 'ap_invoice_id', 'payment_date', 'amount', 'method', 'reference', 'notes'] },
   { module: 'ap', router: 'payments', action: 'import', label: 'Import Payments', description: 'Import payment records from spreadsheet', sort_order: 731, policy_required: false },
-  { module: 'ap', router: 'payments', action: 'export', label: 'Export Payments', description: 'Export payment records to spreadsheet', sort_order: 732, policy_required: false },
+  { module: 'ap', router: 'payments', action: 'export', label: 'Export Payments', description: 'Export payment records to spreadsheet', sort_order: 732 },
   { module: 'ap', router: 'ap-credit-memos', action: null, label: 'AP Credit Memos', description: 'Vendor credit memos', sort_order: 740, valid_statuses: ['open', 'applied', 'voided'], available_fields: ['vendor_id', 'ap_invoice_id', 'credit_number', 'credit_date', 'amount', 'reason', 'status'] },
   { module: 'ap', router: 'ap-credit-memos', action: 'import', label: 'Import AP Credit Memos', description: 'Import AP credit memo records from spreadsheet', sort_order: 741, policy_required: false },
-  { module: 'ap', router: 'ap-credit-memos', action: 'export', label: 'Export AP Credit Memos', description: 'Export AP credit memo records to spreadsheet', sort_order: 742, policy_required: false },
+  { module: 'ap', router: 'ap-credit-memos', action: 'export', label: 'Export AP Credit Memos', description: 'Export AP credit memo records to spreadsheet', sort_order: 742 },
 
   // ── AR ──────────────────────────────────────────────────────────
   { module: 'ar', router: null, action: null, label: 'AR Module', description: 'Accounts receivable — client invoices and receipts', sort_order: 800 },
   { module: 'ar', router: 'ar-invoices', action: null, label: 'AR Invoices', description: 'Client invoices', sort_order: 810, valid_statuses: ['open', 'sent', 'paid', 'voided'], available_fields: ['company_id', 'client_id', 'project_id', 'deliverable_id', 'invoice_number', 'invoice_date', 'due_date', 'total_amount', 'currency', 'status', 'notes'] },
   { module: 'ar', router: 'ar-invoices', action: 'import', label: 'Import AR Invoices', description: 'Import AR invoice records from spreadsheet', sort_order: 811, policy_required: false },
-  { module: 'ar', router: 'ar-invoices', action: 'export', label: 'Export AR Invoices', description: 'Export AR invoice records to spreadsheet', sort_order: 812, policy_required: false },
+  { module: 'ar', router: 'ar-invoices', action: 'export', label: 'Export AR Invoices', description: 'Export AR invoice records to spreadsheet', sort_order: 812 },
+  // ar-invoice-lines: line/sub-record — spreadsheet I/O disabled.
   { module: 'ar', router: 'ar-invoice-lines', action: null, label: 'AR Invoice Lines', description: 'Line items on client invoices', sort_order: 820, policy_required: false, available_fields: ['invoice_id', 'description', 'amount', 'account_id'] },
-  { module: 'ar', router: 'ar-invoice-lines', action: 'import', label: 'Import AR Invoice Lines', description: 'Import AR invoice line records from spreadsheet', sort_order: 821, policy_required: false },
-  { module: 'ar', router: 'ar-invoice-lines', action: 'export', label: 'Export AR Invoice Lines', description: 'Export AR invoice line records to spreadsheet', sort_order: 822, policy_required: false },
   { module: 'ar', router: 'receipts', action: null, label: 'Receipts', description: 'Client payment receipts', sort_order: 830, available_fields: ['client_id', 'ar_invoice_id', 'receipt_date', 'amount', 'method', 'reference', 'notes'] },
   { module: 'ar', router: 'receipts', action: 'import', label: 'Import Receipts', description: 'Import receipt records from spreadsheet', sort_order: 831, policy_required: false },
-  { module: 'ar', router: 'receipts', action: 'export', label: 'Export Receipts', description: 'Export receipt records to spreadsheet', sort_order: 832, policy_required: false },
+  { module: 'ar', router: 'receipts', action: 'export', label: 'Export Receipts', description: 'Export receipt records to spreadsheet', sort_order: 832 },
 
   // ── Accounting ──────────────────────────────────────────────────
   { module: 'accounting', router: null, action: null, label: 'Accounting Module', description: 'General ledger, journal entries, and intercompany accounting', sort_order: 900 },
   { module: 'accounting', router: 'chart-of-accounts', action: null, label: 'Chart of Accounts', description: 'GL account definitions', sort_order: 910, available_fields: ['code', 'name', 'type', 'is_active', 'cash_basis', 'bank_account_number', 'routing_number', 'bank_name'] },
   { module: 'accounting', router: 'chart-of-accounts', action: 'import', label: 'Import Chart of Accounts', description: 'Import GL account records from spreadsheet', sort_order: 911, policy_required: false },
-  { module: 'accounting', router: 'chart-of-accounts', action: 'export', label: 'Export Chart of Accounts', description: 'Export GL account records to spreadsheet', sort_order: 912, policy_required: false },
+  { module: 'accounting', router: 'chart-of-accounts', action: 'export', label: 'Export Chart of Accounts', description: 'Export GL account records to spreadsheet', sort_order: 912 },
   { module: 'accounting', router: 'journal-entries', action: null, label: 'Journal Entries', description: 'Double-entry journal headers', sort_order: 920, valid_statuses: ['pending', 'posted', 'reversed'], available_fields: ['company_id', 'project_id', 'entry_date', 'description', 'status', 'source_type', 'corrects_id'] },
   { module: 'accounting', router: 'journal-entries', action: 'import', label: 'Import Journal Entries', description: 'Import journal entry records from spreadsheet', sort_order: 921, policy_required: false },
-  { module: 'accounting', router: 'journal-entries', action: 'export', label: 'Export Journal Entries', description: 'Export journal entry records to spreadsheet', sort_order: 922, policy_required: false },
+  { module: 'accounting', router: 'journal-entries', action: 'export', label: 'Export Journal Entries', description: 'Export journal entry records to spreadsheet', sort_order: 922 },
+  // journal-entry-lines: line/sub-record — bypasses balanced-entry
+  // validation if imported standalone. Spreadsheet I/O disabled.
   { module: 'accounting', router: 'journal-entry-lines', action: null, label: 'Journal Entry Lines', description: 'Debit/credit lines per journal entry', sort_order: 930, policy_required: false, available_fields: ['entry_id', 'account_id', 'debit', 'credit', 'memo', 'related_table', 'related_id'] },
-  { module: 'accounting', router: 'journal-entry-lines', action: 'import', label: 'Import Journal Entry Lines', description: 'Import journal entry line records from spreadsheet', sort_order: 931, policy_required: false },
-  { module: 'accounting', router: 'journal-entry-lines', action: 'export', label: 'Export Journal Entry Lines', description: 'Export journal entry line records to spreadsheet', sort_order: 932, policy_required: false },
   { module: 'accounting', router: 'ledger-balances', action: null, label: 'Ledger Balances', description: 'Period-end account balances', sort_order: 940, available_fields: ['account_id', 'as_of_date', 'balance'] },
-  { module: 'accounting', router: 'ledger-balances', action: 'export', label: 'Export Ledger Balances', description: 'Export ledger balance records to spreadsheet', sort_order: 942, policy_required: false },
+  { module: 'accounting', router: 'ledger-balances', action: 'export', label: 'Export Ledger Balances', description: 'Export ledger balance records to spreadsheet', sort_order: 942 },
   { module: 'accounting', router: 'posting-queues', action: null, label: 'Posting Queues', description: 'Async journal entry posting queue', sort_order: 950, valid_statuses: ['pending', 'posted', 'failed'], available_fields: ['journal_entry_id', 'status', 'error_message', 'processed_at'] },
   { module: 'accounting', router: 'posting-queues', action: 'import', label: 'Import Posting Queues', description: 'Import posting queue records from spreadsheet', sort_order: 951, policy_required: false },
-  { module: 'accounting', router: 'posting-queues', action: 'export', label: 'Export Posting Queues', description: 'Export posting queue records to spreadsheet', sort_order: 952, policy_required: false },
+  { module: 'accounting', router: 'posting-queues', action: 'export', label: 'Export Posting Queues', description: 'Export posting queue records to spreadsheet', sort_order: 952 },
   { module: 'accounting', router: 'category-account-map', action: null, label: 'Category Account Map', description: 'Maps cost categories to GL accounts', sort_order: 960, available_fields: ['category_id', 'account_id', 'valid_from', 'valid_to'] },
   { module: 'accounting', router: 'category-account-map', action: 'import', label: 'Import Category Account Map', description: 'Import category-account mapping records from spreadsheet', sort_order: 961, policy_required: false },
-  { module: 'accounting', router: 'category-account-map', action: 'export', label: 'Export Category Account Map', description: 'Export category-account mapping records to spreadsheet', sort_order: 962, policy_required: false },
+  { module: 'accounting', router: 'category-account-map', action: 'export', label: 'Export Category Account Map', description: 'Export category-account mapping records to spreadsheet', sort_order: 962 },
   { module: 'accounting', router: 'company-accounts', action: null, label: 'Company Accounts', description: 'Due-to / due-from account pairs', sort_order: 970, available_fields: ['source_company_id', 'target_company_id', 'inter_company_account_id', 'is_active'] },
   { module: 'accounting', router: 'company-accounts', action: 'import', label: 'Import Company Accounts', description: 'Import company account records from spreadsheet', sort_order: 971, policy_required: false },
-  { module: 'accounting', router: 'company-accounts', action: 'export', label: 'Export Company Accounts', description: 'Export company account records to spreadsheet', sort_order: 972, policy_required: false },
+  { module: 'accounting', router: 'company-accounts', action: 'export', label: 'Export Company Accounts', description: 'Export company account records to spreadsheet', sort_order: 972 },
   { module: 'accounting', router: 'company-transactions', action: null, label: 'Company Transactions', description: 'Intercompany transaction records', sort_order: 980, valid_statuses: ['pending', 'posted', 'reversed'], available_fields: ['source_company_id', 'target_company_id', 'source_journal_entry_id', 'target_journal_entry_id', 'module', 'amount', 'status', 'is_eliminated', 'description'] },
   { module: 'accounting', router: 'company-transactions', action: 'import', label: 'Import Company Transactions', description: 'Import company transaction records from spreadsheet', sort_order: 981, policy_required: false },
-  { module: 'accounting', router: 'company-transactions', action: 'export', label: 'Export Company Transactions', description: 'Export company transaction records to spreadsheet', sort_order: 982, policy_required: false },
+  { module: 'accounting', router: 'company-transactions', action: 'export', label: 'Export Company Transactions', description: 'Export company transaction records to spreadsheet', sort_order: 982 },
   { module: 'accounting', router: 'internal-transfers', action: null, label: 'Internal Transfers', description: 'Cash transfers between company accounts', sort_order: 990, available_fields: ['from_account_id', 'to_account_id', 'transfer_date', 'amount', 'description'] },
   { module: 'accounting', router: 'internal-transfers', action: 'import', label: 'Import Internal Transfers', description: 'Import internal transfer records from spreadsheet', sort_order: 991, policy_required: false },
-  { module: 'accounting', router: 'internal-transfers', action: 'export', label: 'Export Internal Transfers', description: 'Export internal transfer records to spreadsheet', sort_order: 992, policy_required: false },
+  { module: 'accounting', router: 'internal-transfers', action: 'export', label: 'Export Internal Transfers', description: 'Export internal transfer records to spreadsheet', sort_order: 992 },
 
   // ── Reports ─────────────────────────────────────────────────────
   { module: 'reports', router: null, action: null, label: 'Reports Module', description: 'Profitability, cashflow, and aging reports', sort_order: 1000 },
@@ -238,21 +226,14 @@ export const CATALOG_ENTRIES = [
 
   // ── Tenants (Axerra admin scope) ───────────────────────────────
   // Tenants module routes are gated first by `requireRootTenant` (Axerra
-  // membership) and then by `rbac()`, so the action-level rows below are
-  // independently grantable in the role editor. Use them to compose
-  // finer-grained Axerra ops roles (e.g. read-only auditor with only
-  // view-level grants) on top of the wildcard super_user role.
-  // tenants::tenants exposes import/export per PRD §3.2.1.
-  // tenants::portal-users does NOT — users are created via /register, so
-  // portalUsersRouter sets disableImportXls/disableExportXls and there
-  // are no catalog rows for those actions (granting them would no-op).
-  // Import/export rows here are policy_required: true so finer-grained
-  // Axerra ops roles can deny them independently of CRUD via PolicyEditor
-  // (other modules' import/export rows use policy_required: false for
-  // historical reasons; aligning them is a separate PR).
+  // membership) and then by `rbac()`. tenants::tenants exposes
+  // import/export per PRD §3.2.1; tenants::portal-users does not
+  // (users are created via /register, so portalUsersRouter sets
+  // disableImportXls/disableExportXls and no catalog rows exist for
+  // those actions).
   { module: 'tenants', router: null, action: null, label: 'Tenants Module', description: 'Multi-tenant administration (Axerra only)', sort_order: 1100 },
   { module: 'tenants', router: 'tenants', action: null, label: 'Tenants', description: 'Tenant CRUD and provisioning', sort_order: 1110 },
-  { module: 'tenants', router: 'tenants', action: 'import', label: 'Import Tenants', description: 'Import tenant records from spreadsheet', sort_order: 1111 },
+  { module: 'tenants', router: 'tenants', action: 'import', label: 'Import Tenants', description: 'Import tenant records from spreadsheet', sort_order: 1111, policy_required: false },
   { module: 'tenants', router: 'tenants', action: 'export', label: 'Export Tenants', description: 'Export tenant records to spreadsheet', sort_order: 1112 },
   { module: 'tenants', router: 'portal-users', action: null, label: 'Portal Users', description: 'Application user accounts', sort_order: 1120 },
   { module: 'tenants', router: 'orphan-portal-users', action: null, label: 'Orphan Portal Users', description: 'Maintenance for portal_users with no tenant bindings (Axerra only)', sort_order: 1125 },

--- a/apps/server/src/system/core/services/systemRoleSeeder.js
+++ b/apps/server/src/system/core/services/systemRoleSeeder.js
@@ -37,6 +37,16 @@ const EXACT_MATCH_TENANT_SCOPED = EXACT_MATCH_POLICIES.filter((p) => p.module !=
 const EXACT_MATCH_ROOT_ONLY = EXACT_MATCH_POLICIES;
 
 /**
+ * Support role variant — same as root-only but with financial-module
+ * exact-match grants stripped. Required because rbac.resolveLevel()
+ * short-circuits the broader-grant fallback for exact-match keys, so
+ * an explicit `ap::ap-invoices::export = full` would override the
+ * module-level `ap = none` deny that defines the role's non-financial
+ * scope.
+ */
+const EXACT_MATCH_NON_FINANCIAL = EXACT_MATCH_POLICIES.filter((p) => !FINANCIAL_MODULES.includes(p.module));
+
+/**
  * System role definitions.
  * @param {boolean} isRootTenant Whether this is the Axerra platform tenant
  * @returns {Array<object>} Role definitions with their policies
@@ -115,7 +125,7 @@ function getSystemRoleDefinitions(isRootTenant) {
       scope: 'all_projects',
       policies: [
         { module: '', router: null, action: null, level: 'full' },
-        ...EXACT_MATCH_ROOT_ONLY,
+        ...EXACT_MATCH_NON_FINANCIAL,
         // Override financial modules to none
         ...FINANCIAL_MODULES.map((mod) => ({ module: mod, router: null, action: null, level: 'none' })),
       ],

--- a/apps/server/tests/contract/disabledImportExport.test.js
+++ b/apps/server/tests/contract/disabledImportExport.test.js
@@ -1,0 +1,94 @@
+/**
+ * @file Contract test: routers that should NOT auto-mount /import-xls or /export-xls
+ * @module tests/contract/disabledImportExport
+ *
+ * Several routers disable spreadsheet I/O because the resource doesn't
+ * make sense as a standalone import/export:
+ *   - sources-child tables (importing creates orphans)
+ *   - UI-managed config (roles, policies, state-filters, field-group-*)
+ *   - line/sub-record tables (invoice/journal-entry lines, cost items,
+ *     deliverable assignments) — should ride the parent's import
+ *   - blueprint tables (template-units, template-tasks, etc.)
+ *   - read-only registries (policy-catalog)
+ *
+ * This test locks the contract: hitting /import-xls or /export-xls on
+ * any of these routers returns 404 (route not registered) when the
+ * caller is otherwise authenticated and authorized.
+ *
+ * Authenticated request is required because authRedis runs before the
+ * route lookup — unauthenticated requests get 401, masking the 404.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+beforeAll(async () => {
+  await cleanupTestDb();
+  await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+const DISABLED_ROUTES = [
+  // sources-child
+  '/api/core/v1/sources',
+  '/api/core/v1/addresses',
+  '/api/core/v1/phone-numbers',
+  '/api/core/v1/emails',
+  '/api/core/v1/tax-identifiers',
+  // UI-managed config
+  '/api/core/v1/roles',
+  '/api/core/v1/policies',
+  '/api/core/v1/state-filters',
+  '/api/core/v1/field-group-definitions',
+  '/api/core/v1/field-group-grants',
+  '/api/core/v1/policy-catalog',
+  // line/sub-record + blueprints
+  '/api/projects/v1/cost-items',
+  '/api/projects/v1/template-units',
+  '/api/projects/v1/template-tasks',
+  '/api/projects/v1/template-cost-items',
+  '/api/projects/v1/template-change-orders',
+  '/api/activities/v1/deliverable-assignments',
+  '/api/ap/v1/ap-invoice-lines',
+  '/api/ar/v1/ar-invoice-lines',
+  '/api/accounting/v1/journal-entry-lines',
+];
+
+describe('Disabled import/export endpoints', () => {
+  let cookies;
+
+  beforeAll(async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({
+        email: process.env.ROOT_EMAIL || 'admin@axerra.io',
+        password: process.env.ROOT_PASSWORD || 'TestPass123!',
+      });
+    expect(res.status).toBe(200);
+    cookies = res.headers['set-cookie'];
+  }, 15000);
+
+  describe.each(DISABLED_ROUTES)('%s', (base) => {
+    test('POST /import-xls returns 404 (route not registered)', async () => {
+      const res = await request(app)
+        .post(`${base}/import-xls`)
+        .set('Cookie', cookies);
+      expect(res.status).toBe(404);
+    });
+
+    test('POST /export-xls returns 404 (route not registered)', async () => {
+      const res = await request(app)
+        .post(`${base}/export-xls`)
+        .set('Cookie', cookies);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/apps/server/tests/rbac/systemRoles.test.js
+++ b/apps/server/tests/rbac/systemRoles.test.js
@@ -32,7 +32,13 @@ describe('System Role Seeding', () => {
         return role;
       }),
       none: vi.fn().mockImplementation(async (_sql, params) => {
-        insertedPolicies.push({ role_id: params[1], module: params[2], level: params[5] });
+        insertedPolicies.push({
+          role_id: params[1],
+          module: params[2],
+          router: params[3],
+          action: params[4],
+          level: params[5],
+        });
       }),
     };
 
@@ -81,6 +87,32 @@ describe('System Role Seeding', () => {
       (p) => ['accounting', 'ap', 'ar'].includes(p.module) && p.level === 'none',
     );
     expect(financialDenied.length).toBe(3);
+  });
+
+  it('support does NOT receive explicit financial-module exact-match grants', async () => {
+    // Regression guard: exact-match keys short-circuit the broader-grant
+    // fallback in rbac.resolveLevel(), so an explicit ap::*::export=full
+    // would override the module-level ap=none deny. Support's policies
+    // must NOT include any financial-module router-action rows.
+    await seedSystemRoles(mockDb, mockPgp, 'axerra', 'AXERRA', true);
+
+    const supportPolicies = insertedPolicies.filter((p) => p.role_id === 'role-support');
+    const leaks = supportPolicies.filter(
+      (p) => ['accounting', 'ap', 'ar'].includes(p.module) && p.router && p.action,
+    );
+    expect(leaks).toEqual([]);
+  });
+
+  it('super_user DOES receive financial-module exact-match grants (full platform access)', async () => {
+    // super_user has no financial deny, so exact-match grants are correct.
+    await seedSystemRoles(mockDb, mockPgp, 'axerra', 'AXERRA', true);
+
+    const superPolicies = insertedPolicies.filter((p) => p.role_id === 'role-super_user');
+    const apExport = superPolicies.find(
+      (p) => p.module === 'ap' && p.router === 'ap-invoices' && p.action === 'export',
+    );
+    expect(apExport).toBeDefined();
+    expect(apExport.level).toBe('full');
   });
 
   it('is idempotent — skips existing roles', async () => {

--- a/apps/server/tests/unit/rbac.test.js
+++ b/apps/server/tests/unit/rbac.test.js
@@ -131,6 +131,29 @@ describe('resolveLevel', () => {
     const caps = { 'core::vendors::': 'full' };
     expect(resolveLevel(caps, 'core', 'vendors', 'import')).toBe('full');
   });
+
+  it('exact-match short-circuits module-level deny (motivates support-role financial filter)', () => {
+    // Demonstrates why systemRoleSeeder must NOT seed support with
+    // explicit financial export grants: an exact-match key for
+    // ap::ap-invoices::export would bypass the ap=none module deny.
+    const caps = {
+      '::::': 'full',
+      'ap::::': 'none',
+      'ap::ap-invoices::export': 'full',
+    };
+    expect(resolveLevel(caps, 'ap', 'ap-invoices', 'export')).toBe('full');
+  });
+
+  it('without an explicit financial export grant, exact-match returns none (support-role behavior)', () => {
+    // Support role gets wildcard full + ap/ar/accounting=none, but no
+    // explicit ap::ap-invoices::export. exact-match resolution reads
+    // only the exact key, returns none — financial export blocked.
+    const caps = {
+      '::::': 'full',
+      'ap::::': 'none',
+    };
+    expect(resolveLevel(caps, 'ap', 'ap-invoices', 'export')).toBe('none');
+  });
 });
 
 describe('rbac middleware', () => {

--- a/apps/server/tests/unit/rbac.test.js
+++ b/apps/server/tests/unit/rbac.test.js
@@ -61,10 +61,10 @@ describe('resolveLevel', () => {
     expect(resolveLevel(caps, 'core', 'vendors', 'import')).toBe('none');
   });
 
-  it('wildcard :::: covers import/export for system roles', () => {
+  it('wildcard :::: covers import (policy_required: false) but NOT export (exact-match)', () => {
     const caps = { '::::': 'full' };
     expect(resolveLevel(caps, 'core', 'vendors', 'import')).toBe('full');
-    expect(resolveLevel(caps, 'core', 'vendors', 'export')).toBe('full');
+    expect(resolveLevel(caps, 'core', 'vendors', 'export')).toBe('none');
   });
 
   // ── Exact-match (policy_required) actions ─────────────────────
@@ -99,6 +99,37 @@ describe('resolveLevel', () => {
     expect(EXACT_MATCH_KEYS.has('core::employees::')).toBe(false);
     const caps = { 'core::employees::': 'full' };
     expect(resolveLevel(caps, 'core', 'employees', 'create')).toBe('full');
+  });
+
+  // ── Exact-match (export) — independent compliance gate ────────
+
+  it('registers export addresses as exact-match (compliance gate)', () => {
+    expect(EXACT_MATCH_KEYS.has('core::vendors::export')).toBe(true);
+    expect(EXACT_MATCH_KEYS.has('core::employees::export')).toBe(true);
+    expect(EXACT_MATCH_KEYS.has('ap::ap-invoices::export')).toBe(true);
+    expect(EXACT_MATCH_KEYS.has('ar::ar-invoices::export')).toBe(true);
+    expect(EXACT_MATCH_KEYS.has('accounting::journal-entries::export')).toBe(true);
+  });
+
+  it('does NOT register import addresses as exact-match (covered by CRUD)', () => {
+    expect(EXACT_MATCH_KEYS.has('core::vendors::import')).toBe(false);
+    expect(EXACT_MATCH_KEYS.has('ap::ap-invoices::import')).toBe(false);
+    expect(EXACT_MATCH_KEYS.has('accounting::journal-entries::import')).toBe(false);
+  });
+
+  it('export with router-level full alone resolves to none', () => {
+    const caps = { 'core::vendors::': 'full' };
+    expect(resolveLevel(caps, 'core', 'vendors', 'export')).toBe('none');
+  });
+
+  it('export with explicit view grant resolves to view', () => {
+    const caps = { 'core::vendors::export': 'view' };
+    expect(resolveLevel(caps, 'core', 'vendors', 'export')).toBe('view');
+  });
+
+  it('import still falls back to router-level (policy_required: false)', () => {
+    const caps = { 'core::vendors::': 'full' };
+    expect(resolveLevel(caps, 'core', 'vendors', 'import')).toBe('full');
   });
 });
 
@@ -257,8 +288,17 @@ describe('rbac middleware', () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
-  it('falls back to router-level when no export action policy exists', async () => {
-    const req = makeReq('POST', { caps: { 'core::vendors::': 'view' } }, { module: 'core', router: 'vendors', action: 'export' });
+  it('export does NOT fall back to router-level (exact-match required)', async () => {
+    const req = makeReq('POST', { caps: { 'core::vendors::': 'full' } }, { module: 'core', router: 'vendors', action: 'export' });
+    const res = makeRes();
+    const next = vi.fn();
+    await rbac('view')(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('export with explicit grant succeeds', async () => {
+    const req = makeReq('POST', { caps: { 'core::vendors::export': 'view' } }, { module: 'core', router: 'vendors', action: 'export' });
     const res = makeRes();
     const next = vi.fn();
     await rbac('view')(req, res, next);
@@ -275,7 +315,7 @@ describe('rbac middleware', () => {
     expect(res.statusCode).toBe(403);
   });
 
-  it('wildcard :::: grants import/export to system roles', async () => {
+  it('wildcard :::: grants import (policy_required: false) but NOT export (exact-match)', async () => {
     const importReq = makeReq('POST', { caps: { '::::': 'full' } }, { module: 'core', router: 'vendors', action: 'import' });
     const exportReq = makeReq('POST', { caps: { '::::': 'full' } }, { module: 'core', router: 'vendors', action: 'export' });
     const res1 = makeRes();
@@ -285,7 +325,8 @@ describe('rbac middleware', () => {
     await rbac('full')(importReq, res1, next1);
     await rbac('view')(exportReq, res2, next2);
     expect(next1).toHaveBeenCalledOnce();
-    expect(next2).toHaveBeenCalledOnce();
+    expect(next2).not.toHaveBeenCalled();
+    expect(res2.statusCode).toBe(403);
   });
 
   it('does NOT bypass for any special role — all go through policy resolution', async () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #66 addressing two latent gaps surfaced in review:

1. **Hidden export gate.** All import/export catalog rows used `policy_required: false`, so the UI hid the toggles. Endpoints still executed via fallback to router-level CRUD — admins couldn't independently grant or deny export, a real compliance concern for financial and personal-data exports.
2. **Auto-mounted endpoints that shouldn't exist.** 20 routers exposed standalone `/import-xls` and `/export-xls` for resources that don't make sense as spreadsheet I/O: sources-child tables (importing creates orphans), UI-managed config, line/sub-record tables (should ride parent imports), blueprint templates, and the read-only policy-catalog. `journal-entry-lines` was the spiciest — standalone import bypasses balanced-entry validation.

## What changed

- **Export → exact-match.** Catalog rows for `action: 'export'` drop their `policy_required: false`, becoming `true` by default. PR #66's catalog-driven `EXACT_MATCH_KEYS` automatically picks them up, so the rbac middleware requires an exact policy grant (no fallback to router/module/wildcard).
- **Imports unchanged.** Stay `policy_required: false` — covered by router-level CREATE/UPDATE per principle 1.
- **20 routers disabled.** Added `disableImportXls: true, disableExportXls: true` and removed their import/export catalog rows. policy-catalog also gets `disableExportXls: true` (was missing).
- **systemRoleSeeder unchanged.** Already derives `EXACT_MATCH_POLICIES` from `CATALOG_ENTRIES`, so admin / super_user / support automatically pick up explicit `full` grants for every newly promoted export.

## Test plan

- [x] `npm run lint` clean
- [x] `npm -w apps/server run test:unit` (153 ✓ — 6 new export exact-match cases, 3 updated fallback/wildcard tests)
- [x] `npm -w apps/server run test:contract` (325 ✓ — new `disabledImportExport` spec locks 404 contract for all 20 disabled routers, 40 cases)
- [x] `npm -w apps/server run test:integration` (86 ✓)
- [x] `npm -w apps/server run test:rbac` (35 ✓)
- [x] Manual smoke in PolicyEditor: per-router Export toggles now visible, granting Vendors:full alone no longer enables export, disabled routers show no import/export toggle

## Side-note (out of scope)

`policyCatalogRouter.js:15` declares `withMeta({ module: 'core', router: 'roles' })` — looks like a copy-paste from rolesRouter; should likely be `router: 'policy-catalog'`. Not fixed here to keep the PR focused.