### PR TITLE
feat(server): admin.countries lookup + FK from tenant tables

### DIFF
--- a/apps/server/scripts/setupAdmin.js
+++ b/apps/server/scripts/setupAdmin.js
@@ -84,6 +84,10 @@ async function main() {
   }
   logger.info('Admin migrations complete.');
 
+  // ── Seed admin reference data ─────────────────────────────────────
+  const { seedCountries } = await import('../src/system/auth/services/countriesSeeder.js');
+  await seedCountries(db, DB.pgp);
+
   // ── Provision Axerra tenant schema ────────────────────────────────
   const rootTenantCode = process.env.ROOT_TENANT_CODE || 'AXERRA';
   const tenantSchema = rootTenantCode.toLowerCase();

--- a/apps/server/src/system/auth/authRepositories.js
+++ b/apps/server/src/system/auth/authRepositories.js
@@ -10,12 +10,14 @@ import PortalUsers from './models/PortalUsers.js';
 import PortalUserTenants from './models/PortalUserTenants.js';
 import ImpersonationLogs from './models/ImpersonationLogs.js';
 import MatchReviewLogs from './models/MatchReviewLogs.js';
+import Countries from './models/Countries.js';
 const repositories = {
   tenants: Tenants,
   portalUsers: PortalUsers,
   portalUserTenants: PortalUserTenants,
   impersonationLogs: ImpersonationLogs,
   matchReviewLogs: MatchReviewLogs,
+  countries: Countries,
 };
 
 export default repositories;

--- a/apps/server/src/system/auth/models/Countries.js
+++ b/apps/server/src/system/auth/models/Countries.js
@@ -1,0 +1,15 @@
+/**
+ * @file Countries model — extends TableModel for admin.countries
+ * @module auth/models/Countries
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { TableModel } from 'pg-schemata';
+import countriesSchema from '../schemas/countriesSchema.js';
+
+export default class Countries extends TableModel {
+  constructor(db, pgp, logger = null) {
+    super(db, pgp, countriesSchema, logger);
+  }
+}

--- a/apps/server/src/system/auth/schemas/countriesSchema.js
+++ b/apps/server/src/system/auth/schemas/countriesSchema.js
@@ -1,0 +1,33 @@
+/**
+ * @file Schema definition for admin.countries reference table
+ * @module auth/schemas/countriesSchema
+ *
+ * ISO 3166-1 alpha-2 country list seeded from packages/shared. Tenant-scope
+ * tables (phone_numbers, addresses, tax_identifiers) FK their country_code
+ * column here so typos like 'Us' or non-ISO 'UK' are rejected at the DB.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+/** @type {import('pg-schemata').TableSchema} */
+const countriesSchema = {
+  dbSchema: 'admin',
+  table: 'countries',
+  version: '1.0.0',
+  hasAuditFields: { enabled: false },
+  softDelete: false,
+  columns: [
+    { name: 'code', type: 'char(2)', notNull: true, immutable: true },
+    { name: 'name', type: 'varchar(128)', notNull: true },
+    { name: 'dial_code', type: 'varchar(8)' },
+    { name: 'placeholder', type: 'varchar(64)' },
+  ],
+  constraints: {
+    primaryKey: ['code'],
+    indexes: [
+      { type: 'Index', columns: ['name'] },
+    ],
+  },
+};
+
+export default countriesSchema;

--- a/apps/server/src/system/auth/services/countriesSeeder.js
+++ b/apps/server/src/system/auth/services/countriesSeeder.js
@@ -1,0 +1,46 @@
+/**
+ * @file Countries seeder — populates admin.countries from @axerra/shared
+ * @module auth/services/countriesSeeder
+ *
+ * Called once after admin migrations during setupAdmin. Idempotent — uses
+ * INSERT … ON CONFLICT (code) DO UPDATE so re-runs reconcile drift in the
+ * canonical COUNTRIES list (e.g. a renamed country or a tweaked dial_code).
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { COUNTRIES } from '@axerra/shared';
+import logger from '../../../lib/logger.js';
+
+/**
+ * Seed admin.countries from the shared COUNTRIES list.
+ *
+ * @param {object} dbInstance pg-promise database connection or transaction
+ * @param {object} pgp pg-promise helpers
+ */
+export async function seedCountries(dbInstance, pgp) {
+  if (!COUNTRIES?.length) {
+    logger.warn('seedCountries: COUNTRIES list is empty, skipping');
+    return;
+  }
+
+  const cs = new pgp.helpers.ColumnSet(
+    ['code', 'name', 'dial_code', 'placeholder'],
+    { table: { table: 'countries', schema: 'admin' } },
+  );
+  const rows = COUNTRIES.map((c) => ({
+    code: c.code,
+    name: c.name,
+    dial_code: c.dial_code || null,
+    placeholder: c.placeholder || null,
+  }));
+
+  const sql = `${pgp.helpers.insert(rows, cs)}
+    ON CONFLICT (code) DO UPDATE
+    SET name = EXCLUDED.name,
+        dial_code = EXCLUDED.dial_code,
+        placeholder = EXCLUDED.placeholder`;
+
+  await dbInstance.none(sql);
+  logger.info(`Seeded admin.countries with ${rows.length} entries.`);
+}

