### PR TITLE
chore: bump deps and relocate db scripts under apps/server

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -11,25 +11,23 @@
     "favicons": "node scripts/generate-favicons.js"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^5.15.16",
-    "@mui/material": "^5.15.16",
-    "@mui/x-charts": "^6.4.0",
-    "@mui/x-data-grid": "^6.4.0",
-    "@tanstack/react-query": "^5.28.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^7.9.6"
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^5.18.0",
+    "@mui/material": "^5.18.0",
+    "@mui/x-charts": "^6.19.8",
+    "@mui/x-data-grid": "^6.20.4",
+    "@tanstack/react-query": "^5.100.9",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.15.0"
   },
   "devDependencies": {
     "@fontsource/inter": "^5.2.8",
-    "@vitejs/plugin-react": "^4.0.0",
-    "eslint": "^8.56.0",
+    "@vitejs/plugin-react": "^4.7.0",
     "fontkit": "^2.0.4",
     "png-to-ico": "^3.0.1",
-    "prettier": "^3.2.5",
     "sharp": "^0.34.5",
-    "vite": "^7.1.3"
+    "vite": "^7.3.3"
   }
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,6 +27,7 @@
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
+    "cross-env": "^7.0.3",
     "dotenv": "^16.6.1",
     "express": "^5.2.1",
     "ioredis": "^5.10.1",
