### PR TITLE
fix(server): correct withMeta router keys on 4 core routers

### DIFF
--- a/apps/server/src/system/core/apiRoutes/v1/addressesRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/addressesRouter.js
@@ -9,7 +9,7 @@ import createRouter from '../../../../lib/createRouter.js';
 import addressesController from '../../controllers/addressesController.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
 
-const meta = withMeta({ module: 'core' });
+const meta = withMeta({ module: 'core', router: 'addresses' });
 
 export default createRouter(addressesController, null, {
   getMiddlewares: [meta],

--- a/apps/server/src/system/core/apiRoutes/v1/phoneNumbersRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/phoneNumbersRouter.js
@@ -9,7 +9,7 @@ import createRouter from '../../../../lib/createRouter.js';
 import phoneNumbersController from '../../controllers/phoneNumbersController.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
 
-const meta = withMeta({ module: 'core' });
+const meta = withMeta({ module: 'core', router: 'phone-numbers' });
 
 export default createRouter(phoneNumbersController, null, {
   getMiddlewares: [meta],

--- a/apps/server/src/system/core/apiRoutes/v1/policyCatalogRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/policyCatalogRouter.js
@@ -12,7 +12,7 @@ import createRouter from '../../../../lib/createRouter.js';
 import policyCatalogController from '../../controllers/policyCatalogController.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
 
-const meta = withMeta({ module: 'core', router: 'roles' });
+const meta = withMeta({ module: 'core', router: 'policy-catalog' });
 
 export default createRouter(policyCatalogController, null, {
   getMiddlewares: [meta],

--- a/apps/server/src/system/core/apiRoutes/v1/taxIdentifiersRouter.js
+++ b/apps/server/src/system/core/apiRoutes/v1/taxIdentifiersRouter.js
@@ -9,7 +9,7 @@ import createRouter from '../../../../lib/createRouter.js';
 import taxIdentifiersController from '../../controllers/taxIdentifiersController.js';
 import { withMeta } from '../../../../middleware/withMeta.js';
 
-const meta = withMeta({ module: 'core' });
+const meta = withMeta({ module: 'core', router: 'tax-identifiers' });
 
 export default createRouter(taxIdentifiersController, null, {
   getMiddlewares: [meta],


### PR DESCRIPTION
## Summary

- Three child-table routers (addresses, phone-numbers, tax-identifiers) declared `withMeta({ module: 'core' })` without a router key, so endpoints reached `rbac()` with `req.resource.router = ''` and resolved at the module-level address. Deny payloads also misidentified the router in audit logs.
- policyCatalogRouter had `router: 'roles'` — a copy-paste leftover from rolesRouter, so granting Roles:full accidentally authorized policy-catalog endpoints (most are disabled; GET leaked).
- One-line metadata correction per file. No middleware, seeder, or catalog changes — `EXACT_MATCH_KEYS` doesn't grow.

## Test plan

- [x] `npm run lint`
- [x] `npm -w apps/server run test:unit` (155 ✓)
- [x] `npm -w apps/server run test:contract` (325 ✓)
- [x] `npm -w apps/server run test:integration` (86 ✓)
- [x] `npm -w apps/server run test:rbac` (37 ✓)