--- a/apps/server/src/system/core/schemas/addressesSchema.js
+++ b/apps/server/src/system/core/schemas/addressesSchema.js
@@ -38,6 +38,12 @@ const addressesSchema = {
         references: { table: 'sources', columns: ['id'] },
         onDelete: 'CASCADE',
       },
+      {
+        type: 'ForeignKey',
+        columns: ['country_code'],
+        references: { table: 'admin.countries', columns: ['code'] },
+        onDelete: 'RESTRICT',
+      },
     ],
     indexes: [
       { type: 'Index', columns: ['tenant_id'] },

--- a/apps/server/src/system/core/schemas/phoneNumbersSchema.js
+++ b/apps/server/src/system/core/schemas/phoneNumbersSchema.js
@@ -36,6 +36,12 @@ const phoneNumbersSchema = {
         references: { table: 'sources', columns: ['id'] },
         onDelete: 'CASCADE',
       },
+      {
+        type: 'ForeignKey',
+        columns: ['country_code'],
+        references: { table: 'admin.countries', columns: ['code'] },
+        onDelete: 'RESTRICT',
+      },
     ],
     indexes: [
       { type: 'Index', columns: ['tenant_id'] },

--- a/apps/server/src/system/core/schemas/taxIdentifiersSchema.js
+++ b/apps/server/src/system/core/schemas/taxIdentifiersSchema.js
@@ -28,6 +28,12 @@ const taxIdentifiersSchema = {
         references: { table: 'sources', columns: ['id'] },
         onDelete: 'CASCADE',
       },
+      {
+        type: 'ForeignKey',
+        columns: ['country_code'],
+        references: { table: 'admin.countries', columns: ['code'] },
+        onDelete: 'RESTRICT',
+      },
     ],
     indexes: [
       { type: 'Index', columns: ['tenant_id'] },

--- a/apps/server/tests/helpers/testDb.js
+++ b/apps/server/tests/helpers/testDb.js
@@ -215,6 +215,12 @@ export async function bootstrapAdmin() {
     },
   });
 
+  // Seed admin.countries — tenant tables FK to it, so it must be populated
+  // before any tenant provisioning that creates phone_numbers/addresses/
+  // tax_identifiers rows.
+  const { seedCountries } = await import('../../src/system/auth/services/countriesSeeder.js');
+  await seedCountries(db, DB.pgp);
+
   // Insert the root admin.tenants row BEFORE provisionTenant runs.
   // Otherwise tenantProvisioning's numberingConfigSeeder and
   // tenantPreferencesSeeder look up admin.tenants by schema_name, find
@@ -286,8 +292,11 @@ export async function cleanupTestDb() {
     // find the existing System Administrator row, leaking duplicate
     // employees on every test file.
     const rootTenantCode = process.env.ROOT_TENANT_CODE || 'AXERRA';
+    // Preserve admin.tenants (root tenant UUID stability — see comment
+     // above) and admin.countries (reference data FK'd by persisted
+     // tenant schemas; truncating would orphan their country_code FKs).
     const adminTables = await db.manyOrNone(
-      "SELECT table_name FROM information_schema.tables WHERE table_schema = 'admin' AND table_type = 'BASE TABLE' AND table_name != 'tenants'",
+      "SELECT table_name FROM information_schema.tables WHERE table_schema = 'admin' AND table_type = 'BASE TABLE' AND table_name NOT IN ('tenants', 'countries')",
     );
     if (adminTables.length) {
       const tableList = adminTables.map((r) => `admin.${DB.pgp.as.name(r.table_name)}`).join(', ');


### PR DESCRIPTION
## Summary

- Add `admin.countries` reference table (PK `code char(2)`) seeded from `@axerra/shared`'s 249-country list via a new `seedCountries(db, pgp)` service. Wired into `setupAdmin.js` after admin migrations and into the test helper so persisted tenant FKs stay valid across the inter-test admin truncate.
- FK `phone_numbers.country_code`, `addresses.country_code`, and `tax_identifiers.country_code` to `admin.countries.code` with `ON DELETE RESTRICT`. Closes the gap where typos like `'Us'` or non-ISO `'UK'` silently bypassed country-keyed downstream logic (phone `formatByPattern`, `TAX_TYPES` lookup).
- No migration authored — fresh-data project; bootstrap discovery picks up the new admin model and tenant FKs land via pg-schemata table creation when each tenant schema is provisioned.

## Test plan

- [x] `npm run lint` (clean — 1 unrelated pre-existing warning)
- [x] `npm -w apps/server run test:unit` (159 ✓)
- [x] `npm -w apps/server run test:contract` (319 ✓ — see note below)
- [x] `npm -w apps/server run test:integration` (94 ✓)
- [x] `npm -w apps/server run test:rbac` (37 ✓)
- [x] Manual SQL sanity check: `admin.countries` seeded with 249 rows post-`setupAdmin:test`; bogus `country_code = 'XX'` insert into `phone_numbers` rejected with `fk_phone_numbers_a9cde7` violation.

Note: contract suite passes cleanly in repeat focused runs. Two `npm run pr` gate runs each failed one different unrelated test (`auth.test.js > change-password` socket hang up; `disabledImportExport.test.js` 401 vs expected 404) — both pass in isolation, and neither touches country_code or admin schema. Looks like pre-existing inter-test ordering flake worth investigating separately.