@@ -41,7 +42,6 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",
-    "cross-env": "^7.0.3",
     "nodemon": "^3.1.14",
     "supertest": "^7.2.2",
     "vitest": "^3.2.4"

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -26,25 +26,24 @@
   "dependencies": {
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
-    "cors": "^2.8.5",
-    "cross-env": "^7.0.3",
-    "dotenv": "^16.5.0",
-    "express": "^5.1.0",
-    "ioredis": "^5.6.1",
-    "jsonwebtoken": "^9.0.2",
-    "morgan": "^1.10.0",
-    "multer": "^2.0.1",
+    "cors": "^2.8.6",
+    "dotenv": "^16.6.1",
+    "express": "^5.2.1",
+    "ioredis": "^5.10.1",
+    "jsonwebtoken": "^9.0.3",
+    "morgan": "^1.10.1",
+    "multer": "^2.1.1",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
-    "pg-schemata": "^1.3.0",
-    "winston": "^3.17.0",
-    "zod": "^3.25.74"
+    "pg-schemata": "^1.3.2",
+    "winston": "^3.19.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^3.1.4",
-    "eslint": "^9.26.0",
-    "nodemon": "^3.1.9",
-    "supertest": "^7.1.0",
-    "vitest": "^3.1.4"
+    "@vitest/coverage-v8": "^3.2.4",
+    "cross-env": "^7.0.3",
+    "nodemon": "^3.1.14",
+    "supertest": "^7.2.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/server/scripts/db/provisionTenantCli.js
+++ b/apps/server/scripts/db/provisionTenantCli.js
@@ -3,7 +3,7 @@
  * @module server/scripts/db/provisionTenantCli
  *
  * Usage:
- *   cross-env NODE_ENV=development node scripts/db/provisionTenantCli.js \
+ *   cross-env NODE_ENV=development node apps/server/scripts/db/provisionTenantCli.js \
  *     --tenant-code SRH \
  *     --company "Sterling Ridge Homes, LLC" \
  *     --schema-name srh
@@ -51,9 +51,9 @@ if (!tenantCode || !company || !schemaName) {
 
 async function main() {
   const { DB } = await import('pg-schemata');
-  const { default: repositories } = await import('../../apps/server/src/db/repositories.js');
-  const { default: logger } = await import('../../apps/server/src/lib/logger.js');
-  const { getDatabaseUrl } = await import('../../apps/server/src/lib/envValidator.js');
+  const { default: repositories } = await import('../../src/db/repositories.js');
+  const { default: logger } = await import('../../src/lib/logger.js');
+  const { getDatabaseUrl } = await import('../../src/lib/envValidator.js');
 
   const DATABASE_URL = getDatabaseUrl();
   logger.info(`Provisioning tenant "${tenantCode}" on ${process.env.NODE_ENV || 'development'} database...`);
@@ -93,7 +93,7 @@ async function main() {
   }
 
   // 2. Provision schema (drops existing, creates fresh tables + seeds)
-  const { provisionTenant } = await import('../../apps/server/src/services/tenantProvisioning.js');
+  const { provisionTenant } = await import('../../src/services/tenantProvisioning.js');
   await provisionTenant({ schemaName: normalizedSchema, tenantCode: upperCode });
 
   logger.info(`Tenant "${upperCode}" fully provisioned.`);

--- a/apps/server/scripts/db/provisionTenantCli.js
+++ b/apps/server/scripts/db/provisionTenantCli.js
@@ -3,7 +3,7 @@
  * @module server/scripts/db/provisionTenantCli
  *
  * Usage:
- *   cross-env NODE_ENV=development node apps/server/scripts/db/provisionTenantCli.js \
+ *   npx cross-env NODE_ENV=development node apps/server/scripts/db/provisionTenantCli.js \
  *     --tenant-code SRH \
  *     --company "Sterling Ridge Homes, LLC" \
  *     --schema-name srh

--- a/apps/server/scripts/db/reconcilePolicyCatalog.js
+++ b/apps/server/scripts/db/reconcilePolicyCatalog.js
@@ -7,14 +7,14 @@
  *
  * Usage:
  *   # Reconcile a single schema; --root flag overrides admin.tenants lookup.
- *   cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema srh
- *   cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema axerra --root
+ *   npx cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema srh
+ *   npx cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema axerra --root
  *
  *   # Reconcile every non-admin tenant schema known to admin.tenants.
- *   cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js
+ *   npx cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js
  *
  *   # Show diffs without applying writes.
- *   cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --dry-run
+ *   npx cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --dry-run
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */

--- a/apps/server/scripts/db/reconcilePolicyCatalog.js
+++ b/apps/server/scripts/db/reconcilePolicyCatalog.js
@@ -7,14 +7,14 @@
  *
  * Usage:
  *   # Reconcile a single schema; --root flag overrides admin.tenants lookup.
- *   cross-env NODE_ENV=development node scripts/db/reconcilePolicyCatalog.js --schema srh
- *   cross-env NODE_ENV=development node scripts/db/reconcilePolicyCatalog.js --schema axerra --root
+ *   cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema srh
+ *   cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema axerra --root
  *
  *   # Reconcile every non-admin tenant schema known to admin.tenants.
- *   cross-env NODE_ENV=development node scripts/db/reconcilePolicyCatalog.js
+ *   cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js
  *
  *   # Show diffs without applying writes.
- *   cross-env NODE_ENV=development node scripts/db/reconcilePolicyCatalog.js --dry-run
+ *   cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --dry-run
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
@@ -49,10 +49,10 @@ const dryRun = values['dry-run'];
 
 async function main() {
   const { DB } = await import('pg-schemata');
-  const { default: repositories } = await import('../../apps/server/src/db/repositories.js');
-  const { default: logger } = await import('../../apps/server/src/lib/logger.js');
-  const { getDatabaseUrl } = await import('../../apps/server/src/lib/envValidator.js');
-  const { reconcilePolicyCatalog } = await import('../../apps/server/src/system/core/services/policyCatalogReconciler.js');
+  const { default: repositories } = await import('../../src/db/repositories.js');
+  const { default: logger } = await import('../../src/lib/logger.js');
+  const { getDatabaseUrl } = await import('../../src/lib/envValidator.js');
+  const { reconcilePolicyCatalog } = await import('../../src/system/core/services/policyCatalogReconciler.js');
 
   const ROOT_TENANT_CODE = (process.env.ROOT_TENANT_CODE || 'AXERRA').toUpperCase();
   const DATABASE_URL = getDatabaseUrl();

--- a/docs/other/srh_schema_backup_restore_workflow.md
+++ b/docs/other/srh_schema_backup_restore_workflow.md
@@ -20,7 +20,7 @@ For routine `policy_catalog` drift (new entries, label/description tweaks,
 required: run the reconciler instead.
 
 ```bash
-cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js
+npx cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js
 ```
 
 The reconciler diff/upserts `CATALOG_ENTRIES` (defined in
@@ -122,7 +122,7 @@ Drops the `srh_restore` staging schema.
 CLI script to provision any tenant from the command line.
 
 ```bash
-cross-env NODE_ENV=development node apps/server/scripts/db/provisionTenantCli.js \
+npx cross-env NODE_ENV=development node apps/server/scripts/db/provisionTenantCli.js \
   --tenant-code SRH \
   --company "Sterling Ridge Homes, LLC" \
   --schema-name srh \
@@ -139,16 +139,16 @@ tenant schemas. Stable row IDs, idempotent, safe to re-run.
 
 ```bash
 # All non-admin tenants in admin.tenants
-cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js
+npx cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js
 
 # Single schema (root flag derived from admin.tenants)
-cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema srh
+npx cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema srh
 
 # Override root flag for a not-yet-registered schema
-cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema axerra --root
+npx cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema axerra --root
 
 # Diff only, no writes
-cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --dry-run
+npx cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --dry-run
 ```
 
 Removed entries (rows in DB whose tuple no longer appears in `CATALOG_ENTRIES`)

--- a/docs/other/srh_schema_backup_restore_workflow.md
+++ b/docs/other/srh_schema_backup_restore_workflow.md
@@ -20,7 +20,7 @@ For routine `policy_catalog` drift (new entries, label/description tweaks,
 required: run the reconciler instead.
 
 ```bash
-cross-env NODE_ENV=development node scripts/db/reconcilePolicyCatalog.js
+cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js
 ```
 
 The reconciler diff/upserts `CATALOG_ENTRIES` (defined in
@@ -117,12 +117,12 @@ Drops the `srh_restore` staging schema.
 
 ## Supporting scripts
 
-### `scripts/db/provisionTenantCli.js`
+### `apps/server/scripts/db/provisionTenantCli.js`
 
 CLI script to provision any tenant from the command line.
 
 ```bash
-cross-env NODE_ENV=development node scripts/db/provisionTenantCli.js \
+cross-env NODE_ENV=development node apps/server/scripts/db/provisionTenantCli.js \
   --tenant-code SRH \
   --company "Sterling Ridge Homes, LLC" \
   --schema-name srh \
@@ -131,7 +131,7 @@ cross-env NODE_ENV=development node scripts/db/provisionTenantCli.js \
 
 Inserts tenant record (idempotent) and calls `provisionTenant()`.
 
-### `scripts/db/reconcilePolicyCatalog.js`
+### `apps/server/scripts/db/reconcilePolicyCatalog.js`
 
 Diff/upsert/delete reconciler for `policy_catalog`. Imports `CATALOG_ENTRIES`
 from `policyCatalogSeeder.js` and applies the delta against one or all
@@ -139,16 +139,16 @@ tenant schemas. Stable row IDs, idempotent, safe to re-run.
 
 ```bash
 # All non-admin tenants in admin.tenants
-cross-env NODE_ENV=development node scripts/db/reconcilePolicyCatalog.js
+cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js
 
 # Single schema (root flag derived from admin.tenants)
-cross-env NODE_ENV=development node scripts/db/reconcilePolicyCatalog.js --schema srh
+cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema srh
 
 # Override root flag for a not-yet-registered schema
-cross-env NODE_ENV=development node scripts/db/reconcilePolicyCatalog.js --schema axerra --root
+cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --schema axerra --root
 
 # Diff only, no writes
-cross-env NODE_ENV=development node scripts/db/reconcilePolicyCatalog.js --dry-run
+cross-env NODE_ENV=development node apps/server/scripts/db/reconcilePolicyCatalog.js --dry-run
 ```
 
 Removed entries (rows in DB whose tuple no longer appears in `CATALOG_ENTRIES`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
+        "cross-env": "^7.0.3",
         "dotenv": "^16.6.1",
         "express": "^5.2.1",
         "ioredis": "^5.10.1",
@@ -70,7 +71,6 @@
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^3.2.4",
-        "cross-env": "^7.0.3",
         "nodemon": "^3.1.14",
         "supertest": "^7.2.2",
         "vitest": "^3.2.4"
@@ -2551,7 +2551,6 @@
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.1"
@@ -2568,7 +2567,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4615,7 +4613,6 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5756,7 +5753,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6719,7 +6715,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6730,7 +6725,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7839,7 +7833,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,14 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@eslint/js": "^9.34.0",
-        "eslint": "^9.34.0",
+        "@eslint/js": "^9.39.4",
+        "eslint": "^9.39.4",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.5",
         "husky": "^9.1.7",
-        "lint-staged": "^16.3.1"
+        "lint-staged": "^16.4.0",
+        "prettier": "^3.8.3"
       },
       "engines": {
         "node": ">=20"
@@ -27,88 +28,24 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@emotion/react": "^11.11.1",
-        "@emotion/styled": "^11.11.0",
-        "@mui/icons-material": "^5.15.16",
-        "@mui/material": "^5.15.16",
-        "@mui/x-charts": "^6.4.0",
-        "@mui/x-data-grid": "^6.4.0",
-        "@tanstack/react-query": "^5.28.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router-dom": "^7.9.6"
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^5.18.0",
+        "@mui/material": "^5.18.0",
+        "@mui/x-charts": "^6.19.8",
+        "@mui/x-data-grid": "^6.20.4",
+        "@tanstack/react-query": "^5.100.9",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.15.0"
       },
       "devDependencies": {
         "@fontsource/inter": "^5.2.8",
-        "@vitejs/plugin-react": "^4.0.0",
-        "eslint": "^8.56.0",
+        "@vitejs/plugin-react": "^4.7.0",
         "fontkit": "^2.0.4",
         "png-to-ico": "^3.0.1",
-        "prettier": "^3.2.5",
         "sharp": "^0.34.5",
-        "vite": "^7.1.3"
-      }
-    },
-    "apps/client/node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "apps/client/node_modules/eslint": {
-      "version": "8.57.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.1",
-        "@humanwhocodes/config-array": "^0.13.0",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "vite": "^7.3.3"
       }
     },
     "apps/server": {
@@ -118,26 +55,25 @@
       "dependencies": {
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
-        "cors": "^2.8.5",
-        "cross-env": "^7.0.3",
-        "dotenv": "^16.5.0",
-        "express": "^5.1.0",
-        "ioredis": "^5.6.1",
-        "jsonwebtoken": "^9.0.2",
-        "morgan": "^1.10.0",
-        "multer": "^2.0.1",
+        "cors": "^2.8.6",
+        "dotenv": "^16.6.1",
+        "express": "^5.2.1",
+        "ioredis": "^5.10.1",
+        "jsonwebtoken": "^9.0.3",
+        "morgan": "^1.10.1",
+        "multer": "^2.1.1",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
-        "pg-schemata": "^1.3.0",
-        "winston": "^3.17.0",
-        "zod": "^3.25.74"
+        "pg-schemata": "^1.3.2",
+        "winston": "^3.19.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@vitest/coverage-v8": "^3.1.4",
-        "eslint": "^9.26.0",
-        "nodemon": "^3.1.9",
-        "supertest": "^7.1.0",
-        "vitest": "^3.1.4"
+        "@vitest/coverage-v8": "^3.2.4",
+        "cross-env": "^7.0.3",
+        "nodemon": "^3.1.14",
+        "supertest": "^7.2.2",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -629,28 +565,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
       "dev": true,
@@ -740,19 +654,6 @@
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=10.10.0"
-      }
-    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "dev": true,
@@ -764,11 +665,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
-    },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
@@ -1310,37 +1206,17 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
@@ -1466,7 +1342,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.20",
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1474,10 +1352,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.21",
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.20"
+        "@tanstack/query-core": "5.100.9"
       },
       "funding": {
         "type": "github",
@@ -1588,11 +1468,6 @@
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
       "license": "MIT"
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1840,7 +1715,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2177,7 +2054,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2594,6 +2473,8 @@
     },
     "node_modules/cookie": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2660,7 +2541,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -2668,6 +2551,7 @@
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.1"
@@ -2684,6 +2568,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2934,17 +2819,6 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3483,21 +3357,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "dev": true,
@@ -3605,22 +3464,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/espree": {
-      "version": "9.6.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esquery": {
@@ -3765,7 +3608,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
       "funding": [
         {
           "type": "github",
@@ -3778,7 +3623,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.6",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -3787,20 +3634,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
       }
     },
     "node_modules/fdir": {
@@ -3826,17 +3666,6 @@
     "node_modules/fflate": {
       "version": "0.8.2",
       "license": "MIT"
-    },
-    "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flat-cache": "^3.0.4"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3887,21 +3716,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
     "node_modules/flatted": {
-      "version": "3.4.1",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4017,11 +3835,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4145,25 +3958,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "dev": true,
@@ -4173,20 +3967,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/globals": {
-      "version": "13.24.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -4213,11 +3993,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4394,15 +4169,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
@@ -4428,7 +4194,9 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.10.0",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "1.5.1",
@@ -4699,14 +4467,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "license": "MIT"
@@ -4855,6 +4615,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5130,7 +4891,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -5620,7 +5383,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5975,7 +5740,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.3",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -5987,16 +5754,9 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6027,7 +5787,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -6178,10 +5940,12 @@
       }
     },
     "node_modules/pg-schemata": {
-      "version": "1.3.1",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pg-schemata/-/pg-schemata-1.3.2.tgz",
+      "integrity": "sha512-R710HUM4OGSzWGoHAdMcIWMOGqDorJRdH0DqAzcmzpvID0NnAvtaYPQT0eoJFNkikw6gBmg6DtyzALmvxBC94w==",
       "license": "MIT",
       "dependencies": {
-        "@nap-sft/tablsx": "^0.1.2",
+        "@nap-sft/tablsx": "^0.1.3",
         "dotenv": "^16.5.0",
         "lodash": "^4.17.21",
         "lru-cache": "^11.1.0",
@@ -6225,7 +5989,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6268,7 +6034,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -6334,7 +6102,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6397,25 +6167,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "license": "MIT",
@@ -6470,7 +6221,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -6490,10 +6243,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.15.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6541,7 +6296,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6657,33 +6414,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -6740,28 +6474,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -6900,6 +6612,8 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -7005,6 +6719,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7015,6 +6730,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7452,7 +7168,9 @@
       "license": "MIT"
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -7548,7 +7266,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7583,7 +7303,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7620,11 +7342,6 @@
     },
     "node_modules/text-hex": {
       "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-inflate": {
@@ -7753,17 +7470,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -7960,7 +7666,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8131,6 +7839,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8406,7 +8115,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
     ]
   },
   "devDependencies": {
-    "@eslint/js": "^9.34.0",
-    "eslint": "^9.34.0",
+    "@eslint/js": "^9.39.4",
+    "eslint": "^9.39.4",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "husky": "^9.1.7",
-    "lint-staged": "^16.3.1"
+    "lint-staged": "^16.4.0",
+    "prettier": "^3.8.3"
   }
 }

--- a/scripts/db/restore_srh.sh
+++ b/scripts/db/restore_srh.sh
@@ -108,7 +108,7 @@ echo ""
 # ══════════════════════════════════════════════════════════════════
 echo "=== Step 4: Provision SRH tenant ==="
 cd "$SERV_DIR"
-npx cross-env NODE_ENV=development node "$SCRIPT_DIR/provisionTenantCli.js" \
+npx cross-env NODE_ENV=development node "$SERV_DIR/scripts/db/provisionTenantCli.js" \
   --tenant-code "$TENANT_CODE" \
   --company "$COMPANY" \
   --schema-name "$SOURCE_SCHEMA"


### PR DESCRIPTION
## Summary

- Patch/minor dependency bumps across client, server, and root (MUI, React, vite, eslint, vitest, pg-schemata, etc.).
- Consolidate `eslint` and `prettier` to root devDependencies. `cross-env` stays in server `dependencies` — `start`, `dev`, `migrate`, `seed`, and `setupAdmin` scripts all invoke it, so a production install with `--omit=dev` would break them.
- Relocate `provisionTenantCli.js` and `reconcilePolicyCatalog.js` from `scripts/db/` to `apps/server/scripts/db/`; update internal import paths, the `restore_srh.sh` wrapper, and the SRH backup/restore workflow doc. Doc and script-header examples invoke `npx cross-env` for cwd-independent copy-paste.

Split into two commits on initial push to satisfy the husky client/server split rule; review fixes in a third commit.

## Test plan

- [x] \`npm run lint\` (clean — one pre-existing unrelated warning)
- [x] \`npm -w apps/server run test:unit\` (159 ✓)
- [x] \`npm -w apps/server run test:contract\` (319 ✓)
- [x] \`npm -w apps/server run test:integration\` (94 ✓)
- [x] \`npm -w apps/server run test:rbac\` (37 ✓)