### PR TITLE
Flat-format import: per-row reconciliation, mandatory preview, app-user cascade hardening

### DIFF
--- a/apps/client/src/components/shared/ImportDialog.jsx
+++ b/apps/client/src/components/shared/ImportDialog.jsx
@@ -1,6 +1,14 @@
 /**
- * @file Reusable spreadsheet import dialog — file picker + FormDialog wrapper
+ * @file Reusable spreadsheet import dialog with optional mandatory preview step
  * @module client/components/shared/ImportDialog
+ *
+ * Two flows:
+ *   - Without `onPreview`: legacy file-picker + Submit. Parent's onSubmit
+ *     is invoked with the FormData.
+ *   - With `onPreview`: mandatory three-step flow — pick file → preview
+ *     (counts or errors) → confirm. onPreview must resolve to the server's
+ *     preview payload `{ preview: true, inserts, updates, noops, omitted, errors }`
+ *     or throw with `err.payload.errors` if validation failed.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
@@ -8,6 +16,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
+import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -18,32 +27,85 @@ import UploadFileIcon from '@mui/icons-material/UploadFile';
 import FormDialog from './FormDialog.jsx';
 import SecondaryButton from './SecondaryButton.jsx';
 
-export default function ImportDialog({ open, title = 'Import Spreadsheet', loading, errors, onSubmit, onCancel }) {
+export default function ImportDialog({
+  open,
+  title = 'Import Spreadsheet',
+  loading,
+  errors,
+  onPreview,
+  onSubmit,
+  onCancel,
+}) {
   const [file, setFile] = useState(null);
+  const [stage, setStage] = useState('pick'); // 'pick' | 'preview' | 'previewing'
+  const [previewData, setPreviewData] = useState(null);
+  const [previewErrors, setPreviewErrors] = useState(null);
 
   useEffect(() => {
-    if (!open) setFile(null);
+    if (!open) {
+      setFile(null);
+      setStage('pick');
+      setPreviewData(null);
+      setPreviewErrors(null);
+    }
   }, [open]);
 
   const handleFileChange = useCallback((e) => {
     setFile(e.target.files?.[0] || null);
+    setStage('pick');
+    setPreviewData(null);
+    setPreviewErrors(null);
   }, []);
 
-  const handleSubmit = useCallback(() => {
-    if (!file) return;
+  const buildFormData = useCallback(() => {
     const fd = new FormData();
     fd.append('file', file);
-    onSubmit(fd);
-  }, [file, onSubmit]);
+    return fd;
+  }, [file]);
+
+  const handlePreview = useCallback(async () => {
+    if (!file || !onPreview) return;
+    setStage('previewing');
+    setPreviewErrors(null);
+    try {
+      const result = await onPreview(buildFormData());
+      setPreviewData(result);
+      setPreviewErrors(null);
+      setStage('preview');
+    } catch (err) {
+      const validationErrors = err?.payload?.errors;
+      setPreviewData(null);
+      setPreviewErrors(validationErrors?.length ? validationErrors : [{ sheet: null, row: null, column: null, value: null, message: err?.message || 'Preview failed' }]);
+      setStage('preview');
+    }
+  }, [file, onPreview, buildFormData]);
+
+  const handleConfirm = useCallback(() => {
+    if (!file) return;
+    onSubmit(buildFormData());
+  }, [file, onSubmit, buildFormData]);
+
+  // Legacy single-step flow when onPreview not supplied
+  const handleLegacySubmit = useCallback(() => {
+    if (!file) return;
+    onSubmit(buildFormData());
+  }, [file, onSubmit, buildFormData]);
+
+  const showServerErrors = errors?.length > 0;
+  const showPreviewErrors = previewErrors?.length > 0;
+  const showPreviewCounts = stage === 'preview' && previewData && !showPreviewErrors;
+  const submitLabel = onPreview ? (stage === 'preview' && !showPreviewErrors ? 'Import' : 'Preview') : 'Import';
+  const submitHandler = onPreview ? (stage === 'preview' && !showPreviewErrors ? handleConfirm : handlePreview) : handleLegacySubmit;
+  const submitDisabled = !file || stage === 'previewing' || (onPreview && showPreviewErrors);
 
   return (
     <FormDialog
       open={open}
       title={title}
-      submitLabel="Import"
-      loading={loading}
-      submitDisabled={!file}
-      onSubmit={handleSubmit}
+      submitLabel={submitLabel}
+      loading={loading || stage === 'previewing'}
+      submitDisabled={submitDisabled}
+      onSubmit={submitHandler}
       onCancel={onCancel}
     >
       <SecondaryButton component="label" startIcon={<UploadFileIcon />}>
@@ -55,7 +117,54 @@ export default function ImportDialog({ open, title = 'Import Spreadsheet', loadi
           {(file.size / 1024).toFixed(1)} KB
         </Typography>
       )}
-      {errors?.length > 0 && (
+
+      {showPreviewCounts && (
+        <Alert severity="info" sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Preview — review before importing:
+          </Typography>
+          <Stack spacing={0.5}>
+            <Typography variant="body2">New rows: <strong>{previewData.inserts}</strong></Typography>
+            <Typography variant="body2">Updates in place: <strong>{previewData.updates}</strong></Typography>
+            <Typography variant="body2">Unchanged: <strong>{previewData.noops}</strong></Typography>
+            <Typography variant="body2">Existing rows not in file (left unchanged): <strong>{previewData.omitted}</strong></Typography>
+          </Stack>
+        </Alert>
+      )}
+
+      {showPreviewErrors && (
+        <Alert severity="error" sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Fix {previewErrors.length} issue{previewErrors.length > 1 ? 's' : ''} in the spreadsheet, then re-upload:
+          </Typography>
+          <TableContainer sx={{ maxHeight: 240 }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Sheet</TableCell>
+                  <TableCell>Row</TableCell>
+                  <TableCell>Column</TableCell>
+                  <TableCell>Value</TableCell>
+                  <TableCell>Error</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {previewErrors.map((e, i) => (
+                  <TableRow key={i}>
+                    <TableCell>{e.sheet}</TableCell>
+                    <TableCell>{e.row}</TableCell>
+                    <TableCell>{e.column}</TableCell>
+                    <TableCell sx={{ maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.value}</TableCell>
+                    <TableCell>{e.message}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Alert>
+      )}
+
+      {showServerErrors && !showPreviewErrors && (
         <Alert severity="error" sx={{ mt: 2 }}>
           <Typography variant="subtitle2" gutterBottom>
             Please fix {errors.length} error{errors.length > 1 ? 's' : ''} in the spreadsheet:

--- a/apps/client/src/components/shared/ImportDialog.jsx
+++ b/apps/client/src/components/shared/ImportDialog.jsx
@@ -94,9 +94,14 @@ export default function ImportDialog({
   const showServerErrors = errors?.length > 0;
   const showPreviewErrors = previewErrors?.length > 0;
   const showPreviewCounts = stage === 'preview' && previewData && !showPreviewErrors;
-  const submitLabel = onPreview ? (stage === 'preview' && !showPreviewErrors ? 'Import' : 'Preview') : 'Import';
-  const submitHandler = onPreview ? (stage === 'preview' && !showPreviewErrors ? handleConfirm : handlePreview) : handleLegacySubmit;
-  const submitDisabled = !file || stage === 'previewing' || (onPreview && showPreviewErrors);
+  // When `onPreview` is supplied the button toggles between Preview (idle or
+  // when preview returned errors) and Import (preview-clean). Only disable
+  // for the Import action — leaving Preview re-clickable so the user can
+  // retry after a transient network error or after fixing the file.
+  const isConfirmAction = onPreview && stage === 'preview' && !showPreviewErrors;
+  const submitLabel = onPreview ? (isConfirmAction ? 'Import' : 'Preview') : 'Import';
+  const submitHandler = onPreview ? (isConfirmAction ? handleConfirm : handlePreview) : handleLegacySubmit;
+  const submitDisabled = !file || stage === 'previewing';
 
   return (
     <FormDialog

--- a/apps/client/src/hooks/useTenantPreferences.js
+++ b/apps/client/src/hooks/useTenantPreferences.js
@@ -7,14 +7,17 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { tenantPreferencesApi } from '../services/tenantPreferencesApi.js';
+import { useAuth } from '../contexts/AuthContext.jsx';
 
 export const TENANT_PREFS_KEY = ['tenant-preferences'];
 
-/** Fetch tenant preferences (single row). */
+/** Fetch tenant preferences (single row). Gated on an authenticated session. */
 export function useTenantPreferences() {
+  const { user } = useAuth();
   return useQuery({
     queryKey: TENANT_PREFS_KEY,
     queryFn: () => tenantPreferencesApi.list({ limit: 1 }),
+    enabled: !!user,
   });
 }
 

--- a/apps/client/src/pages/Core/ClientsPage.jsx
+++ b/apps/client/src/pages/Core/ClientsPage.jsx
@@ -334,6 +334,7 @@ export default function ClientsPage() {
       <ImportDialog
         open={importDialog.isOpen} title="Import Clients" loading={importMut.isPending}
         errors={importErrors}
+        onPreview={(fd) => clientApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />

--- a/apps/client/src/pages/Core/CompaniesPage.jsx
+++ b/apps/client/src/pages/Core/CompaniesPage.jsx
@@ -257,6 +257,7 @@ export default function CompaniesPage() {
       <ImportDialog
         open={importDialog.isOpen} title="Import Companies" loading={importMut.isPending}
         errors={importErrors}
+        onPreview={(fd) => companyApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />

--- a/apps/client/src/pages/Core/ContactsPage.jsx
+++ b/apps/client/src/pages/Core/ContactsPage.jsx
@@ -276,6 +276,7 @@ export default function ContactsPage() {
       <ImportDialog
         open={importDialog.isOpen} title="Import Contacts" loading={importMut.isPending}
         errors={importErrors}
+        onPreview={(fd) => contactApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />

--- a/apps/client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/client/src/pages/Core/EmployeesPage.jsx
@@ -351,6 +351,7 @@ export default function EmployeesPage() {
       <ImportDialog
         open={importDialog.isOpen} title="Import Employees" loading={importMut.isPending}
         errors={importErrors}
+        onPreview={(fd) => employeeApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />

--- a/apps/client/src/services/clientApi.js
+++ b/apps/client/src/services/clientApi.js
@@ -24,7 +24,8 @@ export const clientApi = {
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
   resetPassword: (id, password) => client.post(`${BASE}/${id}/reset-password`, { password }),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/companyApi.js
+++ b/apps/client/src/services/companyApi.js
@@ -23,7 +23,8 @@ export const companyApi = {
   update: (filterParams, changes) => client.put(`${BASE}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/contactApi.js
+++ b/apps/client/src/services/contactApi.js
@@ -23,7 +23,8 @@ export const contactApi = {
   update: (filterParams, changes) => client.put(`${BASE}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/employeeApi.js
+++ b/apps/client/src/services/employeeApi.js
@@ -24,7 +24,8 @@ export const employeeApi = {
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
   resetPassword: (id, password) => client.post(`${BASE}/${id}/reset-password`, { password }),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/server/src/lib/BaseController.js
+++ b/apps/server/src/lib/BaseController.js
@@ -101,8 +101,12 @@ class BaseController extends ViewController {
 
   /**
    * POST /import-xls — import records from uploaded spreadsheet.
-   * Pass `?preview=1` to run validation + classification only and receive a
-   * counts-only preview instead of writing.
+   *
+   * Pass `?preview=1` to receive a counts-only preview instead of writing.
+   * NOTE: preview is only honored by importers whose model's
+   * `importFromSpreadsheet` implements the `previewOnly` option (currently
+   * the flat-format path used by employees, clients, contacts, companies).
+   * Legacy multi-sheet importers ignore the flag and still write.
    */
   async importXls(req, res) {
     const file = req.file;

--- a/apps/server/src/lib/BaseController.js
+++ b/apps/server/src/lib/BaseController.js
@@ -100,21 +100,27 @@ class BaseController extends ViewController {
   }
 
   /**
-   * POST /import-xls — import records from uploaded spreadsheet
+   * POST /import-xls — import records from uploaded spreadsheet.
+   * Pass `?preview=1` to run validation + classification only and receive a
+   * counts-only preview instead of writing.
    */
   async importXls(req, res) {
     const file = req.file;
     if (!file) return res.status(400).json({ error: 'No file uploaded' });
 
     const index = parseInt(req.body.index || '0', 10);
+    const previewOnly = req.query.preview === '1' || req.query.preview === 'true';
     try {
       const tenantCode = req.user?.tenant_code;
-      const result = await this.model(this.getSchema(req)).importFromSpreadsheet(file.path, index, (row) => ({
-        ...row,
-        tenant_code: tenantCode,
-        created_by: req.user?.id,
-      }));
-      if (result.errors) return res.status(422).json(result);
+      const result = await this.model(this.getSchema(req)).importFromSpreadsheet(
+        file.path,
+        index,
+        (row) => ({ ...row, tenant_code: tenantCode, created_by: req.user?.id }),
+        null,
+        { previewOnly },
+      );
+      if (result?.errors?.length) return res.status(422).json(result);
+      if (result?.preview) return res.status(200).json(result);
       res.status(201).json(result);
     } catch (err) {
       this.handleError(err, res, 'importing', this.errorLabel);

--- a/apps/server/src/lib/BaseController.js
+++ b/apps/server/src/lib/BaseController.js
@@ -115,7 +115,12 @@ class BaseController extends ViewController {
       const result = await this.model(this.getSchema(req)).importFromSpreadsheet(
         file.path,
         index,
-        (row) => ({ ...row, tenant_code: tenantCode, created_by: req.user?.id }),
+        (row) => ({
+          ...row,
+          tenant_code: tenantCode,
+          created_by: req.user?.id,
+          updated_by: req.user?.id,
+        }),
         null,
         { previewOnly },
       );

--- a/apps/server/src/lib/employeeAppUserSync.js
+++ b/apps/server/src/lib/employeeAppUserSync.js
@@ -1,0 +1,200 @@
+/**
+ * @file App-user lifecycle service for tenant entities with portal access
+ * @module server/lib/employeeAppUserSync
+ *
+ * Centralises portal_users + portal_user_tenants cascade rules for entities
+ * that opt in to app access (employees, clients). Used by both controllers
+ * (single-row CRUD) and the flat-import reconciler. Functions are pure of
+ * req/res — callers pass plain arguments and a transaction handle.
+ *
+ * Naming note: the module is called `employeeAppUserSync` for historical
+ * reasons; the helpers are polymorphic and accept any entity_type that
+ * binds to portal_users (employee, client, vendor_contact).
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import logger from './logger.js';
+
+/**
+ * Provision a portal_user + binding for an entity gaining app access.
+ * Skips when an active portal_user already owns this email (the caller's
+ * pre-validation should catch this case as a collision; this is a defensive
+ * fallback). Returns true on success, false on collision-skip.
+ *
+ * @param {Object} t           pg-promise transaction
+ * @param {string} entityType  'employee' | 'client' | 'vendor_contact'
+ * @param {string} entityId    primary key of the entity in its tenant table
+ * @param {string} email       login email to assign to portal_users
+ * @param {string} password    clear-text password (will be bcrypted) — supply random when caller doesn't have one
+ * @param {string} tenantId    binding tenant_id
+ * @param {string|null} userId caller user id for audit
+ * @param {string} [preHash]   pre-computed bcrypt hash; skips hashing when supplied
+ * @returns {Promise<boolean>} true on success, false on collision
+ */
+export async function provisionAppUser(t, entityType, entityId, email, password, tenantId, userId, preHash = null) {
+  const existing = await t.oneOrNone(
+    'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
+    [email],
+  );
+  if (existing) return false;
+
+  let passwordHash;
+  if (preHash) {
+    passwordHash = preHash;
+  } else {
+    const bcrypt = await import('bcrypt');
+    const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
+    passwordHash = await bcrypt.default.hash(password, rounds);
+  }
+
+  const inserted = await t.one(
+    `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
+     VALUES ($1, $2, 'invited', $3)
+     RETURNING id`,
+    [email, passwordHash, userId],
+  );
+  await t.none(
+    `INSERT INTO admin.portal_user_tenants
+       (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
+     VALUES ($1, $2, $3, $4, 'active', $5)`,
+    [inserted.id, tenantId, entityType, entityId, userId],
+  );
+  return true;
+}
+
+/**
+ * Restore an archived portal_user + binding for an entity that's coming
+ * back online (employee restore, is_app_user re-enabled). Restores the
+ * binding if one exists in archived state; updates the password/email on
+ * the way back. Returns true if a restore occurred, false if no prior
+ * binding exists.
+ *
+ * @param {Object} t           pg-promise transaction
+ * @param {string} entityType
+ * @param {string} entityId
+ * @param {string} tenantId
+ * @param {string|null} userId
+ * @param {string} [email]     when supplied, also updates the portal_user email
+ * @param {string} [preHash]   when supplied, also updates the password
+ */
+export async function restoreAppUserBinding(t, entityType, entityId, tenantId, userId, email = null, preHash = null) {
+  const binding = await t.oneOrNone(
+    `SELECT id, portal_user_id FROM admin.portal_user_tenants
+     WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3
+     ORDER BY deactivated_at IS NULL DESC, created_at DESC LIMIT 1`,
+    [entityType, entityId, tenantId],
+  );
+  if (!binding) return false;
+
+  if (email && preHash) {
+    await t.none(
+      `UPDATE admin.portal_users
+       SET deactivated_at = NULL, status = 'invited', password_hash = $1, email = $2, updated_by = $3
+       WHERE id = $4`,
+      [preHash, email, userId, binding.portal_user_id],
+    );
+  } else if (email) {
+    await t.none(
+      `UPDATE admin.portal_users
+       SET deactivated_at = NULL, status = 'active', email = $1, updated_by = $2
+       WHERE id = $3`,
+      [email, userId, binding.portal_user_id],
+    );
+  } else {
+    await t.none(
+      `UPDATE admin.portal_users
+       SET deactivated_at = NULL, status = 'active', updated_by = $1
+       WHERE id = $2`,
+      [userId, binding.portal_user_id],
+    );
+  }
+  await t.none(
+    `UPDATE admin.portal_user_tenants
+     SET deactivated_at = NULL, status = 'active', updated_by = $1
+     WHERE id = $2`,
+    [userId, binding.id],
+  );
+  logger.info(`Restored portal_user ${binding.portal_user_id} + binding for ${entityType} ${entityId}`);
+  return true;
+}
+
+/**
+ * High-level: enable app access for an entity. Picks the right primitive
+ * based on any prior binding state.
+ *
+ *   no binding   → provision new portal_user + binding
+ *   archived     → restore portal_user + binding (and update email/password)
+ *   active       → no-op (already enabled)
+ *   email taken  → returns 'collision' without writing (caller surfaces error)
+ *
+ * @param {Object} t
+ * @param {string} entityType
+ * @param {string} entityId
+ * @param {string} email
+ * @param {string|null} password   clear-text; bcrypted internally when no preHash
+ * @param {string} tenantId
+ * @param {string|null} userId
+ * @param {Object} [opts]
+ * @param {string} [opts.preHash]  pre-computed bcrypt hash
+ * @returns {Promise<'provisioned'|'restored'|'already_active'|'collision'>}
+ */
+export async function enableAppUser(t, entityType, entityId, email, password, tenantId, userId, opts = {}) {
+  const { preHash = null } = opts;
+  const priorBinding = await t.oneOrNone(
+    `SELECT id, portal_user_id, deactivated_at FROM admin.portal_user_tenants
+     WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3
+     ORDER BY deactivated_at IS NULL DESC, created_at DESC LIMIT 1`,
+    [entityType, entityId, tenantId],
+  );
+
+  if (priorBinding && !priorBinding.deactivated_at) return 'already_active';
+
+  if (priorBinding && priorBinding.deactivated_at) {
+    let hash = preHash;
+    if (!hash && password) {
+      const bcrypt = await import('bcrypt');
+      const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
+      hash = await bcrypt.default.hash(password, rounds);
+    }
+    await restoreAppUserBinding(t, entityType, entityId, tenantId, userId, email, hash);
+    return 'restored';
+  }
+
+  const provisioned = await provisionAppUser(t, entityType, entityId, email, password, tenantId, userId, preHash);
+  return provisioned ? 'provisioned' : 'collision';
+}
+
+/**
+ * Archive (soft-delete) the portal_user + binding linked to an entity.
+ * No-op when no active binding exists.
+ *
+ * @param {Object} t
+ * @param {string} entityType
+ * @param {string} entityId
+ * @param {string} tenantId
+ * @param {string|null} userId
+ */
+export async function archiveAppUser(t, entityType, entityId, tenantId, userId) {
+  const binding = await t.oneOrNone(
+    `SELECT id, portal_user_id FROM admin.portal_user_tenants
+     WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3 AND deactivated_at IS NULL`,
+    [entityType, entityId, tenantId],
+  );
+  if (!binding) return false;
+
+  await t.none(
+    `UPDATE admin.portal_user_tenants
+     SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+     WHERE id = $2`,
+    [userId, binding.id],
+  );
+  await t.none(
+    `UPDATE admin.portal_users
+     SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+     WHERE id = $2`,
+    [userId, binding.portal_user_id],
+  );
+  logger.info(`Archived portal_user ${binding.portal_user_id} + binding for ${entityType} ${entityId}`);
+  return true;
+}

--- a/apps/server/src/lib/employeeAppUserSync.js
+++ b/apps/server/src/lib/employeeAppUserSync.js
@@ -123,8 +123,9 @@ export async function restoreAppUserBinding(t, entityType, entityId, tenantId, u
  * High-level: enable app access for an entity. Picks the right primitive
  * based on any prior binding state.
  *
- *   no binding   → provision new portal_user + binding
- *   archived     → restore portal_user + binding (and update email/password)
+ *   no binding   → provision new portal_user + binding (password required)
+ *   archived     → restore portal_user + binding; existing password_hash is
+ *                  preserved unless caller explicitly supplies opts.preHash
  *   active       → no-op (already enabled)
  *   email taken  → returns 'collision' without writing (caller surfaces error)
  *
@@ -132,11 +133,14 @@ export async function restoreAppUserBinding(t, entityType, entityId, tenantId, u
  * @param {string} entityType
  * @param {string} entityId
  * @param {string} email
- * @param {string|null} password   clear-text; bcrypted internally when no preHash
+ * @param {string|null} password   clear-text; used ONLY when provisioning a
+ *                                 brand-new portal_user. Ignored on restore —
+ *                                 supply opts.preHash explicitly to reset.
  * @param {string} tenantId
  * @param {string|null} userId
  * @param {Object} [opts]
- * @param {string} [opts.preHash]  pre-computed bcrypt hash
+ * @param {string} [opts.preHash]  pre-computed bcrypt hash. When set on a
+ *                                 restore, overwrites the existing password.
  * @returns {Promise<'provisioned'|'restored'|'already_active'|'collision'>}
  */
 export async function enableAppUser(t, entityType, entityId, email, password, tenantId, userId, opts = {}) {
@@ -151,13 +155,10 @@ export async function enableAppUser(t, entityType, entityId, email, password, te
   if (priorBinding && !priorBinding.deactivated_at) return 'already_active';
 
   if (priorBinding && priorBinding.deactivated_at) {
-    let hash = preHash;
-    if (!hash && password) {
-      const bcrypt = await import('bcrypt');
-      const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
-      hash = await bcrypt.default.hash(password, rounds);
-    }
-    await restoreAppUserBinding(t, entityType, entityId, tenantId, userId, email, hash);
+    // Restore archived binding. Pass preHash through unchanged — null means
+    // "preserve the existing password." Callers who want a true reset must
+    // supply preHash explicitly.
+    await restoreAppUserBinding(t, entityType, entityId, tenantId, userId, email, preHash);
     return 'restored';
   }
 

--- a/apps/server/src/lib/employeeAppUserSync.js
+++ b/apps/server/src/lib/employeeAppUserSync.js
@@ -33,9 +33,11 @@ import logger from './logger.js';
  * @returns {Promise<boolean>} true on success, false on collision
  */
 export async function provisionAppUser(t, entityType, entityId, email, password, tenantId, userId, preHash = null) {
+  // Normalize email so case-only variants can't create two active portal_users.
+  const normEmail = email == null ? null : String(email).trim().toLowerCase();
   const existing = await t.oneOrNone(
-    'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
-    [email],
+    'SELECT id FROM admin.portal_users WHERE LOWER(email) = $1 AND deactivated_at IS NULL',
+    [normEmail],
   );
   if (existing) return false;
 
@@ -52,7 +54,7 @@ export async function provisionAppUser(t, entityType, entityId, email, password,
     `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
      VALUES ($1, $2, 'invited', $3)
      RETURNING id`,
-    [email, passwordHash, userId],
+    [normEmail, passwordHash, userId],
   );
   await t.none(
     `INSERT INTO admin.portal_user_tenants
@@ -87,19 +89,20 @@ export async function restoreAppUserBinding(t, entityType, entityId, tenantId, u
   );
   if (!binding) return false;
 
-  if (email && preHash) {
+  const normEmail = email == null ? null : String(email).trim().toLowerCase();
+  if (normEmail && preHash) {
     await t.none(
       `UPDATE admin.portal_users
        SET deactivated_at = NULL, status = 'invited', password_hash = $1, email = $2, updated_by = $3
        WHERE id = $4`,
-      [preHash, email, userId, binding.portal_user_id],
+      [preHash, normEmail, userId, binding.portal_user_id],
     );
-  } else if (email) {
+  } else if (normEmail) {
     await t.none(
       `UPDATE admin.portal_users
        SET deactivated_at = NULL, status = 'active', email = $1, updated_by = $2
        WHERE id = $3`,
-      [email, userId, binding.portal_user_id],
+      [normEmail, userId, binding.portal_user_id],
     );
   } else {
     await t.none(

--- a/apps/server/src/lib/employeeAppUserSync.js
+++ b/apps/server/src/lib/employeeAppUserSync.js
@@ -51,15 +51,15 @@ export async function provisionAppUser(t, entityType, entityId, email, password,
   }
 
   const inserted = await t.one(
-    `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
-     VALUES ($1, $2, 'invited', $3)
+    `INSERT INTO admin.portal_users (email, password_hash, status, created_by, updated_by)
+     VALUES ($1, $2, 'invited', $3, $3)
      RETURNING id`,
     [normEmail, passwordHash, userId],
   );
   await t.none(
     `INSERT INTO admin.portal_user_tenants
-       (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
-     VALUES ($1, $2, $3, $4, 'active', $5)`,
+       (portal_user_id, tenant_id, entity_type, entity_id, status, created_by, updated_by)
+     VALUES ($1, $2, $3, $4, 'active', $5, $5)`,
     [inserted.id, tenantId, entityType, entityId, userId],
   );
   return true;
@@ -93,28 +93,31 @@ export async function restoreAppUserBinding(t, entityType, entityId, tenantId, u
   if (normEmail && preHash) {
     await t.none(
       `UPDATE admin.portal_users
-       SET deactivated_at = NULL, status = 'invited', password_hash = $1, email = $2, updated_by = $3
+       SET deactivated_at = NULL, status = 'invited', password_hash = $1, email = $2,
+           updated_by = $3, updated_at = NOW()
        WHERE id = $4`,
       [preHash, normEmail, userId, binding.portal_user_id],
     );
   } else if (normEmail) {
     await t.none(
       `UPDATE admin.portal_users
-       SET deactivated_at = NULL, status = 'active', email = $1, updated_by = $2
+       SET deactivated_at = NULL, status = 'active', email = $1,
+           updated_by = $2, updated_at = NOW()
        WHERE id = $3`,
       [normEmail, userId, binding.portal_user_id],
     );
   } else {
     await t.none(
       `UPDATE admin.portal_users
-       SET deactivated_at = NULL, status = 'active', updated_by = $1
+       SET deactivated_at = NULL, status = 'active',
+           updated_by = $1, updated_at = NOW()
        WHERE id = $2`,
       [userId, binding.portal_user_id],
     );
   }
   await t.none(
     `UPDATE admin.portal_user_tenants
-     SET deactivated_at = NULL, status = 'active', updated_by = $1
+     SET deactivated_at = NULL, status = 'active', updated_by = $1, updated_at = NOW()
      WHERE id = $2`,
     [userId, binding.id],
   );
@@ -189,13 +192,13 @@ export async function archiveAppUser(t, entityType, entityId, tenantId, userId) 
 
   await t.none(
     `UPDATE admin.portal_user_tenants
-     SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+     SET deactivated_at = NOW(), status = 'locked', updated_by = $1, updated_at = NOW()
      WHERE id = $2`,
     [userId, binding.id],
   );
   await t.none(
     `UPDATE admin.portal_users
-     SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+     SET deactivated_at = NOW(), status = 'locked', updated_by = $1, updated_at = NOW()
      WHERE id = $2`,
     [userId, binding.portal_user_id],
   );

--- a/apps/server/src/lib/employeeRoleValidator.js
+++ b/apps/server/src/lib/employeeRoleValidator.js
@@ -1,0 +1,61 @@
+/**
+ * @file Validate role codes assigned to an app-user employee
+ * @module server/lib/employeeRoleValidator
+ *
+ * Ensures every role code on an employee (or client) about to gain app
+ * access exists in the tenant's `roles` table and is active. Used by both
+ * the controllers and the flat-import reconciler so the rule is enforced
+ * everywhere a portal_user is provisioned.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+// Lazy-load pgp to avoid module-load-order cycles with the pg-schemata
+// repositories map (db.js → repositories → modules → controllers → here).
+let _pgp;
+async function getPgp() {
+  if (!_pgp) {
+    const mod = await import('../db/db.js');
+    _pgp = mod.pgp;
+  }
+  return _pgp;
+}
+
+/**
+ * Validate a roles array against the tenant's active roles table.
+ *
+ * @param {Object}    tOrDb         pg-promise transaction OR db handle
+ * @param {string}    schema        tenant schema name
+ * @param {string[]}  roles         the roles[] value to validate
+ * @returns {Promise<{ok: true} | {ok: false, code: 'empty'|'unknown', error: string, invalid?: string[]}>}
+ */
+export async function validateEmployeeRoles(tOrDb, schema, roles) {
+  const arr = Array.isArray(roles)
+    ? roles.map((r) => (r == null ? '' : String(r).trim())).filter((r) => r !== '')
+    : [];
+
+  if (!arr.length) {
+    return {
+      ok: false,
+      code: 'empty',
+      error: 'Roles must be assigned before enabling app user access',
+    };
+  }
+
+  const pgp = await getPgp();
+  const s = pgp.as.name(schema);
+  // `roles` is configured with softDelete: false — no deactivated_at column.
+  const validRows = await tOrDb.any(`SELECT code FROM ${s}.roles`);
+  const valid = new Set(validRows.map((r) => String(r.code).toLowerCase()));
+  const invalid = arr.filter((r) => !valid.has(r.toLowerCase()));
+
+  if (invalid.length) {
+    return {
+      ok: false,
+      code: 'unknown',
+      invalid,
+      error: `Unknown role code${invalid.length > 1 ? 's' : ''}: ${invalid.join(', ')}`,
+    };
+  }
+  return { ok: true };
+}

--- a/apps/server/src/lib/employeeRoleValidator.js
+++ b/apps/server/src/lib/employeeRoleValidator.js
@@ -1,11 +1,11 @@
 /**
- * @file Validate role codes assigned to an app-user employee
+ * @file Validate role codes assigned to an employee/client
  * @module server/lib/employeeRoleValidator
  *
- * Ensures every role code on an employee (or client) about to gain app
- * access exists in the tenant's `roles` table and is active. Used by both
- * the controllers and the flat-import reconciler so the rule is enforced
- * everywhere a portal_user is provisioned.
+ * Ensures every role code on an employee (or client) exists in the tenant's
+ * `roles` table. Used by both the controllers and the flat-import reconciler
+ * so the rule is enforced everywhere a record is created or updated —
+ * regardless of `is_app_user` state, so a roleless record never exists.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
@@ -38,7 +38,7 @@ export async function validateEmployeeRoles(tOrDb, schema, roles) {
     return {
       ok: false,
       code: 'empty',
-      error: 'Roles must be assigned before enabling app user access',
+      error: 'At least one role must be assigned',
     };
   }
 

--- a/apps/server/src/lib/loginEmailSync.js
+++ b/apps/server/src/lib/loginEmailSync.js
@@ -1,0 +1,102 @@
+/**
+ * @file Login email + portal_users sync service
+ * @module server/lib/loginEmailSync
+ *
+ * Shared business rules for keeping `admin.portal_users.email` in sync with
+ * the per-tenant `emails` row flagged `is_login = true`. Used by both the
+ * emails controller (single-row CRUD) and the flat-import reconciler (bulk
+ * spreadsheet imports). Functions are pure of req/res — callers pass plain
+ * arguments and a transaction handle (or `db` for outside-tx use).
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+// Lazy-load db/pgp to avoid module-load-order issues with the pg-schemata
+// repositories map (db.js → repositories → moduleRegistry → models → this
+// module would be a cycle if imported eagerly).
+let _pgp;
+async function getPgp() {
+  if (!_pgp) {
+    const mod = await import('../db/db.js');
+    _pgp = mod.pgp;
+  }
+  return _pgp;
+}
+
+/** Tenant schema entity table for each polymorphic source_type. */
+export const ENTITY_TABLE_BY_SOURCE_TYPE = {
+  employee: 'employees',
+  client: 'clients',
+  vendor_contact: 'vendor_contacts',
+};
+
+/**
+ * Update `admin.portal_users.email` for the binding linked to (sourceId,
+ * tenantId). No-op when no binding exists or the source_type isn't one of
+ * the login-bearing entities. Throws on actual DB errors so callers can
+ * surface them.
+ *
+ * @param {Object} tOrDb       pg-promise transaction OR the db instance
+ * @param {string} schema      tenant schema name (used for the sources lookup)
+ * @param {string} sourceId    polymorphic source id
+ * @param {string} email       new login email value
+ * @param {Object} opts
+ * @param {string} opts.tenantId  the tenant that owns the binding to update
+ * @param {string} [opts.userId]  caller user id for updated_by audit
+ */
+export async function syncLoginEmail(tOrDb, schema, sourceId, email, opts) {
+  const { tenantId, userId = null } = opts || {};
+  if (!tenantId) return;
+  const pgp = await getPgp();
+  const s = pgp.as.name(schema);
+
+  const source = await tOrDb.oneOrNone(
+    `SELECT table_id, source_type FROM ${s}.sources WHERE id = $1 AND deactivated_at IS NULL`,
+    [sourceId],
+  );
+  if (!source) return;
+  if (!ENTITY_TABLE_BY_SOURCE_TYPE[source.source_type]) return;
+
+  const binding = await tOrDb.oneOrNone(
+    `SELECT portal_user_id FROM admin.portal_user_tenants
+     WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3 AND deactivated_at IS NULL`,
+    [source.source_type, source.table_id, tenantId],
+  );
+  if (!binding) return;
+
+  await tOrDb.none(
+    `UPDATE admin.portal_users SET email = $1, updated_by = $2
+     WHERE id = $3 AND deactivated_at IS NULL`,
+    [email, userId, binding.portal_user_id],
+  );
+}
+
+/**
+ * True when the entity linked to `sourceId` is NOT an active app user — i.e.
+ * the `is_login` flag can be safely cleared without breaking a live login.
+ * Returns true when there is no matching source/entity (defensive: nothing
+ * to break).
+ *
+ * @param {Object} tOrDb   pg-promise transaction OR the db instance
+ * @param {string} schema  tenant schema name
+ * @param {string} sourceId
+ * @returns {Promise<boolean>}
+ */
+export async function canUnsetLogin(tOrDb, schema, sourceId) {
+  const pgp = await getPgp();
+  const s = pgp.as.name(schema);
+  const source = await tOrDb.oneOrNone(
+    `SELECT table_id, source_type FROM ${s}.sources WHERE id = $1 AND deactivated_at IS NULL`,
+    [sourceId],
+  );
+  if (!source) return true;
+  const table = ENTITY_TABLE_BY_SOURCE_TYPE[source.source_type];
+  if (!table) return true;
+
+  const entity = await tOrDb.oneOrNone(
+    `SELECT is_app_user FROM ${s}.${table} WHERE id = $1 AND deactivated_at IS NULL`,
+    [source.table_id],
+  );
+  return !entity?.is_app_user;
+}
+

--- a/apps/server/src/lib/loginEmailSync.js
+++ b/apps/server/src/lib/loginEmailSync.js
@@ -64,10 +64,13 @@ export async function syncLoginEmail(tOrDb, schema, sourceId, email, opts) {
   );
   if (!binding) return;
 
+  // Normalize the new login email so case-only variants can't bypass the
+  // case-sensitive unique index on admin.portal_users.email.
+  const normEmail = email == null ? null : String(email).trim().toLowerCase();
   await tOrDb.none(
     `UPDATE admin.portal_users SET email = $1, updated_by = $2
      WHERE id = $3 AND deactivated_at IS NULL`,
-    [email, userId, binding.portal_user_id],
+    [normEmail, userId, binding.portal_user_id],
   );
 }
 

--- a/apps/server/src/lib/loginEmailSync.js
+++ b/apps/server/src/lib/loginEmailSync.js
@@ -68,7 +68,7 @@ export async function syncLoginEmail(tOrDb, schema, sourceId, email, opts) {
   // case-sensitive unique index on admin.portal_users.email.
   const normEmail = email == null ? null : String(email).trim().toLowerCase();
   await tOrDb.none(
-    `UPDATE admin.portal_users SET email = $1, updated_by = $2
+    `UPDATE admin.portal_users SET email = $1, updated_by = $2, updated_at = NOW()
      WHERE id = $3 AND deactivated_at IS NULL`,
     [normEmail, userId, binding.portal_user_id],
   );

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -900,6 +900,19 @@ export async function importSourceEntity(model, filePath, _sheetIndex, callbackF
           return rest;
         });
 
+        // When tenant numbering is enabled for this entity type, strip any
+        // codes typed into the spreadsheet — the configured sequence is the
+        // single source of truth for bulk imports.
+        if (config.idType) {
+          const cfg = await t.oneOrNone(
+            `SELECT is_enabled FROM ${s}.tenant_numbering_config WHERE id_type = $1`,
+            [config.idType],
+          );
+          if (cfg?.is_enabled) {
+            for (const row of cleanInserts) row.code = null;
+          }
+        }
+
         // Clear codes that already exist to avoid unique constraint violations
         if (!config.codeRequired) {
           const insertCodes = cleanInserts.map((r) => r.code).filter(Boolean);
@@ -928,6 +941,7 @@ export async function importSourceEntity(model, filePath, _sheetIndex, callbackF
           source_type: config.sourceType,
           label: config.buildLabel(rec),
           created_by: createdBy,
+          updated_by: createdBy,
         }));
 
         const sourceResults = await sourcesModel.bulkInsert(sourceRecords, ['id', 'table_id']);
@@ -1652,19 +1666,16 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
     }
   }
 
-  // Role validation for any group whose entity will end up an app user.
-  // Empty roles[] OR unknown role codes are blocking errors — both controller
-  // and importer paths must reject before provisioning a portal_user that
-  // could log in but have no policies.
-  if (config.appUserProvisioning) {
+  // Role validation. Empty roles[] OR unknown role codes are blocking errors
+  // for every employee/client parent — not just app users — so a roleless
+  // record cannot be created via import regardless of is_app_user state.
+  if (config.appUserProvisioning && config.hasRoles) {
     // `roles` is softDelete: false — query all rows, no deactivated_at filter.
     const validRows = await db.any(`SELECT code FROM ${s}.roles`);
     const validCodes = new Set(validRows.map((r) => String(r.code).toLowerCase()));
     for (const group of groups) {
       const incoming = group._transformedParent || {};
       const existing = group._ownEntity || null;
-      const willBeAppUser = 'is_app_user' in incoming ? !!incoming.is_app_user : !!existing?.is_app_user;
-      if (!willBeAppUser) continue;
 
       const finalRoles = incoming.roles !== undefined ? incoming.roles : existing?.roles;
       const arr = Array.isArray(finalRoles)
@@ -1749,6 +1760,16 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
 
       // ── Phase 2: Run updates ───────────────────────────────────────────
       const userId = sampleRow.created_by || null;
+      // Resolve numbering state once for the update phase too (same rule as
+      // inserts: when numbering is on, the sequence is authoritative).
+      let updateNumberingEnabled = false;
+      if (config.idType) {
+        const cfg = await t.oneOrNone(
+          `SELECT is_enabled FROM ${s}.tenant_numbering_config WHERE id_type = $1`,
+          [config.idType],
+        );
+        updateNumberingEnabled = !!cfg?.is_enabled;
+      }
       for (const { transformed, isArchived, group } of toUpdate) {
         const { id } = transformed;
         const before = group._ownEntity;
@@ -1757,6 +1778,10 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
         const willBeAppUser = 'is_app_user' in transformed ? !!transformed.is_app_user : wasAppUser;
 
         const changes = _diffParent(transformed, before);
+        // Numbering on → ignore any code change attempted via the import.
+        // Codes for existing rows are owned by the numbering allocator (set
+        // once, never rewritten through the import path).
+        if (updateNumberingEnabled && 'code' in changes) delete changes.code;
         if (Object.keys(changes).length > 0) {
           // Stamp audit fields on every real write. We add them after the diff
           // so they don't themselves trigger NO-OP-failing updates. pg-schemata's
@@ -1777,6 +1802,17 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
           await t.none(`UPDATE ${s}.${tbl} SET deactivated_at = NULL WHERE id = $1 AND deactivated_at IS NOT NULL`, [
             id,
           ]);
+        }
+
+        // If the entity has no code and the import didn't supply one, allocate
+        // from the tenant's numbering config. Mirrors the INSERT-path behavior
+        // so existing employees who predate the numbering rollout (or were
+        // imported before numbering was enabled) get codes on re-import.
+        if (config.idType && !before.code && !transformed.code) {
+          const numbering = await allocateNumber(schema, config.idType, null, new Date(), t);
+          if (numbering) {
+            await t.none(`UPDATE ${s}.${tbl} SET code = $1 WHERE id = $2`, [numbering.displayId, id]);
+          }
         }
 
         // Reconcile children for this entity (slot-keyed, NO-OPs preserved)
@@ -1831,15 +1867,31 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
         }
       }
 
+      // Determine whether tenant numbering is enabled for this entity type.
+      // When it is, the configured sequence is authoritative for bulk imports:
+      // any code typed into the spreadsheet is discarded and replaced with
+      // the next number from the allocator.
+      let numberingEnabled = false;
+      if (config.idType) {
+        const cfg = await t.oneOrNone(
+          `SELECT is_enabled FROM ${s}.tenant_numbering_config WHERE id_type = $1`,
+          [config.idType],
+        );
+        numberingEnabled = !!cfg?.is_enabled;
+      }
+
       // ── Phase 3: Run inserts ───────────────────────────────────────────
       if (toInsert.length) {
         const cleanInserts = toInsert.map(({ transformed }) => {
           const { id: _id, ...clean } = transformed;
           if (typeof clean.code === 'string' && !clean.code.trim()) clean.code = null;
+          // Numbering on → strip supplied codes so the allocator can fill them in.
+          if (numberingEnabled) clean.code = null;
           return clean;
         });
 
-        // Clear codes that already exist in the DB
+        // Clear codes that already exist in the DB (only relevant when the
+        // spreadsheet's codes survived the numbering-enabled strip above).
         if (!config.codeRequired) {
           const insertCodes = cleanInserts.map((r) => r.code).filter(Boolean);
           if (insertCodes.length) {
@@ -1866,6 +1918,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
           source_type: config.sourceType,
           label: config.buildLabel(rec),
           created_by: createdBy,
+          updated_by: createdBy,
         }));
         const sourceResults = await sourcesModel.bulkInsert(sourceRecords, ['id', 'table_id']);
         const sourceByParentId = new Map(sourceResults.map((sr) => [sr.table_id, sr.id]));

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -12,6 +12,8 @@
 import { writeFileSync, readFileSync } from 'node:fs';
 import { allocateNumber, allocateNumbers } from '../system/core/services/numberingService.js';
 import { stripFormatting, formatByPattern, COUNTRIES, TAX_TYPES } from '@axerra/shared';
+import { syncLoginEmail } from './loginEmailSync.js';
+import { archiveAppUser, restoreAppUserBinding, enableAppUser } from './employeeAppUserSync.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -432,63 +434,108 @@ export async function validateImportGroups(groups, opts) {
  * @returns {Promise<Object[]>} Array of validation errors (empty = no collisions)
  */
 export async function checkPortalUserEmailCollisions(groups, opts) {
-  const { sheetName, entityType } = opts;
+  const { sheetName, entityType, ownEntities, tenantId } = opts;
   if (!groups?.length) return [];
 
   // vendor_contact bind-existing flow runs in the controller — don't pay
   // for a DB query whose result we'd discard.
   if (entityType === 'vendor_contact') return [];
 
-  // Collect login emails for *new* app-user parents only. Updates and
-  // non-app-users never provision a portal_user, so they can't collide.
+  const isAppUserFlag = (v) => v === true || v === 1 || (typeof v === 'string' && v.toLowerCase() === 'true');
+  const isLoginFlag = (v) => v === true || v === 1 || (typeof v === 'string' && v.toLowerCase() === 'true');
+  const hasOwnEntities = ownEntities && typeof ownEntities.get === 'function';
+
+  // Collect login emails for any group whose entity will end up an app user.
+  //
+  //   INSERT case: parent.id non-UUID (or UUID without a DB row when
+  //     ownEntities is provided), parent.is_app_user truthy → new portal_user
+  //     will be provisioned with this login email; check for collision.
+  //
+  //   UPDATE case (only when ownEntities is supplied): existing entity's
+  //     portal_user.email may sync to the new value. Check for collision but
+  //     exclude self.
+  //
+  // Legacy callers that don't pass ownEntities preserve the original behavior:
+  // skip UUID-id parents entirely (treated as round-trip updates).
   const loginEmailRows = [];
+  const updatingEntityIds = new Set();
   for (const group of groups) {
     const parent = group.parent || {};
-    // parent.id is a UUID → existing entity → row is an update → existing
-    // portal_user already owns this email; skip. Non-UUID id values are
-    // just spreadsheet linkage refs for new rows and don't disqualify.
-    if (isUuid(parent.id)) continue;
-    // is_app_user falsy → no portal_user will be provisioned; skip.
-    const isAppUser = parent.is_app_user === true || parent.is_app_user === 1 || (typeof parent.is_app_user === 'string' && parent.is_app_user.toLowerCase() === 'true');
-    if (!isAppUser) continue;
+    let existing = null;
+    if (hasOwnEntities) {
+      existing = ownEntities.get(parent.id) || null;
+    } else if (isUuid(parent.id)) {
+      // Legacy path: existing entity → updates are not checked here.
+      continue;
+    }
+
+    let willBeAppUser;
+    if (existing) {
+      const incoming = parent.is_app_user;
+      willBeAppUser = incoming === undefined || incoming === '' ? !!existing.is_app_user : isAppUserFlag(incoming);
+    } else {
+      willBeAppUser = isAppUserFlag(parent.is_app_user);
+    }
+    if (!willBeAppUser) continue;
+
+    if (existing) updatingEntityIds.add(existing.id);
 
     for (const child of group.children?.emails || []) {
       if (!child?.email) continue;
-      // is_login may arrive as boolean, the string 'true', or 1
-      const isLogin = child.is_login === true || child.is_login === 1 || (typeof child.is_login === 'string' && child.is_login.toLowerCase() === 'true');
-      if (!isLogin) continue;
-      // Only do the lookup for plausibly valid emails — invalid format is
-      // already flagged separately and would skew the IN-list.
+      if (!isLoginFlag(child.is_login)) continue;
       if (!EMAIL_RE.test(child.email)) continue;
       loginEmailRows.push({
         email: String(child.email).trim().toLowerCase(),
         row: child._rowNum || null,
+        ownEntityId: existing?.id || null,
       });
     }
   }
   if (!loginEmailRows.length) return [];
 
-  const uniqueEmails = [...new Set(loginEmailRows.map((r) => r.email))];
   const { db } = await getDb();
-  const existing = await db.manyOrNone(
-    `SELECT LOWER(email) AS email FROM admin.portal_users
+
+  // Resolve own portal_user_ids for entities being updated in this import,
+  // so the cross-tenant collision check can skip self-matches.
+  const selfPortalUserIds = new Set();
+  if (updatingEntityIds.size && tenantId) {
+    const rows = await db.manyOrNone(
+      `SELECT portal_user_id FROM admin.portal_user_tenants
+       WHERE entity_type = $1 AND tenant_id = $2 AND entity_id IN ($3:csv) AND deactivated_at IS NULL`,
+      [entityType, tenantId, [...updatingEntityIds]],
+    );
+    if (rows?.length) for (const r of rows) selfPortalUserIds.add(r.portal_user_id);
+  }
+
+  const uniqueEmails = [...new Set(loginEmailRows.map((r) => r.email))];
+  const existingPortalUsers = await db.manyOrNone(
+    `SELECT id, LOWER(email) AS email FROM admin.portal_users
      WHERE LOWER(email) = ANY($1::text[]) AND deactivated_at IS NULL`,
     [uniqueEmails],
   );
-  if (!existing.length) return [];
+  if (!existingPortalUsers?.length) return [];
 
-  const taken = new Set(existing.map((r) => r.email));
+  // Build a map of email → portal_user_ids that hold it.
+  const holdersByEmail = new Map();
+  for (const r of existingPortalUsers) {
+    if (!holdersByEmail.has(r.email)) holdersByEmail.set(r.email, new Set());
+    holdersByEmail.get(r.email).add(r.id);
+  }
+
   const errors = [];
-  for (const { email, row } of loginEmailRows) {
-    if (taken.has(email)) {
-      errors.push({
-        sheet: sheetName,
-        row,
-        column: 'email',
-        value: email,
-        message: `Login email ${email} is already in use by another portal user. Single-tenant entities cannot share login identity.`,
-      });
-    }
+  for (const { email, row, ownEntityId } of loginEmailRows) {
+    const holders = holdersByEmail.get(email);
+    if (!holders || !holders.size) continue;
+    const otherHolders = [...holders].filter((id) => !selfPortalUserIds.has(id));
+    if (!otherHolders.length) continue;
+    void ownEntityId;
+    errors.push({
+      sheet: sheetName,
+      row,
+      column: 'email',
+      value: email,
+      message: `Login email ${email} is already in use by another portal user. Single-tenant entities cannot share login identity.`,
+    });
   }
   return errors;
 }
@@ -1419,13 +1466,8 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
   }
   for (const e of validateChildEnums(groups, { sheetName, childEnums })) pushIssue(errors, e);
 
-  // Cross-tenant portal_user collision check (Part 2 of import dedup spec)
-  const provisionEntityType = config.appUserProvisioning?.entityType;
-  if (provisionEntityType === 'employee' || provisionEntityType === 'client') {
-    for (const e of await checkPortalUserEmailCollisions(groups, { sheetName, entityType: provisionEntityType })) {
-      pushIssue(errors, e);
-    }
-  }
+  // Cross-tenant portal_user collision check moved to after _resolveOwnEntities
+  // (below) so it can include update-case collisions and exclude self.
 
   // Validate no duplicate codes
   const codeCounts = new Map();
@@ -1539,6 +1581,91 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
     group._transformedParent = await _transformParent(group, callbackFn, tenantId, config, STRIP_COLS);
   }
 
+  // Login-email pre-checks: load existing email rows for any updating source.
+  // Used by L2 (can't unset is_login while app user) and L4 (final state can
+  // have at most one is_login=true row per source).
+  const emailsCfg = config.flat.children.find((c) => c.key === 'emails');
+  if (emailsCfg) {
+    const sourceIdsForCheck = groups.map((g) => g._ownSourceId).filter(Boolean);
+    const existingEmailsBySource = await _loadEmailsBySource(db, s, pgp, schema, emailsCfg, sourceIdsForCheck);
+
+    for (const group of groups) {
+      const incoming = group.children.emails || [];
+      if (!incoming.length && !group._ownEntity) continue;
+      const existingRows = group._ownSourceId ? existingEmailsBySource.get(group._ownSourceId) || [] : [];
+      const existingBySlot = new Map();
+      for (const ex of existingRows) {
+        const k = _computeSlotKey(ex, emailsCfg);
+        if (k != null) existingBySlot.set(k, ex);
+      }
+
+      // L2: incoming is_login: false on a row whose existing was is_login: true
+      // AND the entity remains an app user post-import → blocking error.
+      const postImportIsAppUser =
+        group._transformedParent && 'is_app_user' in group._transformedParent
+          ? !!group._transformedParent.is_app_user
+          : !!group._ownEntity?.is_app_user;
+
+      for (const child of incoming) {
+        const slot = _computeSlotKey(child, emailsCfg);
+        if (slot == null) continue;
+        const existing = existingBySlot.get(slot);
+        if (!existing || existing.is_login !== true) continue;
+        const incomingLogin = _truthyFlag(child.is_login);
+        if (incomingLogin) continue; // not unsetting
+        if (postImportIsAppUser) {
+          pushIssue(errors, {
+            sheet: sheetName,
+            row: child._rowNum || null,
+            column: 'is_login',
+            value: 'false',
+            message: 'Cannot remove the login flag while the entity is an active app user. Disable app access first.',
+          });
+        }
+      }
+
+      // L4: count final is_login: true rows per source after the file is applied.
+      // Start from existing rows, then apply incoming overrides (by slot) and inserts.
+      const finalLogin = new Map(); // slot → boolean
+      for (const ex of existingRows) {
+        const k = _computeSlotKey(ex, emailsCfg);
+        if (k != null) finalLogin.set(k, ex.is_login === true);
+      }
+      for (const child of incoming) {
+        const slot = _computeSlotKey(child, emailsCfg);
+        if (slot == null) continue;
+        finalLogin.set(slot, _truthyFlag(child.is_login));
+      }
+      const loginSlots = [...finalLogin.entries()].filter(([, v]) => v === true).map(([k]) => k);
+      if (loginSlots.length > 1) {
+        // Find the incoming row(s) that contributed to the over-count for row-keyed errors.
+        const incomingLoginRows = incoming.filter((c) => _truthyFlag(c.is_login));
+        const target = incomingLoginRows[incomingLoginRows.length - 1] || incomingLoginRows[0];
+        pushIssue(errors, {
+          sheet: sheetName,
+          row: target?._rowNum || null,
+          column: 'is_login',
+          value: 'true',
+          message: `Only one login email is allowed per entity. ${loginSlots.length} rows would end up with is_login = true (slots: ${loginSlots.join(', ')}).`,
+        });
+      }
+    }
+  }
+
+  // Cross-tenant portal_user collision check (insert + update cases). Runs
+  // after _resolveOwnEntities so it can exclude the entity's own portal_user.
+  const provisionEntityType = config.appUserProvisioning?.entityType;
+  if (provisionEntityType === 'employee' || provisionEntityType === 'client') {
+    for (const e of await checkPortalUserEmailCollisions(groups, {
+      sheetName,
+      entityType: provisionEntityType,
+      ownEntities,
+      tenantId,
+    })) {
+      pushIssue(errors, e);
+    }
+  }
+
   // Cross-source value collision pre-check (R8). Runs against db (not in tx yet).
   await _collectCrossSourceConflicts(db, s, pgp, schema, config.sourceType, groups, config.flat.children, sheetName, errors);
 
@@ -1579,9 +1706,15 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
       }
 
       // ── Phase 2: Run updates ───────────────────────────────────────────
+      const userId = sampleRow.created_by || null;
       for (const { transformed, isArchived, group } of toUpdate) {
         const { id } = transformed;
-        const changes = _diffParent(transformed, group._ownEntity);
+        const before = group._ownEntity;
+        const wasArchived = !!before.deactivated_at;
+        const wasAppUser = !!before.is_app_user;
+        const willBeAppUser = 'is_app_user' in transformed ? !!transformed.is_app_user : wasAppUser;
+
+        const changes = _diffParent(transformed, before);
         if (Object.keys(changes).length > 0) {
           await model.updateWhere([{ id }], changes, { includeDeactivated: true });
           updatedCount++;
@@ -1602,6 +1735,51 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
         const sourceId = group._ownSourceId;
         if (sourceId) {
           await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, group.children, config.flat.children, callbackFn, tenantId);
+        }
+
+        // ── Login email portal_users sync (L1) ───────────────────────────
+        // Find the live login email after reconcile and sync portal_users.
+        if (sourceId && config.appUserProvisioning && willBeAppUser && !isArchived) {
+          const loginRow = await t.oneOrNone(
+            `SELECT email FROM ${s}.emails WHERE source_id = $1 AND is_login = true AND deactivated_at IS NULL LIMIT 1`,
+            [sourceId],
+          );
+          if (loginRow?.email) {
+            await syncLoginEmail(t, schema, sourceId, loginRow.email, { tenantId, userId });
+          }
+        }
+
+        // ── Parent-state cascades to portal_users (L2b) ─────────────────
+        if (config.appUserProvisioning) {
+          const entityType = config.appUserProvisioning.entityType;
+
+          // Active → archived: lock the portal_user
+          if (!wasArchived && isArchived && wasAppUser) {
+            await archiveAppUser(t, entityType, id, tenantId, userId);
+          }
+
+          // Archived → active: restore the portal_user (if it was app user)
+          if (wasArchived && !isArchived && wasAppUser) {
+            await restoreAppUserBinding(t, entityType, id, tenantId, userId);
+          }
+
+          // is_app_user true → false (not via archive — handled above): archive portal_user
+          if (!isArchived && wasAppUser && !willBeAppUser) {
+            await archiveAppUser(t, entityType, id, tenantId, userId);
+          }
+
+          // is_app_user false → true: provision or restore portal_user
+          if (!isArchived && !wasAppUser && willBeAppUser) {
+            const loginRow = await t.oneOrNone(
+              `SELECT email FROM ${s}.emails WHERE source_id = $1 AND is_login = true AND deactivated_at IS NULL LIMIT 1`,
+              [sourceId],
+            );
+            if (loginRow?.email) {
+              const crypto = await import('node:crypto');
+              const password = crypto.randomBytes(12).toString('base64url');
+              await enableAppUser(t, entityType, id, loginRow.email, password, tenantId, userId);
+            }
+          }
         }
       }
 
@@ -1817,6 +1995,37 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
   }
 
   return { inserts, updates, noops, omitted };
+}
+
+/**
+ * Coerce a spreadsheet boolean-ish cell value to a JS true/false. Accepts
+ * native booleans, the strings 'true' / 'false' (any case), and 1/0.
+ * @private
+ */
+function _truthyFlag(v) {
+  return v === true || v === 1 || (typeof v === 'string' && v.toLowerCase() === 'true');
+}
+
+/**
+ * Batch-load active email rows for the given source_ids and group them by
+ * source_id. Used by the email-specific pre-validation block.
+ * @private
+ */
+async function _loadEmailsBySource(db, s, pgp, schema, cfg, sourceIds) {
+  const out = new Map();
+  if (!sourceIds.length) return out;
+  const childModel = db(cfg.modelName, schema);
+  const tableName = childModel._schema?.table || cfg.modelName;
+  const tName = pgp.as.name(tableName);
+  const rows = await db.any(
+    `SELECT * FROM ${s}.${tName} WHERE source_id IN ($1:csv) AND deactivated_at IS NULL`,
+    [sourceIds],
+  );
+  for (const r of rows) {
+    if (!out.has(r.source_id)) out.set(r.source_id, []);
+    out.get(r.source_id).push(r);
+  }
+  return out;
 }
 
 /**

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -515,13 +515,38 @@ export async function checkPortalUserEmailCollisions(groups, opts) {
     if (rows?.length) for (const r of rows) selfPortalUserIds.add(r.portal_user_id);
   }
 
+  const errors = [];
+
+  // Intra-file collision: two or more rows in the same file claim the same
+  // login email. Caught here rather than in the DB pass because both rows
+  // would be "new" or not-yet-bound and the cross-tenant check can't see
+  // them. Emit an error keyed to each offending row so the user can fix all
+  // collisions in one pass.
+  const rowsByEmail = new Map();
+  for (const lr of loginEmailRows) {
+    if (!rowsByEmail.has(lr.email)) rowsByEmail.set(lr.email, []);
+    rowsByEmail.get(lr.email).push(lr);
+  }
+  for (const [email, dupes] of rowsByEmail) {
+    if (dupes.length < 2) continue;
+    for (const lr of dupes) {
+      errors.push({
+        sheet: sheetName,
+        row: lr.row,
+        column: 'email',
+        value: email,
+        message: `Login email ${email} appears on multiple rows in this file. Each app-user employee must have a unique login email.`,
+      });
+    }
+  }
+
   const uniqueEmails = [...new Set(loginEmailRows.map((r) => r.email))];
   const existingPortalUsers = await db.manyOrNone(
     `SELECT id, LOWER(email) AS email FROM admin.portal_users
      WHERE LOWER(email) = ANY($1::text[]) AND deactivated_at IS NULL`,
     [uniqueEmails],
   );
-  if (!existingPortalUsers?.length) return [];
+  if (!existingPortalUsers?.length) return errors;
 
   // Build a map of email → portal_user_ids that hold it.
   const holdersByEmail = new Map();
@@ -530,7 +555,6 @@ export async function checkPortalUserEmailCollisions(groups, opts) {
     holdersByEmail.get(r.email).add(r.id);
   }
 
-  const errors = [];
   for (const { email, row, ownEntityId } of loginEmailRows) {
     const holders = holdersByEmail.get(email);
     if (!holders || !holders.size) continue;
@@ -1811,6 +1835,70 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
     }
   }
 
+  // Provisioning a new portal_user requires a password. Without one the writer
+  // would generate a random hash nobody can sign in with (silent footgun). Block
+  // when:
+  //   - INSERT + is_app_user=true + password blank, OR
+  //   - UPDATE toggling is_app_user false→true with no archived prior binding
+  //     to restore, + password blank.
+  if (config.appUserProvisioning) {
+    const entityType = config.appUserProvisioning.entityType;
+    // Build the set of entity_ids whose prior binding exists (archived OR
+    // active) — those entities can restore without a password.
+    const toggleOnIds = [];
+    for (const group of groups) {
+      if (!group._ownEntity) continue;
+      const incoming = group._transformedParent || {};
+      const willBeAppUser = 'is_app_user' in incoming ? !!incoming.is_app_user : !!group._ownEntity.is_app_user;
+      if (willBeAppUser && !group._ownEntity.is_app_user) toggleOnIds.push(group._ownEntity.id);
+    }
+    let restorableSet = new Set();
+    if (toggleOnIds.length && tenantId) {
+      const rows = await db.manyOrNone(
+        `SELECT entity_id FROM admin.portal_user_tenants
+         WHERE entity_type = $1 AND tenant_id = $2 AND entity_id IN ($3:csv)`,
+        [entityType, tenantId, toggleOnIds],
+      );
+      restorableSet = new Set((rows || []).map((r) => r.entity_id));
+    }
+
+    for (const group of groups) {
+      const incoming = group._transformedParent || {};
+      const existing = group._ownEntity || null;
+      const willBeAppUser = 'is_app_user' in incoming ? !!incoming.is_app_user : !!existing?.is_app_user;
+      if (!willBeAppUser) continue;
+
+      const passwordSupplied = !!(group.parent.password && String(group.parent.password).trim());
+      if (passwordSupplied) continue;
+
+      // INSERT path → always require a password.
+      if (!existing) {
+        pushIssue(errors, {
+          sheet: sheetName,
+          row: group.parent._rowNum || null,
+          column: 'password',
+          value: '',
+          message: 'A password is required to provision a new app user.',
+        });
+        continue;
+      }
+
+      // UPDATE path: only require a password when toggling on with no prior
+      // binding (no portal_user to restore). Already-active app users and
+      // archived-binding restores are both fine with a blank cell.
+      const wasAppUser = !!existing.is_app_user;
+      if (!wasAppUser && !restorableSet.has(existing.id)) {
+        pushIssue(errors, {
+          sheet: sheetName,
+          row: group.parent._rowNum || null,
+          column: 'password',
+          value: '',
+          message: 'A password is required to enable app user access.',
+        });
+      }
+    }
+  }
+
   // Cross-tenant portal_user collision check (insert + update cases). Runs
   // after _resolveOwnEntities so it can exclude the entity's own portal_user.
   const provisionEntityType = config.appUserProvisioning?.entityType;
@@ -1893,7 +1981,13 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
         // so the count + audit-field stamping fires even when no other column
         // changed (e.g. a re-import that only flips status active→archived).
         const archiveChanged = isArchived !== wasArchived;
-        if (Object.keys(changes).length > 0 || archiveChanged) {
+        // Password rotation on an active app user has the same shape — the
+        // password column is stripped from `changes` but the writer rotates
+        // the portal_user's hash below. Count it as an update.
+        const passwordSupplied =
+          !!(group.parent.password && String(group.parent.password).trim());
+        const passwordRotation = passwordSupplied && !isArchived && wasAppUser && willBeAppUser;
+        if (Object.keys(changes).length > 0 || archiveChanged || passwordRotation) {
           // Stamp audit fields on every real write. We add them after the diff
           // so they don't themselves trigger NO-OP-failing updates. pg-schemata's
           // `updateWhere` does not auto-bump updated_at (unlike its singular
@@ -2173,7 +2267,17 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
     const willBeArchived = String(group.parent.status || '').toLowerCase() === 'archived';
     const wasArchived = !!existing.deactivated_at;
     const archiveChanged = willBeArchived !== wasArchived;
-    if (Object.keys(changes).length > 0 || archiveChanged) updates += 1;
+    // Password rotation: `password` is stripped from _transformedParent. The
+    // writer rotates the portal_user's password_hash for an active app user
+    // when this cell is non-blank — count that as an update too.
+    const passwordSupplied =
+      !!(group.parent.password && String(group.parent.password).trim());
+    const willBeAppUser =
+      'is_app_user' in (group._transformedParent || {})
+        ? !!group._transformedParent.is_app_user
+        : !!existing.is_app_user;
+    const passwordRotation = passwordSupplied && !willBeArchived && existing.is_app_user && willBeAppUser;
+    if (Object.keys(changes).length > 0 || archiveChanged || passwordRotation) updates += 1;
     else noops += 1;
   }
 

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -495,7 +495,6 @@ export async function checkPortalUserEmailCollisions(groups, opts) {
       loginEmailRows.push({
         email: String(child.email).trim().toLowerCase(),
         row: child._rowNum || null,
-        ownEntityId: existing?.id || null,
       });
     }
   }
@@ -555,12 +554,11 @@ export async function checkPortalUserEmailCollisions(groups, opts) {
     holdersByEmail.get(r.email).add(r.id);
   }
 
-  for (const { email, row, ownEntityId } of loginEmailRows) {
+  for (const { email, row } of loginEmailRows) {
     const holders = holdersByEmail.get(email);
     if (!holders || !holders.size) continue;
     const otherHolders = [...holders].filter((id) => !selfPortalUserIds.has(id));
     if (!otherHolders.length) continue;
-    void ownEntityId;
     errors.push({
       sheet: sheetName,
       row,
@@ -1769,7 +1767,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
           row: group.parent._rowNum || null,
           column: 'roles',
           value: '',
-          message: 'Roles must be assigned before enabling app user access',
+          message: 'At least one role must be assigned',
         });
         continue;
       }
@@ -2013,10 +2011,20 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
         // from the tenant's numbering config. Mirrors the INSERT-path behavior
         // so existing employees who predate the numbering rollout (or were
         // imported before numbering was enabled) get codes on re-import.
+        // This is a real write — stamp audit fields and count it as an
+        // update so the preview/response numbers reflect it.
         if (config.idType && !before.code && !transformed.code) {
           const numbering = await allocateNumber(schema, config.idType, null, new Date(), t);
           if (numbering) {
-            await t.none(`UPDATE ${s}.${tbl} SET code = $1 WHERE id = $2`, [numbering.displayId, id]);
+            await t.none(
+              `UPDATE ${s}.${tbl} SET code = $1, updated_by = $2, updated_at = NOW() WHERE id = $3`,
+              [numbering.displayId, userId, id],
+            );
+            // Don't double-count when the parent already had other changes
+            // captured above; only increment when this is the only write.
+            if (!(Object.keys(changes).length > 0 || archiveChanged || passwordRotation)) {
+              updatedCount++;
+            }
           }
         }
 
@@ -2058,8 +2066,12 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
           }
 
           // is_app_user false → true: provision or restore portal_user.
-          // Prefer the password the user supplied in the spreadsheet; fall
-          // back to a random one only when the cell is blank.
+          // Honor the spreadsheet password for both branches:
+          //   - provision (no prior binding): pass clear password through;
+          //     enableAppUser → provisionAppUser bcrypts it.
+          //   - restore (archived prior binding): enableAppUser only honors a
+          //     pre-computed hash. Bcrypt up front and hand it through as
+          //     `preHash` so the supplied password actually takes effect.
           if (!isArchived && !wasAppUser && willBeAppUser) {
             const loginRow = await t.oneOrNone(
               `SELECT email FROM ${s}.emails WHERE source_id = $1 AND is_login = true AND deactivated_at IS NULL LIMIT 1`,
@@ -2070,7 +2082,13 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
                 ? String(group.parent.password)
                 : null;
               const password = suppliedPassword || (await import('node:crypto')).randomBytes(12).toString('base64url');
-              await enableAppUser(t, entityType, id, loginRow.email, password, tenantId, userId);
+              let preHash;
+              if (suppliedPassword) {
+                const bcrypt = (await import('bcrypt')).default;
+                const rounds = Number(process.env.BCRYPT_ROUNDS || 12);
+                preHash = await bcrypt.hash(suppliedPassword, rounds);
+              }
+              await enableAppUser(t, entityType, id, loginRow.email, password, tenantId, userId, { preHash });
             }
           }
 

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -16,6 +16,26 @@ import { stripFormatting, formatByPattern, COUNTRIES, TAX_TYPES } from '@axerra/
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/** Hard cap on collected validation/reconciliation issues per import. */
+export const MAX_IMPORT_ISSUES = 100;
+const ISSUE_LIMIT_MESSAGE = `Issue limit reached (${MAX_IMPORT_ISSUES}). Fix and re-import to see remaining problems.`;
+
+/**
+ * Append an issue to the array, capped at MAX_IMPORT_ISSUES. After the cap
+ * is hit, subsequent calls are no-ops; a single sentinel entry is appended once.
+ */
+export function pushIssue(errors, issue) {
+  if (!Array.isArray(errors)) return;
+  if (errors.length < MAX_IMPORT_ISSUES) {
+    errors.push(issue);
+    return;
+  }
+  if (!errors._limitFlagged) {
+    errors.push({ sheet: issue?.sheet ?? null, row: null, column: null, value: null, message: ISSUE_LIMIT_MESSAGE });
+    Object.defineProperty(errors, '_limitFlagged', { value: true, enumerable: false });
+  }
+}
+
 /** Columns stripped from every exported sheet (id is kept for upsert) */
 const INTERNAL_COLS = new Set(['tenant_id', 'source_id', 'created_at', 'created_by', 'updated_at', 'updated_by', 'deactivated_at']);
 
@@ -1128,6 +1148,16 @@ export async function provisionAppUser(entityId, email, password, tenantId, crea
  * @property {string[]} flatCols  Column names in the flat sheet
  */
 
+/**
+ * Reconciliation metadata extensions on each FlatChildDescriptor:
+ *   slotKeyCols          - identifies the per-source slot (e.g. ['label'], ['phone_type'])
+ *   slotKeyLabel         - user-facing label for that slot in error messages
+ *   compareCols          - columns that count as "data changed → UPDATE"
+ *   crossSourceUniqCols  - columns subject to a cross-source partial unique index (or null)
+ *   crossSourceUniqWhere - (row) => boolean restricting which rows trigger the check (e.g. cell phones)
+ *   crossSourceUniqLabel - human label for cross-source conflict messages
+ */
+
 /** @type {FlatChildDescriptor} */
 export const FLAT_CHILD_EMAILS = {
   key: 'emails',
@@ -1136,6 +1166,11 @@ export const FLAT_CHILD_EMAILS = {
   extract: (r) => ({ email: r.email, label: r.email_label, is_primary: r.email_is_primary, is_login: r.email_is_login }),
   cols: ['email', 'label', 'is_primary', 'is_login'],
   flatCols: ['email', 'email_label', 'email_is_primary', 'email_is_login'],
+  slotKeyCols: ['label'],
+  slotKeyLabel: 'label',
+  compareCols: ['email', 'is_primary', 'is_login'],
+  crossSourceUniqCols: ['email'],
+  crossSourceUniqLabel: 'email',
 };
 
 /** @type {FlatChildDescriptor} — same as FLAT_CHILD_EMAILS but without is_login (for contacts) */
@@ -1146,6 +1181,11 @@ export const FLAT_CHILD_EMAILS_NO_LOGIN = {
   extract: (r) => ({ email: r.email, label: r.email_label, is_primary: r.email_is_primary }),
   cols: ['email', 'label', 'is_primary'],
   flatCols: ['email', 'email_label', 'email_is_primary'],
+  slotKeyCols: ['label'],
+  slotKeyLabel: 'label',
+  compareCols: ['email', 'is_primary'],
+  crossSourceUniqCols: ['email'],
+  crossSourceUniqLabel: 'email',
 };
 
 /** @type {FlatChildDescriptor} */
@@ -1161,6 +1201,12 @@ export const FLAT_CHILD_PHONES = {
   }),
   cols: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
   flatCols: ['phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary'],
+  slotKeyCols: ['phone_type'],
+  slotKeyLabel: 'phone_type',
+  compareCols: ['country_code', 'phone_number', 'is_primary'],
+  crossSourceUniqCols: ['country_code', 'phone_number'],
+  crossSourceUniqWhere: (r) => String(r.phone_type || '').toLowerCase() === 'cell',
+  crossSourceUniqLabel: 'cell phone number',
 };
 
 /** @type {FlatChildDescriptor} */
@@ -1189,6 +1235,10 @@ export const FLAT_CHILD_ADDRESSES = {
     'address_postal_code',
     'address_country_code',
   ],
+  slotKeyCols: ['label'],
+  slotKeyLabel: 'label',
+  compareCols: ['address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+  crossSourceUniqCols: null,
 };
 
 /** @type {FlatChildDescriptor} */
@@ -1199,6 +1249,11 @@ export const FLAT_CHILD_TAX_IDS = {
   extract: (r) => ({ country_code: r.tax_country_code, tax_type: r.tax_type, tax_value: r.tax_value }),
   cols: ['country_code', 'tax_type', 'tax_value'],
   flatCols: ['tax_country_code', 'tax_type', 'tax_value'],
+  slotKeyCols: ['country_code', 'tax_type'],
+  slotKeyLabel: 'country_code+tax_type',
+  compareCols: ['tax_value'],
+  crossSourceUniqCols: ['country_code', 'tax_type', 'tax_value'],
+  crossSourceUniqLabel: 'tax identifier',
 };
 
 // EMAIL_RE moved to top of file (before validateImportGroups)
@@ -1291,9 +1346,12 @@ export async function exportFlatSourceEntity(model, filePath, where, joinType, o
  * @param {Object}   reader      WorkbookReader (already loaded)
  * @param {Function} callbackFn  Row transformer (tenant_code, created_by)
  * @param {SourceEntityConfig} config  Must include `flat` sub-object
- * @returns {Promise<{inserted: number, updated: number, appUserSkipped: number} | {errors: Array}>}
+ * @param {Object}   [options]
+ * @param {boolean}  [options.previewOnly=false] Skip write transaction; return a counts-only preview.
+ * @returns {Promise<{inserted: number, updated: number, appUserSkipped: number} | {preview: true, inserts: number, updates: number, noops: number, omitted: number, errors: Array} | {errors: Array}>}
  */
-export async function importFlatSourceEntity(model, reader, callbackFn, config) {
+export async function importFlatSourceEntity(model, reader, callbackFn, config, options = {}) {
+  const previewOnly = options.previewOnly === true;
   const { db, pgp } = await getDb();
   const schema = model._schema.dbSchema;
   const s = pgp.as.name(schema);
@@ -1325,7 +1383,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
 
   // Surface conflicting parent fields across rows in the same group
   for (const c of conflicts) {
-    errors.push({
+    pushIssue(errors, {
       sheet: sheetName,
       row: c.row,
       column: c.column,
@@ -1341,7 +1399,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
     for (const group of groups) {
       for (const child of group.children.emails || []) {
         if (child.email && !EMAIL_RE.test(child.email)) {
-          errors.push({ sheet: sheetName, row: child._rowNum || null, column: 'email', value: child.email, message: 'Invalid email format' });
+          pushIssue(errors, { sheet: sheetName, row: child._rowNum || null, column: 'email', value: child.email, message: 'Invalid email format' });
         }
       }
     }
@@ -1359,12 +1417,14 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
     }
     childEnums.push({ key: cfg.key, enumMap, flatColByCol });
   }
-  errors.push(...validateChildEnums(groups, { sheetName, childEnums }));
+  for (const e of validateChildEnums(groups, { sheetName, childEnums })) pushIssue(errors, e);
 
   // Cross-tenant portal_user collision check (Part 2 of import dedup spec)
   const provisionEntityType = config.appUserProvisioning?.entityType;
   if (provisionEntityType === 'employee' || provisionEntityType === 'client') {
-    errors.push(...(await checkPortalUserEmailCollisions(groups, { sheetName, entityType: provisionEntityType })));
+    for (const e of await checkPortalUserEmailCollisions(groups, { sheetName, entityType: provisionEntityType })) {
+      pushIssue(errors, e);
+    }
   }
 
   // Validate no duplicate codes
@@ -1374,7 +1434,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
     if (code) {
       const prev = codeCounts.get(code);
       if (prev) {
-        errors.push({
+        pushIssue(errors, {
           sheet: sheetName,
           row: group.parent._rowNum || null,
           column: 'code',
@@ -1392,7 +1452,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
   for (const group of groups) {
     for (const field of config.flat.nameFields) {
       if (!group.parent[field] || (typeof group.parent[field] === 'string' && !group.parent[field].trim())) {
-        errors.push({
+        pushIssue(errors, {
           sheet: sheetName,
           row: group.parent._rowNum || null,
           column: field,
@@ -1405,7 +1465,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
       .toLowerCase()
       .trim();
     if (!VALID_STATUSES.has(status)) {
-      errors.push({
+      pushIssue(errors, {
         sheet: sheetName,
         row: group.parent._rowNum || null,
         column: 'status',
@@ -1416,7 +1476,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
     if (config.codeRequired) {
       const code = typeof group.parent.code === 'string' ? group.parent.code.trim() : '';
       if (!code) {
-        errors.push({
+        pushIssue(errors, {
           sheet: sheetName,
           row: group.parent._rowNum || null,
           column: 'code',
@@ -1427,7 +1487,63 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
     }
   }
 
-  if (errors.length) return { errors };
+  // Per-child slot-key validation + intra-file duplicate slot check (R2, R7)
+  for (const group of groups) {
+    for (const cfg of config.flat.children) {
+      const rows = group.children[cfg.key] || [];
+      if (!rows.length || !cfg.slotKeyCols) continue;
+      const seen = new Map();
+      for (const row of rows) {
+        const slotKey = _computeSlotKey(row, cfg);
+        if (slotKey == null) {
+          pushIssue(errors, {
+            sheet: sheetName,
+            row: row._rowNum || null,
+            column: cfg.slotKeyLabel || cfg.slotKeyCols.join('+'),
+            value: '',
+            message: `${cfg.slotKeyLabel || 'slot key'} is required for ${cfg.key} rows`,
+          });
+          continue;
+        }
+        const prev = seen.get(slotKey);
+        if (prev) {
+          pushIssue(errors, {
+            sheet: sheetName,
+            row: row._rowNum || null,
+            column: cfg.slotKeyLabel || cfg.slotKeyCols.join('+'),
+            value: slotKey,
+            message: `Duplicate ${cfg.key} ${cfg.slotKeyLabel || 'slot'} "${slotKey}" — also appears on row ${prev}`,
+          });
+        } else {
+          seen.set(slotKey, row._rowNum || '?');
+        }
+      }
+    }
+  }
+
+  // Resolve own source_ids for existing parents (UUID id matches DB row) so
+  // cross-source uniqueness checks correctly exclude self.
+  const ownSources = await _resolveOwnSourceIds(db, s, tbl, groups);
+  for (const group of groups) {
+    if (isUuid(group.parent.id) && ownSources.has(group.parent.id)) {
+      group._ownSourceId = ownSources.get(group.parent.id);
+    }
+  }
+
+  // Cross-source value collision pre-check (R8). Runs against db (not in tx yet).
+  await _collectCrossSourceConflicts(db, s, pgp, schema, config.sourceType, groups, config.flat.children, sheetName, errors);
+
+  if (errors.length) {
+    return previewOnly
+      ? { preview: true, inserts: 0, updates: 0, noops: 0, omitted: 0, errors }
+      : { errors };
+  }
+
+  // Preview short-circuit (R10). Classify what *would* happen without writing.
+  if (previewOnly) {
+    const counts = await _classifyForPreview(db, s, tbl, pgp, schema, groups, config, ownSources);
+    return { preview: true, ...counts, errors: [] };
+  }
 
   let insertedCount = 0;
   let updatedCount = 0;
@@ -1489,7 +1605,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
         // Upsert children for updated entity
         const sourceId = existingEntities.get(id);
         if (sourceId) {
-          await _upsertFlatChildren(t, s, schema, db, pgp, sourceId, group.children, config.flat.children, callbackFn, tenantId);
+          await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, group.children, config.flat.children, callbackFn, tenantId);
         }
       }
 
@@ -1551,7 +1667,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
 
           // Insert children for new entity
           if (sourceId) {
-            await _upsertFlatChildren(t, s, schema, db, pgp, sourceId, toInsert[i].group.children, config.flat.children, callbackFn, tenantId);
+            await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, toInsert[i].group.children, config.flat.children, callbackFn, tenantId);
           }
         }
 
@@ -1612,10 +1728,220 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config) 
 }
 
 /**
- * Upsert flat children: soft-delete existing, insert new from grouped child arrays.
+ * Classify what a real import would do, without writing. Returns aggregate
+ * counts for the preview step (R10): inserts, updates, no-ops, and omitted
+ * existing rows.
+ *
+ *   - inserts:  parent inserts + child rows that would be INSERTed
+ *   - updates:  parent updates + child rows that would be UPDATEd in place
+ *   - noops:    child rows where the slot exists and values match
+ *   - omitted:  existing active child rows whose slot is not in the file
+ *
  * @private
  */
-async function _upsertFlatChildren(t, s, schema, db, pgp, sourceId, children, childConfigs, callbackFn, tenantId) {
+async function _classifyForPreview(db, s, tbl, pgp, schema, groups, config, ownSources) {
+  let inserts = 0;
+  let updates = 0;
+  let noops = 0;
+  let omitted = 0;
+
+  // Parent-level classification
+  for (const group of groups) {
+    if (isUuid(group.parent.id) && ownSources.has(group.parent.id)) {
+      updates += 1;
+    } else {
+      inserts += 1;
+    }
+  }
+
+  // Per-child classification for groups that map to an existing source
+  for (const cfg of config.flat.children) {
+    const groupsWithChildren = groups.filter((g) => (g.children[cfg.key] || []).length > 0);
+    if (!groupsWithChildren.length) continue;
+
+    const existingSourceIds = groupsWithChildren
+      .map((g) => g._ownSourceId)
+      .filter((sid) => !!sid);
+
+    // Load existing children for known sources in one query
+    const existingBySource = new Map();
+    if (existingSourceIds.length) {
+      const childModel = db(cfg.modelName, schema);
+      const tableName = childModel._schema?.table || cfg.modelName;
+      const tName = pgp.as.name(tableName);
+      const rows = await db.any(
+        `SELECT * FROM ${s}.${tName} WHERE source_id IN ($1:csv) AND deactivated_at IS NULL`,
+        [existingSourceIds],
+      );
+      for (const r of rows) {
+        if (!existingBySource.has(r.source_id)) existingBySource.set(r.source_id, []);
+        existingBySource.get(r.source_id).push(r);
+      }
+    }
+
+    for (const group of groupsWithChildren) {
+      const incoming = group.children[cfg.key] || [];
+      const ownSource = group._ownSourceId;
+      const existing = ownSource ? (existingBySource.get(ownSource) || []) : [];
+      const existingBySlot = new Map();
+      for (const ex of existing) {
+        const k = _computeSlotKey(ex, cfg);
+        if (k != null) existingBySlot.set(k, ex);
+      }
+      const seenIncomingSlots = new Set();
+
+      for (const row of incoming) {
+        const slot = _computeSlotKey(row, cfg);
+        if (slot != null) seenIncomingSlots.add(slot);
+        const match = slot != null ? existingBySlot.get(slot) : null;
+        if (!match) {
+          inserts += 1;
+          continue;
+        }
+        let changed = false;
+        for (const col of (cfg.compareCols || [])) {
+          if (!_normEq(match[col], row[col])) {
+            changed = true;
+            break;
+          }
+        }
+        if (changed) updates += 1;
+        else noops += 1;
+      }
+
+      // Omitted: existing slots not present in incoming
+      for (const slot of existingBySlot.keys()) {
+        if (!seenIncomingSlots.has(slot)) omitted += 1;
+      }
+    }
+  }
+
+  return { inserts, updates, noops, omitted };
+}
+
+/**
+ * Compute the slot key for a child row using the descriptor's slotKeyCols.
+ * Returns a `|`-joined lowercased string, or null if any component is blank.
+ * @private
+ */
+function _computeSlotKey(row, cfg) {
+  if (!cfg.slotKeyCols || !cfg.slotKeyCols.length) return null;
+  const parts = cfg.slotKeyCols.map((c) => {
+    const v = row[c];
+    return v == null ? '' : String(v).trim();
+  });
+  if (parts.some((v) => v === '')) return null;
+  return parts.map((v) => v.toLowerCase()).join('|');
+}
+
+/**
+ * Normalized equality for comparing existing DB values to incoming row values.
+ * Treats null/undefined/empty-string as equal; case-insensitive for strings.
+ * @private
+ */
+function _normEq(a, b) {
+  const na = a == null ? '' : typeof a === 'string' ? a.trim() : a;
+  const nb = b == null ? '' : typeof b === 'string' ? b.trim() : b;
+  if (typeof na === 'string' && typeof nb === 'string') return na.toLowerCase() === nb.toLowerCase();
+  return na === nb;
+}
+
+/**
+ * Resolve existing parents (parent.id is a UUID present in the DB) to their
+ * current source_id. Returns Map<parentId, sourceId>.
+ * @private
+ */
+async function _resolveOwnSourceIds(db, s, tbl, groups) {
+  const uuidIds = groups.filter((g) => isUuid(g.parent.id)).map((g) => g.parent.id);
+  if (!uuidIds.length) return new Map();
+  const rows = await db.any(`SELECT id, source_id FROM ${s}.${tbl} WHERE id IN ($1:csv)`, [uuidIds]);
+  return new Map(rows.map((r) => [r.id, r.source_id]));
+}
+
+/**
+ * Pre-flight cross-source uniqueness check (R8). For each child type with
+ * `crossSourceUniqCols`, batch-query whether any incoming row's value already
+ * exists on a different source's active row. Emit blocking validation issues
+ * with type-only context ("already in use by another <sourceType>").
+ * @private
+ */
+async function _collectCrossSourceConflicts(db, s, pgp, schema, ownSourceType, groups, childConfigs, sheetName, errors) {
+  for (const cfg of childConfigs) {
+    if (!cfg.crossSourceUniqCols || !cfg.crossSourceUniqCols.length) continue;
+
+    const candidates = [];
+    for (const group of groups) {
+      const rows = group.children[cfg.key] || [];
+      for (const row of rows) {
+        if (cfg.crossSourceUniqWhere && !cfg.crossSourceUniqWhere(row)) continue;
+        const values = cfg.crossSourceUniqCols.map((c) => row[c]);
+        if (values.some((v) => v == null || String(v).trim() === '')) continue;
+        candidates.push({
+          row,
+          ownSourceId: group._ownSourceId || null,
+          values: values.map((v) => String(v).trim()),
+        });
+      }
+    }
+    if (!candidates.length) continue;
+
+    const childModel = db(cfg.modelName, schema);
+    const tableName = childModel._schema?.table || cfg.modelName;
+    const tName = pgp.as.name(tableName);
+    const tupleList = candidates
+      .map((c) => `(${c.values.map((v) => pgp.as.text(v)).join(', ')})`)
+      .join(', ');
+    // Look up which (cols-tuple) values are present on OTHER active rows. Get the
+    // source_type too so the error message can describe the owning entity type.
+    let sql = `
+      SELECT child.source_id, src.source_type, ${cfg.crossSourceUniqCols.map((c) => `child.${pgp.as.name(c)} AS ${pgp.as.name(c)}`).join(', ')}
+      FROM ${s}.${tName} child
+      JOIN ${s}.sources src ON src.id = child.source_id
+      WHERE (${cfg.crossSourceUniqCols.map((c) => `child.${pgp.as.name(c)}`).join(', ')}) IN (${tupleList})
+      AND child.deactivated_at IS NULL
+    `;
+    if (cfg.key === 'phones') sql += ` AND child.phone_type = 'cell'`;
+    const matches = await db.any(sql);
+    if (!matches.length) continue;
+
+    const matchBy = new Map();
+    for (const m of matches) {
+      const key = cfg.crossSourceUniqCols.map((c) => String(m[c]).trim().toLowerCase()).join('|');
+      if (!matchBy.has(key)) matchBy.set(key, []);
+      matchBy.get(key).push({ sourceId: m.source_id, sourceType: m.source_type });
+    }
+
+    for (const cand of candidates) {
+      const key = cand.values.map((v) => v.toLowerCase()).join('|');
+      const hits = matchBy.get(key);
+      if (!hits) continue;
+      const other = hits.find((h) => h.sourceId !== cand.ownSourceId);
+      if (!other) continue;
+      const isSameType = other.sourceType === ownSourceType;
+      const typeLabel = isSameType ? `another ${other.sourceType}` : `another record`;
+      pushIssue(errors, {
+        sheet: sheetName,
+        row: cand.row._rowNum || null,
+        column: cfg.crossSourceUniqCols.join('+'),
+        value: cand.values.join('|'),
+        message: `${cfg.crossSourceUniqLabel || cfg.key} "${cand.values.join('|')}" is already in use by ${typeLabel}`,
+      });
+    }
+  }
+}
+
+/**
+ * Reconcile children for one parent source_id by slot key (R3–R6).
+ *   - Slot in incoming + slot in DB + values equal → NO-OP.
+ *   - Slot in incoming + slot in DB + values differ → UPDATE in place; id preserved.
+ *   - Slot in incoming + no matching slot in DB → INSERT.
+ *   - Slot in DB + not in incoming → left alone. Never deleted by omission.
+ * Slot-key validity has already been enforced upstream (R2), so any blank-slot
+ * row is treated defensively as INSERT (the DB unique index would catch the
+ * resulting collision if it mattered).
+ * @private
+ */
+async function _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, children, childConfigs, callbackFn, tenantId) {
   for (const cfg of childConfigs) {
     const childRows = children[cfg.key];
     if (!childRows || !childRows.length) continue;
@@ -1623,14 +1949,18 @@ async function _upsertFlatChildren(t, s, schema, db, pgp, sourceId, children, ch
     const childModel = db(cfg.modelName, schema);
     childModel.tx = t;
     const tableName = childModel._schema?.table || cfg.modelName;
+    const tName = pgp.as.name(tableName);
 
-    // Soft-delete existing children
-    await t.none(`UPDATE ${s}.${pgp.as.name(tableName)} SET deactivated_at = NOW() WHERE source_id = $1 AND deactivated_at IS NULL`, [
-      sourceId,
-    ]);
+    const existing = await t.any(`SELECT * FROM ${s}.${tName} WHERE source_id = $1 AND deactivated_at IS NULL`, [sourceId]);
+    const existingBySlot = new Map();
+    for (const ex of existing) {
+      const k = _computeSlotKey(ex, cfg);
+      if (k != null) existingBySlot.set(k, ex);
+    }
 
-    // Insert new children
     const toInsert = [];
+    const toUpdate = []; // [{ id, changes }]
+
     for (const row of childRows) {
       const { _rowNum: _, ...rest } = row;
       const base = { ...rest, source_id: sourceId };
@@ -1638,17 +1968,34 @@ async function _upsertFlatChildren(t, s, schema, db, pgp, sourceId, children, ch
       delete transformed.tenant_code;
       if (tenantId) transformed.tenant_id = tenantId;
       coerceChildRow(transformed, childModel);
-      // Default null values on notNull boolean columns to false (continuation rows leave them blank)
       for (const col of childModel._schema?.columns || []) {
         if (col.type === 'boolean' && col.notNull && transformed[col.name] == null) {
           transformed[col.name] = col.default ?? false;
         }
       }
-      toInsert.push(transformed);
+
+      const slot = _computeSlotKey(transformed, cfg);
+      const match = slot != null ? existingBySlot.get(slot) : null;
+
+      if (!match) {
+        toInsert.push(transformed);
+        continue;
+      }
+
+      const changes = {};
+      for (const col of (cfg.compareCols || [])) {
+        if (_normEq(match[col], transformed[col])) continue;
+        changes[col] = transformed[col];
+      }
+      if (Object.keys(changes).length === 0) continue; // NO-OP
+      toUpdate.push({ id: match.id, changes });
     }
 
     if (toInsert.length) {
       await childModel.bulkInsert(toInsert);
+    }
+    for (const u of toUpdate) {
+      await childModel.updateWhere([{ id: u.id }], u.changes);
     }
   }
 }

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -193,8 +193,16 @@ export function parseSheet(reader, sheetIndex) {
  */
 export function coerceRow(row, boolCols, hasRoles) {
   for (const col of boolCols) {
-    if (col in row && typeof row[col] === 'string') {
-      row[col] = row[col].toLowerCase() === 'true';
+    if (!(col in row)) continue;
+    const v = row[col];
+    if (typeof v === 'string') {
+      row[col] = v.toLowerCase() === 'true';
+    } else if (v == null) {
+      // Blank cells in boolean columns are interpreted as `false`. Schemas
+      // mark these columns notNull with default false, so a null/undefined
+      // value would otherwise reach the DB and trip a 23502 with no row
+      // context the user can act on.
+      row[col] = false;
     }
   }
   if (hasRoles) {
@@ -1581,11 +1589,31 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
   // cross-source uniqueness checks and (b) diff parent values for NO-OP detection.
   const ownEntities = await _resolveOwnEntities(db, s, tbl, groups);
   for (const group of groups) {
-    if (isUuid(group.parent.id) && ownEntities.has(group.parent.id)) {
-      const row = ownEntities.get(group.parent.id);
-      group._ownEntity = row;
-      group._ownSourceId = row.source_id;
+    const row = _lookupOwnEntity(ownEntities, group.parent);
+    if (!row) continue;
+
+    // Mismatch guard: if id AND code both supplied and resolve to different
+    // DB rows, that's a user error — refuse to silently pick one.
+    if (isUuid(group.parent.id) && typeof group.parent.code === 'string' && group.parent.code.trim()) {
+      const byId = ownEntities.get(group.parent.id) || null;
+      const byCode = ownEntities.get(`code:${group.parent.code.trim()}`) || null;
+      if (byId && byCode && byId.id !== byCode.id) {
+        pushIssue(errors, {
+          sheet: sheetName,
+          row: group.parent._rowNum || null,
+          column: 'id+code',
+          value: `${group.parent.id}|${group.parent.code}`,
+          message: `Row has id and code that refer to different ${config.entityLabel || 'records'}`,
+        });
+        continue;
+      }
     }
+
+    // Round-trip an id-less import row by stamping the resolved id so the
+    // writer's update branch ($1=parent.id) finds the right row.
+    group.parent.id = row.id;
+    group._ownEntity = row;
+    group._ownSourceId = row.source_id;
   }
 
   // Transform each parent once (matches the write path's coerce/strip pipeline)
@@ -1666,6 +1694,35 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
     }
   }
 
+  // Required-field pre-validation with row context. PG's 23502 (not-null)
+  // would catch missing text fields too, but inside a bulkInsert PG can't
+  // tell us which row in the batch failed — the user sees a generic
+  // "required field cannot be empty" with no row number. Catch it up front
+  // by walking the model's notNull columns that have no default.
+  const requiredCols = (model._schema?.columns || [])
+    .filter((c) => c.notNull && c.default == null && !c.immutable)
+    .filter((c) => c.type !== 'boolean' && c.type !== 'uuid')
+    .filter((c) => !['created_at', 'updated_at', 'deactivated_at'].includes(c.name))
+    .map((c) => c.name);
+  if (requiredCols.length) {
+    for (const group of groups) {
+      // Only check INSERTs — for UPDATEs the column is preserved from the DB row.
+      if (group._ownEntity) continue;
+      for (const col of requiredCols) {
+        const v = group.parent[col];
+        if (v == null || (typeof v === 'string' && v.trim() === '')) {
+          pushIssue(errors, {
+            sheet: sheetName,
+            row: group.parent._rowNum || null,
+            column: col,
+            value: '',
+            message: `${col.replace(/_/g, ' ')} is required`,
+          });
+        }
+      }
+    }
+  }
+
   // Role validation. Empty roles[] OR unknown role codes are blocking errors
   // for every employee/client parent — not just app users — so a roleless
   // record cannot be created via import regardless of is_app_user state.
@@ -1700,6 +1757,55 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
           column: 'roles',
           value: invalid.join(','),
           message: `Unknown role code${invalid.length > 1 ? 's' : ''}: ${invalid.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  // Password vs is_app_user consistency. A `password` cell is only meaningful
+  // when the row ends up an app user — supplying one while the final state is
+  // is_app_user=false (either explicitly or by demoting an existing app user)
+  // is contradictory and would silently drop the password. Block it.
+  if (config.appUserProvisioning) {
+    for (const group of groups) {
+      const supplied = group.parent.password && String(group.parent.password).trim();
+      if (!supplied) continue;
+      const incoming = group._transformedParent || {};
+      const existing = group._ownEntity || null;
+      const willBeAppUser = 'is_app_user' in incoming
+        ? !!incoming.is_app_user
+        : !!existing?.is_app_user;
+      if (!willBeAppUser) {
+        pushIssue(errors, {
+          sheet: sheetName,
+          row: group.parent._rowNum || null,
+          column: 'password',
+          value: '***',
+          message:
+            'A password cannot be supplied while is_app_user is false. Set is_app_user to true to enable app access, or clear the password column.',
+        });
+      }
+    }
+  }
+
+  // is_app_user=true on an INSERT row requires an explicit login email. The
+  // writer used to silently fall back to the primary (or any active) email
+  // when no row was marked is_login=true; that was a footgun. Block it here
+  // so the user has to declare intent in the spreadsheet.
+  if (config.appUserProvisioning) {
+    for (const group of groups) {
+      if (group._ownEntity) continue;                  // INSERT only
+      const incoming = group._transformedParent || {};
+      if (!incoming.is_app_user) continue;
+      const emails = group.children?.emails || [];
+      const hasLogin = emails.some((e) => _truthyFlag(e.is_login) && e.email && String(e.email).trim());
+      if (!hasLogin) {
+        pushIssue(errors, {
+          sheet: sheetName,
+          row: group.parent._rowNum || null,
+          column: 'email_is_login',
+          value: '',
+          message: 'A login email is required to enable app user access. Mark one email row with is_login = true.',
         });
       }
     }
@@ -1782,7 +1888,12 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
         // Codes for existing rows are owned by the numbering allocator (set
         // once, never rewritten through the import path).
         if (updateNumberingEnabled && 'code' in changes) delete changes.code;
-        if (Object.keys(changes).length > 0) {
+        // Archive/restore transition: `status` is stripped from the transformed
+        // parent so it never appears in `changes`. Detect the flip explicitly
+        // so the count + audit-field stamping fires even when no other column
+        // changed (e.g. a re-import that only flips status active→archived).
+        const archiveChanged = isArchived !== wasArchived;
+        if (Object.keys(changes).length > 0 || archiveChanged) {
           // Stamp audit fields on every real write. We add them after the diff
           // so they don't themselves trigger NO-OP-failing updates. pg-schemata's
           // `updateWhere` does not auto-bump updated_at (unlike its singular
@@ -1852,16 +1963,43 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
             await archiveAppUser(t, entityType, id, tenantId, userId);
           }
 
-          // is_app_user false → true: provision or restore portal_user
+          // is_app_user false → true: provision or restore portal_user.
+          // Prefer the password the user supplied in the spreadsheet; fall
+          // back to a random one only when the cell is blank.
           if (!isArchived && !wasAppUser && willBeAppUser) {
             const loginRow = await t.oneOrNone(
               `SELECT email FROM ${s}.emails WHERE source_id = $1 AND is_login = true AND deactivated_at IS NULL LIMIT 1`,
               [sourceId],
             );
             if (loginRow?.email) {
-              const crypto = await import('node:crypto');
-              const password = crypto.randomBytes(12).toString('base64url');
+              const suppliedPassword = group.parent.password && String(group.parent.password).trim()
+                ? String(group.parent.password)
+                : null;
+              const password = suppliedPassword || (await import('node:crypto')).randomBytes(12).toString('base64url');
               await enableAppUser(t, entityType, id, loginRow.email, password, tenantId, userId);
+            }
+          }
+
+          // Already-app-user + password supplied in spreadsheet: reset the
+          // portal_user's password_hash. Lets admins rotate a password through
+          // the import path without going to the auth UI.
+          if (!isArchived && wasAppUser && willBeAppUser) {
+            const suppliedPassword = group.parent.password && String(group.parent.password).trim()
+              ? String(group.parent.password)
+              : null;
+            if (suppliedPassword) {
+              const bcrypt = (await import('bcrypt')).default;
+              const rounds = Number(process.env.BCRYPT_ROUNDS || 12);
+              const passwordHash = await bcrypt.hash(suppliedPassword, rounds);
+              await t.none(
+                `UPDATE admin.portal_users pu
+                 SET password_hash = $1, updated_by = $2, updated_at = NOW()
+                 FROM admin.portal_user_tenants b
+                 WHERE pu.id = b.portal_user_id
+                   AND b.entity_type = $3 AND b.entity_id = $4 AND b.tenant_id = $5
+                   AND b.deactivated_at IS NULL AND pu.deactivated_at IS NULL`,
+                [passwordHash, userId, entityType, id, tenantId],
+              );
             }
           }
         }
@@ -2029,7 +2167,13 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
       continue;
     }
     const changes = _diffParent(group._transformedParent, existing);
-    if (Object.keys(changes).length > 0) updates += 1;
+    // Archive/restore transition: `status` is stripped from _transformedParent
+    // (it's a synthetic spreadsheet column) so _diffParent can't see it. Detect
+    // the state change explicitly so the preview counts it as an update.
+    const willBeArchived = String(group.parent.status || '').toLowerCase() === 'archived';
+    const wasArchived = !!existing.deactivated_at;
+    const archiveChanged = willBeArchived !== wasArchived;
+    if (Object.keys(changes).length > 0 || archiveChanged) updates += 1;
     else noops += 1;
   }
 
@@ -2205,10 +2349,54 @@ function _normEq(a, b) {
  * @private
  */
 async function _resolveOwnEntities(db, s, tbl, groups) {
+  // Match by `id` first (the round-trip path). For rows whose id is blank or
+  // doesn't resolve in the DB (e.g. tenant was re-bootstrapped after export
+  // and the id has rotated), fall back to matching by `code`. The resulting
+  // map is keyed by both `id` and `code` so callers can look up either way.
+  const map = new Map();
+
   const uuidIds = groups.filter((g) => isUuid(g.parent.id)).map((g) => g.parent.id);
-  if (!uuidIds.length) return new Map();
-  const rows = await db.any(`SELECT * FROM ${s}.${tbl} WHERE id IN ($1:csv)`, [uuidIds]);
-  return new Map(rows.map((r) => [r.id, r]));
+  if (uuidIds.length) {
+    const rows = await db.any(`SELECT * FROM ${s}.${tbl} WHERE id IN ($1:csv)`, [uuidIds]);
+    for (const r of rows) {
+      map.set(r.id, r);
+      if (r.code) map.set(`code:${String(r.code).trim()}`, r);
+    }
+  }
+
+  // Identify groups whose id didn't resolve but carry a code we can use.
+  const fallbackCodes = [];
+  for (const g of groups) {
+    const idResolved = isUuid(g.parent.id) && map.has(g.parent.id);
+    if (idResolved) continue;
+    const code = typeof g.parent.code === 'string' ? g.parent.code.trim() : '';
+    if (code && !map.has(`code:${code}`)) fallbackCodes.push(code);
+  }
+  if (fallbackCodes.length) {
+    const rows = await db.any(
+      `SELECT * FROM ${s}.${tbl} WHERE code IN ($1:csv) AND deactivated_at IS NULL`,
+      [fallbackCodes],
+    );
+    for (const r of rows) {
+      map.set(`code:${String(r.code).trim()}`, r);
+      // Don't overwrite an existing id key (it was set by the id path above).
+      if (!map.has(r.id)) map.set(r.id, r);
+    }
+  }
+  return map;
+}
+
+/**
+ * Look up the resolved DB row for a parent group using id first, then code.
+ * @private
+ */
+function _lookupOwnEntity(ownEntities, parent) {
+  if (parent && isUuid(parent.id) && ownEntities.has(parent.id)) {
+    return ownEntities.get(parent.id);
+  }
+  const code = typeof parent?.code === 'string' ? parent.code.trim() : '';
+  if (code && ownEntities.has(`code:${code}`)) return ownEntities.get(`code:${code}`);
+  return null;
 }
 
 /**

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -1521,13 +1521,22 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
     }
   }
 
-  // Resolve own source_ids for existing parents (UUID id matches DB row) so
-  // cross-source uniqueness checks correctly exclude self.
-  const ownSources = await _resolveOwnSourceIds(db, s, tbl, groups);
+  // Resolve full DB rows for existing parents. Used to (a) exclude self from
+  // cross-source uniqueness checks and (b) diff parent values for NO-OP detection.
+  const ownEntities = await _resolveOwnEntities(db, s, tbl, groups);
   for (const group of groups) {
-    if (isUuid(group.parent.id) && ownSources.has(group.parent.id)) {
-      group._ownSourceId = ownSources.get(group.parent.id);
+    if (isUuid(group.parent.id) && ownEntities.has(group.parent.id)) {
+      const row = ownEntities.get(group.parent.id);
+      group._ownEntity = row;
+      group._ownSourceId = row.source_id;
     }
+  }
+
+  // Transform each parent once (matches the write path's coerce/strip pipeline)
+  // so the classifier and writer share the same canonical incoming values.
+  const STRIP_COLS = ['status', 'deactivated_at', 'password'];
+  for (const group of groups) {
+    group._transformedParent = await _transformParent(group, callbackFn, tenantId, config, STRIP_COLS);
   }
 
   // Cross-source value collision pre-check (R8). Runs against db (not in tx yet).
@@ -1541,7 +1550,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
 
   // Preview short-circuit (R10). Classify what *would* happen without writing.
   if (previewOnly) {
-    const counts = await _classifyForPreview(db, s, tbl, pgp, schema, groups, config, ownSources);
+    const counts = await _classifyForPreview(db, s, pgp, schema, groups, config, ownEntities);
     return { preview: true, ...counts, errors: [] };
   }
 
@@ -1554,43 +1563,31 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
       model.tx = t;
 
       // ── Phase 1: Partition into updates vs inserts ──────────────────────
-      const uuidIds = groups.filter((g) => isUuid(g.parent.id)).map((g) => g.parent.id);
-      const existingEntities = new Map();
-      if (uuidIds.length) {
-        const existing = await t.any(`SELECT id, source_id FROM ${s}.${tbl} WHERE id IN ($1:csv)`, [uuidIds]);
-        for (const row of existing) existingEntities.set(row.id, row.source_id);
-      }
-
+      // Parents have already been transformed and diffed in pre-validation;
+      // group._transformedParent and group._ownEntity carry the canonical values.
       const toUpdate = [];
       const toInsert = [];
-      const stripCols = ['status', 'deactivated_at', 'password'];
 
       for (const group of groups) {
-        const { parent } = group;
-        const isArchived = String(parent.status).toLowerCase() === 'archived';
-        const password = parent.password || null;
-        const { _rowNum: _rn, ...entityData } = { ...parent };
-        for (const col of stripCols) delete entityData[col];
-
-        const transformed = callbackFn ? await callbackFn({ ...entityData }) : { ...entityData };
-        for (const col of stripCols) delete transformed[col];
-        delete transformed.tenant_code;
-        if (tenantId) transformed.tenant_id = tenantId;
-        coerceRow(transformed, config.boolCols, config.hasRoles);
-        // Normalize empty-string codes to null
-        if (typeof transformed.code === 'string' && !transformed.code.trim()) transformed.code = null;
-
-        if (existingEntities.has(parent.id)) {
-          toUpdate.push({ transformed, isArchived, group });
+        const isArchived = String(group.parent.status).toLowerCase() === 'archived';
+        const password = group.parent.password || null;
+        if (group._ownEntity) {
+          toUpdate.push({ transformed: group._transformedParent, isArchived, group });
         } else {
-          toInsert.push({ transformed, isArchived, group, ref: parent.id || null, password });
+          toInsert.push({ transformed: group._transformedParent, isArchived, group, ref: group.parent.id || null, password });
         }
       }
 
       // ── Phase 2: Run updates ───────────────────────────────────────────
       for (const { transformed, isArchived, group } of toUpdate) {
-        const { id, ...changes } = transformed;
-        await model.updateWhere([{ id }], changes, { includeDeactivated: true });
+        const { id } = transformed;
+        const changes = _diffParent(transformed, group._ownEntity);
+        if (Object.keys(changes).length > 0) {
+          await model.updateWhere([{ id }], changes, { includeDeactivated: true });
+          updatedCount++;
+        }
+        // Archive/restore via deactivated_at is conditional in SQL — no churn
+        // when the state already matches, so always safe to run.
         if (isArchived) {
           await t.none(`UPDATE ${s}.${tbl} SET deactivated_at = NOW() WHERE id = $1 AND deactivated_at IS NULL`, [
             id,
@@ -1600,10 +1597,9 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
             id,
           ]);
         }
-        updatedCount++;
 
-        // Upsert children for updated entity
-        const sourceId = existingEntities.get(id);
+        // Reconcile children for this entity (slot-keyed, NO-OPs preserved)
+        const sourceId = group._ownSourceId;
         if (sourceId) {
           await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, group.children, config.flat.children, callbackFn, tenantId);
         }
@@ -1739,19 +1735,23 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
  *
  * @private
  */
-async function _classifyForPreview(db, s, tbl, pgp, schema, groups, config, ownSources) {
+async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntities) {
   let inserts = 0;
   let updates = 0;
   let noops = 0;
   let omitted = 0;
 
-  // Parent-level classification
+  // Parent-level classification: existing parents diff against their DB row;
+  // unchanged parents count as NO-OPs, not updates.
   for (const group of groups) {
-    if (isUuid(group.parent.id) && ownSources.has(group.parent.id)) {
-      updates += 1;
-    } else {
+    const existing = isUuid(group.parent.id) ? ownEntities.get(group.parent.id) : null;
+    if (!existing) {
       inserts += 1;
+      continue;
     }
+    const changes = _diffParent(group._transformedParent, existing);
+    if (Object.keys(changes).length > 0) updates += 1;
+    else noops += 1;
   }
 
   // Per-child classification for groups that map to an existing source
@@ -1848,14 +1848,66 @@ function _normEq(a, b) {
 
 /**
  * Resolve existing parents (parent.id is a UUID present in the DB) to their
- * current source_id. Returns Map<parentId, sourceId>.
+ * full current DB row. Returns Map<parentId, row> where row includes source_id
+ * and every entity column — used both for cross-source self-exclusion and for
+ * parent-level NO-OP detection on re-imports.
  * @private
  */
-async function _resolveOwnSourceIds(db, s, tbl, groups) {
+async function _resolveOwnEntities(db, s, tbl, groups) {
   const uuidIds = groups.filter((g) => isUuid(g.parent.id)).map((g) => g.parent.id);
   if (!uuidIds.length) return new Map();
-  const rows = await db.any(`SELECT id, source_id FROM ${s}.${tbl} WHERE id IN ($1:csv)`, [uuidIds]);
-  return new Map(rows.map((r) => [r.id, r.source_id]));
+  const rows = await db.any(`SELECT * FROM ${s}.${tbl} WHERE id IN ($1:csv)`, [uuidIds]);
+  return new Map(rows.map((r) => [r.id, r]));
+}
+
+/**
+ * Order-insensitive array equality, used for text[] columns like `roles`.
+ * @private
+ */
+function _arrayEq(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  const sa = [...a].map(String).sort();
+  const sb = [...b].map(String).sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+/**
+ * Diff a transformed parent row against its current DB row. Returns an object
+ * of changed columns (subset of transformed) or an empty object when nothing
+ * differs. The `id`, `tenant_id`, and audit fields are not compared.
+ * @private
+ */
+function _diffParent(transformed, existing) {
+  const SKIP = new Set(['id', 'tenant_id']);
+  const changes = {};
+  for (const [col, val] of Object.entries(transformed)) {
+    if (SKIP.has(col)) continue;
+    const cur = existing[col];
+    if (Array.isArray(val) || Array.isArray(cur)) {
+      if (!_arrayEq(val, cur)) changes[col] = val;
+      continue;
+    }
+    if (!_normEq(val, cur)) changes[col] = val;
+  }
+  return changes;
+}
+
+/**
+ * Coerce + transform a parent row exactly the way the write path does. Result
+ * is the row that would be sent to model.updateWhere or model.bulkInsert.
+ * @private
+ */
+async function _transformParent(group, callbackFn, tenantId, config, stripCols) {
+  const { _rowNum: _rn, ...entityData } = { ...group.parent };
+  for (const col of stripCols) delete entityData[col];
+  const transformed = callbackFn ? await callbackFn({ ...entityData }) : { ...entityData };
+  for (const col of stripCols) delete transformed[col];
+  delete transformed.tenant_code;
+  if (tenantId) transformed.tenant_id = tenantId;
+  coerceRow(transformed, config.boolCols, config.hasRoles);
+  if (typeof transformed.code === 'string' && !transformed.code.trim()) transformed.code = null;
+  return transformed;
 }
 
 /**

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -1652,6 +1652,48 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
     }
   }
 
+  // Role validation for any group whose entity will end up an app user.
+  // Empty roles[] OR unknown role codes are blocking errors — both controller
+  // and importer paths must reject before provisioning a portal_user that
+  // could log in but have no policies.
+  if (config.appUserProvisioning) {
+    // `roles` is softDelete: false — query all rows, no deactivated_at filter.
+    const validRows = await db.any(`SELECT code FROM ${s}.roles`);
+    const validCodes = new Set(validRows.map((r) => String(r.code).toLowerCase()));
+    for (const group of groups) {
+      const incoming = group._transformedParent || {};
+      const existing = group._ownEntity || null;
+      const willBeAppUser = 'is_app_user' in incoming ? !!incoming.is_app_user : !!existing?.is_app_user;
+      if (!willBeAppUser) continue;
+
+      const finalRoles = incoming.roles !== undefined ? incoming.roles : existing?.roles;
+      const arr = Array.isArray(finalRoles)
+        ? finalRoles.map((r) => (r == null ? '' : String(r).trim())).filter((r) => r !== '')
+        : [];
+
+      if (!arr.length) {
+        pushIssue(errors, {
+          sheet: sheetName,
+          row: group.parent._rowNum || null,
+          column: 'roles',
+          value: '',
+          message: 'Roles must be assigned before enabling app user access',
+        });
+        continue;
+      }
+      const invalid = arr.filter((r) => !validCodes.has(r.toLowerCase()));
+      if (invalid.length) {
+        pushIssue(errors, {
+          sheet: sheetName,
+          row: group.parent._rowNum || null,
+          column: 'roles',
+          value: invalid.join(','),
+          message: `Unknown role code${invalid.length > 1 ? 's' : ''}: ${invalid.join(', ')}`,
+        });
+      }
+    }
+  }
+
   // Cross-tenant portal_user collision check (insert + update cases). Runs
   // after _resolveOwnEntities so it can exclude the entity's own portal_user.
   const provisionEntityType = config.appUserProvisioning?.entityType;
@@ -1716,6 +1758,12 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
 
         const changes = _diffParent(transformed, before);
         if (Object.keys(changes).length > 0) {
+          // Stamp audit fields on every real write. We add them after the diff
+          // so they don't themselves trigger NO-OP-failing updates. pg-schemata's
+          // `updateWhere` does not auto-bump updated_at (unlike its singular
+          // `update`), so we must set it explicitly here.
+          if (userId) changes.updated_by = userId;
+          changes.updated_at = new Date();
           await model.updateWhere([{ id }], changes, { includeDeactivated: true });
           updatedCount++;
         }
@@ -1962,22 +2010,36 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
       const ownSource = group._ownSourceId;
       const existing = ownSource ? (existingBySource.get(ownSource) || []) : [];
       const existingBySlot = new Map();
+      const existingByValue = new Map();
       for (const ex of existing) {
         const k = _computeSlotKey(ex, cfg);
         if (k != null) existingBySlot.set(k, ex);
+        const vk = _computeValueKey(ex, cfg);
+        if (vk != null) existingByValue.set(vk, ex);
       }
+      const claimedExistingIds = new Set();
       const seenIncomingSlots = new Set();
 
       for (const row of incoming) {
         const slot = _computeSlotKey(row, cfg);
         if (slot != null) seenIncomingSlots.add(slot);
-        const match = slot != null ? existingBySlot.get(slot) : null;
+        let match = slot != null ? existingBySlot.get(slot) : null;
+        if (!match) {
+          const vk = _computeValueKey(row, cfg);
+          if (vk != null) {
+            const candidate = existingByValue.get(vk);
+            if (candidate && !claimedExistingIds.has(candidate.id)) match = candidate;
+          }
+        }
         if (!match) {
           inserts += 1;
           continue;
         }
+        claimedExistingIds.add(match.id);
+        // Include slot key cols in the diff so a rename counts as UPDATE.
+        const diffCols = new Set([...(cfg.compareCols || []), ...(cfg.slotKeyCols || [])]);
         let changed = false;
-        for (const col of (cfg.compareCols || [])) {
+        for (const col of diffCols) {
           if (!_normEq(match[col], row[col])) {
             changed = true;
             break;
@@ -1987,9 +2049,13 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
         else noops += 1;
       }
 
-      // Omitted: existing slots not present in incoming
-      for (const slot of existingBySlot.keys()) {
-        if (!seenIncomingSlots.has(slot)) omitted += 1;
+      // Omitted: existing rows whose slot wasn't named AND whose row id wasn't
+      // claimed by a value-key rename match.
+      for (const ex of existing) {
+        const slot = _computeSlotKey(ex, cfg);
+        if (slot != null && seenIncomingSlots.has(slot)) continue;
+        if (claimedExistingIds.has(ex.id)) continue;
+        omitted += 1;
       }
     }
   }
@@ -2026,6 +2092,29 @@ async function _loadEmailsBySource(db, s, pgp, schema, cfg, sourceIds) {
     out.get(r.source_id).push(r);
   }
   return out;
+}
+
+/**
+ * Compute the value key for a child row — based on the descriptor's
+ * crossSourceUniqCols, gated by an optional crossSourceUniqWhere predicate.
+ * Used by the reconciler to detect slot renames: when an incoming row's slot
+ * key doesn't match any existing slot but its value matches an existing row,
+ * treat the row as a rename of that existing row (UPDATE in place, preserving
+ * id and updating the slot label).
+ *
+ * Returns null when the descriptor has no value-uniqueness, when the row
+ * doesn't satisfy crossSourceUniqWhere, or when any value-key component is blank.
+ * @private
+ */
+function _computeValueKey(row, cfg) {
+  if (!cfg.crossSourceUniqCols || !cfg.crossSourceUniqCols.length) return null;
+  if (cfg.crossSourceUniqWhere && !cfg.crossSourceUniqWhere(row)) return null;
+  const parts = cfg.crossSourceUniqCols.map((c) => {
+    const v = row[c];
+    return v == null ? '' : String(v).trim();
+  });
+  if (parts.some((v) => v === '')) return null;
+  return parts.map((v) => v.toLowerCase()).join('|');
 }
 
 /**
@@ -2084,11 +2173,18 @@ function _arrayEq(a, b) {
 /**
  * Diff a transformed parent row against its current DB row. Returns an object
  * of changed columns (subset of transformed) or an empty object when nothing
- * differs. The `id`, `tenant_id`, and audit fields are not compared.
+ * differs.
+ *
+ * Skipped columns:
+ *   - `id`, `tenant_id`            — never updated through this path
+ *   - `created_at`, `created_by`   — set once at insert, must not be overwritten
+ *   - `updated_at`, `updated_by`   — managed separately by the writer; including
+ *     them in the diff would defeat NO-OP detection since the importing user
+ *     normally differs from the prior `updated_by`.
  * @private
  */
 function _diffParent(transformed, existing) {
-  const SKIP = new Set(['id', 'tenant_id']);
+  const SKIP = new Set(['id', 'tenant_id', 'created_at', 'created_by', 'updated_at', 'updated_by']);
   const changes = {};
   for (const [col, val] of Object.entries(transformed)) {
     if (SKIP.has(col)) continue;
@@ -2214,13 +2310,17 @@ async function _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, children,
 
     const existing = await t.any(`SELECT * FROM ${s}.${tName} WHERE source_id = $1 AND deactivated_at IS NULL`, [sourceId]);
     const existingBySlot = new Map();
+    const existingByValue = new Map();
     for (const ex of existing) {
       const k = _computeSlotKey(ex, cfg);
       if (k != null) existingBySlot.set(k, ex);
+      const vk = _computeValueKey(ex, cfg);
+      if (vk != null) existingByValue.set(vk, ex);
     }
 
     const toInsert = [];
     const toUpdate = []; // [{ id, changes }]
+    const claimedExistingIds = new Set();
 
     for (const row of childRows) {
       const { _rowNum: _, ...rest } = row;
@@ -2235,20 +2335,38 @@ async function _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, children,
         }
       }
 
+      // Match priority: 1) slot key. 2) value key (catches slot rename when
+      // the underlying value is unique-by-DB, e.g. an email's address or a
+      // cell phone number — keeps the same row id and just updates the slot).
       const slot = _computeSlotKey(transformed, cfg);
-      const match = slot != null ? existingBySlot.get(slot) : null;
+      let match = slot != null ? existingBySlot.get(slot) : null;
+      if (!match) {
+        const vk = _computeValueKey(transformed, cfg);
+        if (vk != null) {
+          const candidate = existingByValue.get(vk);
+          if (candidate && !claimedExistingIds.has(candidate.id)) match = candidate;
+        }
+      }
 
       if (!match) {
         toInsert.push(transformed);
         continue;
       }
+      claimedExistingIds.add(match.id);
 
+      // Diff against compareCols PLUS the slot key cols (so a slot rename
+      // detected via value-match actually updates the label/phone_type).
+      const diffCols = new Set([...(cfg.compareCols || []), ...(cfg.slotKeyCols || [])]);
       const changes = {};
-      for (const col of (cfg.compareCols || [])) {
+      for (const col of diffCols) {
         if (_normEq(match[col], transformed[col])) continue;
         changes[col] = transformed[col];
       }
       if (Object.keys(changes).length === 0) continue; // NO-OP
+      // Stamp audit fields on every real write. pg-schemata's `updateWhere`
+      // does not auto-bump updated_at, so set both explicitly.
+      if (transformed.updated_by) changes.updated_by = transformed.updated_by;
+      changes.updated_at = new Date();
       toUpdate.push({ id: match.id, changes });
     }
 

--- a/apps/server/src/system/core/controllers/clientsController.js
+++ b/apps/server/src/system/core/controllers/clientsController.js
@@ -76,6 +76,7 @@ class ClientsController extends BaseController {
           source_type: 'client',
           label: client.name,
           created_by: req.body.created_by || null,
+          updated_by: req.body.created_by || null,
         });
 
         // 3. Link the source back to the client

--- a/apps/server/src/system/core/controllers/companiesController.js
+++ b/apps/server/src/system/core/controllers/companiesController.js
@@ -40,6 +40,7 @@ class CompaniesController extends BaseController {
           source_type: 'company',
           label: company.name,
           created_by: req.body.created_by || null,
+          updated_by: req.body.created_by || null,
         });
 
         await t.none(

--- a/apps/server/src/system/core/controllers/contactsController.js
+++ b/apps/server/src/system/core/controllers/contactsController.js
@@ -42,6 +42,7 @@ class ContactsController extends BaseController {
           source_type: 'contact',
           label: contact.name,
           created_by: req.body.created_by || null,
+          updated_by: req.body.created_by || null,
         });
 
         await t.none(

--- a/apps/server/src/system/core/controllers/employeesController.js
+++ b/apps/server/src/system/core/controllers/employeesController.js
@@ -46,14 +46,13 @@ class EmployeesController extends BaseController {
       const suppliedEmail = req.body.email;
       delete req.body.email;
 
-      // Validate: roles must be non-empty AND every role code must exist in
-      // the tenant's roles table before is_app_user can be true.
-      if (req.body.is_app_user) {
-        const roleCheck = await validateEmployeeRoles(db, schema, req.body.roles);
-        if (!roleCheck.ok) return res.status(400).json({ error: roleCheck.error });
-        if (!suppliedEmail) {
-          return res.status(400).json({ error: 'Email is required to enable app user access' });
-        }
+      // Validate: every employee must be assigned at least one valid role.
+      // Stricter than app-user provisioning so a roleless employee can never
+      // exist regardless of is_app_user.
+      const roleCheck = await validateEmployeeRoles(db, schema, req.body.roles);
+      if (!roleCheck.ok) return res.status(400).json({ error: roleCheck.error });
+      if (req.body.is_app_user && !suppliedEmail) {
+        return res.status(400).json({ error: 'Email is required to enable app user access' });
       }
 
       // Extract password before insert — it's for portal_users, not the employees table
@@ -76,6 +75,7 @@ class EmployeesController extends BaseController {
           source_type: 'employee',
           label: `${employee.first_name} ${employee.last_name}`,
           created_by: req.body.created_by || null,
+          updated_by: req.body.created_by || null,
         });
 
         // 3. Link the source back to the employee
@@ -178,13 +178,14 @@ class EmployeesController extends BaseController {
       const needsProvisioning =
         isNowAppUser && (!wasAppUser || !(await findActiveBinding('employee', before.id, req.user?.tenant_id)));
 
-      if (needsProvisioning) {
-        const roles = req.body.roles || before.roles || [];
-        const roleCheck = await validateEmployeeRoles(db, schema, roles);
-        if (!roleCheck.ok) return res.status(400).json({ error: roleCheck.error });
-        if (!resolvedEmail) {
-          return res.status(400).json({ error: 'A login email is required to enable app user access' });
-        }
+      // Always validate roles on update — empty/unknown role codes are
+      // blocking regardless of is_app_user state, so a roleless employee
+      // can never exist.
+      const finalRoles = req.body.roles !== undefined ? req.body.roles : before.roles || [];
+      const roleCheck = await validateEmployeeRoles(db, schema, finalRoles);
+      if (!roleCheck.ok) return res.status(400).json({ error: roleCheck.error });
+      if (needsProvisioning && !resolvedEmail) {
+        return res.status(400).json({ error: 'A login email is required to enable app user access' });
       }
 
       // Apply the standard update

--- a/apps/server/src/system/core/controllers/employeesController.js
+++ b/apps/server/src/system/core/controllers/employeesController.js
@@ -16,6 +16,7 @@ import db, { pgp } from '../../../db/db.js';
 import { allocateNumber } from '../services/numberingService.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
 import { findActiveBinding, findAnyBinding } from '../../auth/services/index.js';
+import { validateEmployeeRoles } from '../../../lib/employeeRoleValidator.js';
 import logger from '../../../lib/logger.js';
 
 class EmployeesController extends BaseController {
@@ -45,12 +46,11 @@ class EmployeesController extends BaseController {
       const suppliedEmail = req.body.email;
       delete req.body.email;
 
-      // Validate: roles must be non-empty before is_app_user can be true
+      // Validate: roles must be non-empty AND every role code must exist in
+      // the tenant's roles table before is_app_user can be true.
       if (req.body.is_app_user) {
-        const roles = req.body.roles || [];
-        if (!roles.length) {
-          return res.status(400).json({ error: 'Roles must be assigned before enabling app user access' });
-        }
+        const roleCheck = await validateEmployeeRoles(db, schema, req.body.roles);
+        if (!roleCheck.ok) return res.status(400).json({ error: roleCheck.error });
         if (!suppliedEmail) {
           return res.status(400).json({ error: 'Email is required to enable app user access' });
         }
@@ -180,9 +180,8 @@ class EmployeesController extends BaseController {
 
       if (needsProvisioning) {
         const roles = req.body.roles || before.roles || [];
-        if (!roles.length) {
-          return res.status(400).json({ error: 'Roles must be assigned before enabling app user access' });
-        }
+        const roleCheck = await validateEmployeeRoles(db, schema, roles);
+        if (!roleCheck.ok) return res.status(400).json({ error: roleCheck.error });
         if (!resolvedEmail) {
           return res.status(400).json({ error: 'A login email is required to enable app user access' });
         }
@@ -395,24 +394,38 @@ class EmployeesController extends BaseController {
       }
     }
 
-    const clearPassword = suppliedPassword || crypto.randomBytes(12).toString('base64url');
-    const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
-    const passwordHash = await bcrypt.hash(clearPassword, rounds);
     const updatedBy = req.user?.id || null;
 
-    // Look for any prior binding for this employee in this tenant (active or archived)
+    // Look for any prior binding for this employee in this tenant (active or archived).
     const priorBinding = await findAnyBinding('employee', employee.id, tenantId);
 
     if (priorBinding) {
-      // Restore both portal_users and the binding to keep them in sync
+      // Restore the existing portal_user + binding. The existing password_hash
+      // is preserved unless the caller explicitly supplies a new password —
+      // re-enabling app access (or restoring an archived employee) must not
+      // silently invalidate the user's existing credentials.
+      let newPasswordHash = null;
+      if (suppliedPassword) {
+        const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
+        newPasswordHash = await bcrypt.hash(suppliedPassword, rounds);
+      }
       await db.tx(async (t) => {
-        await t.none(
-          `UPDATE admin.portal_users
-           SET deactivated_at = NULL, status = 'invited',
-               password_hash = $1, email = $2, updated_by = $3
-           WHERE id = $4`,
-          [passwordHash, loginEmail, updatedBy, priorBinding.portal_user_id],
-        );
+        if (newPasswordHash) {
+          await t.none(
+            `UPDATE admin.portal_users
+             SET deactivated_at = NULL, status = 'invited',
+                 password_hash = $1, email = $2, updated_by = $3
+             WHERE id = $4`,
+            [newPasswordHash, loginEmail, updatedBy, priorBinding.portal_user_id],
+          );
+        } else {
+          await t.none(
+            `UPDATE admin.portal_users
+             SET deactivated_at = NULL, status = 'active', email = $1, updated_by = $2
+             WHERE id = $3`,
+            [loginEmail, updatedBy, priorBinding.portal_user_id],
+          );
+        }
         await t.none(
           `UPDATE admin.portal_user_tenants
            SET deactivated_at = NULL, status = 'active', updated_by = $1
@@ -424,7 +437,13 @@ class EmployeesController extends BaseController {
       return priorBinding.portal_user_id;
     }
 
-    // Create a new portal_users + binding pair
+    // No prior binding — provision a brand-new portal_user. A password is
+    // required; generate a random one if none was supplied (admin must use
+    // the password-reset flow to deliver credentials).
+    const clearPassword = suppliedPassword || crypto.randomBytes(12).toString('base64url');
+    const rounds = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
+    const passwordHash = await bcrypt.hash(clearPassword, rounds);
+
     const portalUserId = await db.tx(async (t) => {
       const user = await t.one(
         `INSERT INTO admin.portal_users (email, password_hash, status, created_by)

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -74,6 +74,7 @@ class VendorContactsController extends BaseController {
           source_type: 'vendor_contact',
           label: `${contact.first_name} ${contact.last_name}`,
           created_by: req.body.created_by || null,
+          updated_by: req.body.created_by || null,
         });
 
         // 3. Link the source back

--- a/apps/server/src/system/core/controllers/vendorsController.js
+++ b/apps/server/src/system/core/controllers/vendorsController.js
@@ -47,6 +47,7 @@ class VendorsController extends BaseController {
           source_type: 'vendor',
           label: vendor.name,
           created_by: req.body.created_by || null,
+          updated_by: req.body.created_by || null,
         });
 
         // 3. Link the source back to the vendor

--- a/apps/server/src/system/core/models/Clients.js
+++ b/apps/server/src/system/core/models/Clients.js
@@ -13,7 +13,6 @@ import { readFileSync } from 'node:fs';
 import { TableModel } from 'pg-schemata';
 import clientsSchema from '../schemas/clientsSchema.js';
 import {
-  importSourceEntity,
   exportFlatSourceEntity,
   importFlatSourceEntity,
   isUuid,
@@ -75,20 +74,12 @@ export default class Clients extends TableModel {
   }
 
   /**
-   * Import clients from a spreadsheet.
-   * Auto-detects format:
-   *   - 1 sheet: new flat repeated-row format
-   *   - >1 sheet: legacy multi-sheet format (delegate to importSourceEntity)
+   * Import clients from a single flat-format spreadsheet.
    */
-  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null) {
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
     const { WorkbookReader } = await import('@nap-sft/tablsx');
     const buffer = readFileSync(filePath);
     const reader = WorkbookReader.fromBuffer(buffer);
-
-    if (reader.sheetCount > 1) {
-      return importSourceEntity(this, filePath, _sheetIndex, callbackFn, CONFIG);
-    }
-
-    return importFlatSourceEntity(this, reader, callbackFn, CONFIG);
+    return importFlatSourceEntity(this, reader, callbackFn, CONFIG, options);
   }
 }

--- a/apps/server/src/system/core/models/Companies.js
+++ b/apps/server/src/system/core/models/Companies.js
@@ -13,7 +13,6 @@ import { readFileSync } from 'node:fs';
 import { TableModel } from 'pg-schemata';
 import companiesSchema from '../schemas/companiesSchema.js';
 import {
-  importSourceEntity,
   exportFlatSourceEntity,
   importFlatSourceEntity,
   isUuid,
@@ -68,20 +67,12 @@ export default class Companies extends TableModel {
   }
 
   /**
-   * Import companies from a spreadsheet.
-   * Auto-detects format:
-   *   - 1 sheet: new flat repeated-row format
-   *   - >1 sheet: legacy multi-sheet format (delegate to importSourceEntity)
+   * Import companies from a single flat-format spreadsheet.
    */
-  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null) {
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
     const { WorkbookReader } = await import('@nap-sft/tablsx');
     const buffer = readFileSync(filePath);
     const reader = WorkbookReader.fromBuffer(buffer);
-
-    if (reader.sheetCount > 1) {
-      return importSourceEntity(this, filePath, _sheetIndex, callbackFn, CONFIG);
-    }
-
-    return importFlatSourceEntity(this, reader, callbackFn, CONFIG);
+    return importFlatSourceEntity(this, reader, callbackFn, CONFIG, options);
   }
 }

--- a/apps/server/src/system/core/models/Contacts.js
+++ b/apps/server/src/system/core/models/Contacts.js
@@ -13,7 +13,6 @@ import { readFileSync } from 'node:fs';
 import { TableModel } from 'pg-schemata';
 import contactsSchema from '../schemas/contactsSchema.js';
 import {
-  importSourceEntity,
   exportFlatSourceEntity,
   importFlatSourceEntity,
   isUuid,
@@ -73,20 +72,12 @@ export default class Contacts extends TableModel {
   }
 
   /**
-   * Import contacts from a spreadsheet.
-   * Auto-detects format:
-   *   - 1 sheet: new flat repeated-row format
-   *   - >1 sheet: legacy multi-sheet format (delegate to importSourceEntity)
+   * Import contacts from a single flat-format spreadsheet.
    */
-  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null) {
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
     const { WorkbookReader } = await import('@nap-sft/tablsx');
     const buffer = readFileSync(filePath);
     const reader = WorkbookReader.fromBuffer(buffer);
-
-    if (reader.sheetCount > 1) {
-      return importSourceEntity(this, filePath, _sheetIndex, callbackFn, CONFIG);
-    }
-
-    return importFlatSourceEntity(this, reader, callbackFn, CONFIG);
+    return importFlatSourceEntity(this, reader, callbackFn, CONFIG, options);
   }
 }

--- a/apps/server/src/system/core/models/Employees.js
+++ b/apps/server/src/system/core/models/Employees.js
@@ -13,7 +13,6 @@ import { readFileSync } from 'node:fs';
 import { TableModel } from 'pg-schemata';
 import employeesSchema from '../schemas/employeesSchema.js';
 import {
-  importSourceEntity,
   exportFlatSourceEntity,
   importFlatSourceEntity,
   isUuid,
@@ -78,20 +77,12 @@ export default class Employees extends TableModel {
   }
 
   /**
-   * Import employees from a spreadsheet.
-   * Auto-detects format:
-   *   - 1 sheet: new flat repeated-row format
-   *   - >1 sheet: legacy multi-sheet format (delegate to importSourceEntity)
+   * Import employees from a single flat-format spreadsheet.
    */
-  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null) {
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
     const { WorkbookReader } = await import('@nap-sft/tablsx');
     const buffer = readFileSync(filePath);
     const reader = WorkbookReader.fromBuffer(buffer);
-
-    if (reader.sheetCount > 1) {
-      return importSourceEntity(this, filePath, _sheetIndex, callbackFn, CONFIG);
-    }
-
-    return importFlatSourceEntity(this, reader, callbackFn, CONFIG);
+    return importFlatSourceEntity(this, reader, callbackFn, CONFIG, options);
   }
 }

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -560,6 +560,7 @@ export default class Vendors extends TableModel {
           source_type: CONFIG.sourceType,
           label: CONFIG.buildLabel(rec),
           created_by: createdBy,
+          updated_by: createdBy,
         }));
         const sourceResults = await sourcesModel.bulkInsert(sourceRecords, ['id', 'table_id']);
         const sourceByParentId = new Map(sourceResults.map((sr) => [sr.table_id, sr.id]));
@@ -696,6 +697,7 @@ export default class Vendors extends TableModel {
           source_type: CONTACT_CONFIG.sourceType,
           label: CONTACT_CONFIG.buildLabel(rec),
           created_by: createdBy,
+          updated_by: createdBy,
         }));
         const sourceResults = await sourcesModel.bulkInsert(sourceRecords, ['id', 'table_id']);
         const sourceByParentId = new Map(sourceResults.map((sr) => [sr.table_id, sr.id]));
@@ -1031,6 +1033,7 @@ export default class Vendors extends TableModel {
           source_type: CONTACT_CONFIG.sourceType,
           label: CONTACT_CONFIG.buildLabel(rec),
           created_by: createdBy,
+          updated_by: createdBy,
         }));
 
         const sourceResults = await sourcesModel.bulkInsert(sourceRecords, ['id', 'table_id']);

--- a/apps/server/src/system/core/schemas/addressesSchema.js
+++ b/apps/server/src/system/core/schemas/addressesSchema.js
@@ -48,6 +48,7 @@ const addressesSchema = {
     indexes: [
       { type: 'Index', columns: ['tenant_id'] },
       { type: 'Index', columns: ['source_id'] },
+      { type: 'Index', columns: ['source_id', 'label'], unique: true, where: 'deactivated_at IS NULL AND label IS NOT NULL' },
     ],
   },
 };

--- a/apps/server/src/system/core/schemas/emailsSchema.js
+++ b/apps/server/src/system/core/schemas/emailsSchema.js
@@ -42,6 +42,7 @@ const emailsSchema = {
       { type: 'Index', columns: ['email'], unique: true, where: 'deactivated_at IS NULL' },
       { type: 'Index', columns: ['source_id'], unique: true, where: 'is_login = true AND deactivated_at IS NULL' },
       { type: 'Index', columns: ['source_id'], unique: true, where: 'is_primary = true AND deactivated_at IS NULL' },
+      { type: 'Index', columns: ['source_id', 'label'], unique: true, where: 'deactivated_at IS NULL AND label IS NOT NULL' },
     ],
   },
 };

--- a/apps/server/src/system/core/schemas/phoneNumbersSchema.js
+++ b/apps/server/src/system/core/schemas/phoneNumbersSchema.js
@@ -47,6 +47,7 @@ const phoneNumbersSchema = {
       { type: 'Index', columns: ['tenant_id'] },
       { type: 'Index', columns: ['source_id'] },
       { type: 'Index', columns: ['source_id'], unique: true, where: 'is_primary = true AND deactivated_at IS NULL' },
+      { type: 'Index', columns: ['source_id', 'phone_type'], unique: true, where: 'deactivated_at IS NULL' },
       {
         type: 'Index',
         columns: ['country_code', 'phone_number'],

--- a/apps/server/src/system/core/schemas/taxIdentifiersSchema.js
+++ b/apps/server/src/system/core/schemas/taxIdentifiersSchema.js
@@ -44,6 +44,12 @@ const taxIdentifiersSchema = {
         unique: true,
         where: 'deactivated_at IS NULL',
       },
+      {
+        type: 'Index',
+        columns: ['source_id', 'country_code', 'tax_type'],
+        unique: true,
+        where: 'deactivated_at IS NULL',
+      },
     ],
   },
 };

--- a/apps/server/src/system/core/services/numberingService.js
+++ b/apps/server/src/system/core/services/numberingService.js
@@ -103,8 +103,11 @@ export async function allocateNumber(schema, idType, scopeId = null, issuedAt = 
     const step = config.increment || 1;
     let serial;
     if (!state) {
-      // 4a. Insert new row — first serial equals the increment value
-      serial = step;
+      // 4a. First allocation for this (idType, scope, period). Honor codes
+      // already in the target table (typed manually, seeded, or imported)
+      // by starting the sequence above the existing max.
+      const maxExisting = await _findMaxExistingSerial(tx, s, pgp, idType, config);
+      serial = (maxExisting > 0 ? maxExisting : 0) + step;
       await tx.none(
         `INSERT INTO ${s}.tenant_number_sequence_state
          (tenant_id, id_type, scope_id, period_key, last_serial)
@@ -170,13 +173,15 @@ export async function allocateNumbers(schema, idType, count, scopeId = null, iss
     const step = config.increment || 1;
     let startSerial;
     if (!state) {
-      // New period — first serial equals increment, last_serial = increment * count
-      startSerial = step;
+      // First allocation. Honor pre-existing codes (see allocateNumber for
+      // the same reasoning).
+      const maxExisting = await _findMaxExistingSerial(tx, s, pgp, idType, config);
+      startSerial = (maxExisting > 0 ? maxExisting : 0) + step;
       await tx.none(
         `INSERT INTO ${s}.tenant_number_sequence_state
          (tenant_id, id_type, scope_id, period_key, last_serial)
          VALUES ($1, $2, $3, $4, $5)`,
-        [config.tenant_id, idType, effectiveScopeId, periodKey, step * count],
+        [config.tenant_id, idType, effectiveScopeId, periodKey, startSerial + step * (count - 1)],
       );
     } else {
       // Existing period — advance by increment * count
@@ -208,6 +213,35 @@ const ID_TYPE_TABLE = {
   client: 'clients',
   contact: 'contacts',
 };
+
+/**
+ * Scan the target table for the highest serial number already present in the
+ * `code` column matching the config's prefix/separator/suffix pattern. Used
+ * when seeding a brand-new sequence_state row so manually-assigned codes
+ * (e.g. tenant bootstrap data) don't collide with allocator output.
+ *
+ * Returns 0 if no existing matching codes are found.
+ * @private
+ */
+async function _findMaxExistingSerial(tx, s, pgp, idType, config) {
+  const baseTable = ID_TYPE_TABLE[idType];
+  if (!baseTable) return 0;
+  const escape = (str) => String(str).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = `^${escape(config.prefix || '')}${escape(config.separator || '')}(\\d+)${escape(config.suffix || '')}$`;
+  const rows = await tx.manyOrNone(
+    `SELECT code FROM ${s}.${pgp.as.name(baseTable)} WHERE code ~ $1`,
+    [pattern],
+  );
+  let max = 0;
+  const re = new RegExp(pattern);
+  for (const r of rows) {
+    const m = String(r.code).match(re);
+    if (!m) continue;
+    const n = parseInt(m[1], 10);
+    if (Number.isFinite(n) && n > max) max = n;
+  }
+  return max;
+}
 
 /**
  * Backfill codes for existing records that have code IS NULL when numbering

--- a/apps/server/src/system/core/services/numberingService.js
+++ b/apps/server/src/system/core/services/numberingService.js
@@ -106,7 +106,7 @@ export async function allocateNumber(schema, idType, scopeId = null, issuedAt = 
       // 4a. First allocation for this (idType, scope, period). Honor codes
       // already in the target table (typed manually, seeded, or imported)
       // by starting the sequence above the existing max.
-      const maxExisting = await _findMaxExistingSerial(tx, s, pgp, idType, config);
+      const maxExisting = await _findMaxExistingSerial(tx, s, pgp, idType, config, periodKey);
       serial = (maxExisting > 0 ? maxExisting : 0) + step;
       await tx.none(
         `INSERT INTO ${s}.tenant_number_sequence_state
@@ -175,7 +175,7 @@ export async function allocateNumbers(schema, idType, count, scopeId = null, iss
     if (!state) {
       // First allocation. Honor pre-existing codes (see allocateNumber for
       // the same reasoning).
-      const maxExisting = await _findMaxExistingSerial(tx, s, pgp, idType, config);
+      const maxExisting = await _findMaxExistingSerial(tx, s, pgp, idType, config, periodKey);
       startSerial = (maxExisting > 0 ? maxExisting : 0) + step;
       await tx.none(
         `INSERT INTO ${s}.tenant_number_sequence_state
@@ -216,18 +216,26 @@ const ID_TYPE_TABLE = {
 
 /**
  * Scan the target table for the highest serial number already present in the
- * `code` column matching the config's prefix/separator/suffix pattern. Used
- * when seeding a brand-new sequence_state row so manually-assigned codes
- * (e.g. tenant bootstrap data) don't collide with allocator output.
+ * `code` column for the current period. Used when seeding a brand-new
+ * sequence_state row so manually-assigned codes (e.g. tenant bootstrap data)
+ * don't collide with allocator output.
+ *
+ * When the config has a date mode, `buildDisplayId` emits codes of the form
+ * `<prefix><sep><periodKey><sep><digits><suffix>`. Only consider codes that
+ * match the current period — codes from other periods are irrelevant to the
+ * sequence we're seeding.
  *
  * Returns 0 if no existing matching codes are found.
  * @private
  */
-async function _findMaxExistingSerial(tx, s, pgp, idType, config) {
+async function _findMaxExistingSerial(tx, s, pgp, idType, config, periodKey) {
   const baseTable = ID_TYPE_TABLE[idType];
   if (!baseTable) return 0;
   const escape = (str) => String(str).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = `^${escape(config.prefix || '')}${escape(config.separator || '')}(\\d+)${escape(config.suffix || '')}$`;
+  const sep = escape(config.separator || '');
+  const hasDate = config.date_mode !== 'none' && periodKey && periodKey !== 'global';
+  const datePart = hasDate ? `${escape(periodKey)}${sep}` : '';
+  const pattern = `^${escape(config.prefix || '')}${sep}${datePart}(\\d+)${escape(config.suffix || '')}$`;
   const rows = await tx.manyOrNone(
     `SELECT code FROM ${s}.${pgp.as.name(baseTable)} WHERE code ~ $1`,
     [pattern],

--- a/apps/server/src/system/core/services/numberingService.js
+++ b/apps/server/src/system/core/services/numberingService.js
@@ -234,8 +234,17 @@ async function _findMaxExistingSerial(tx, s, pgp, idType, config, periodKey) {
   const escape = (str) => String(str).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const sep = escape(config.separator || '');
   const hasDate = config.date_mode !== 'none' && periodKey && periodKey !== 'global';
-  const datePart = hasDate ? `${escape(periodKey)}${sep}` : '';
-  const pattern = `^${escape(config.prefix || '')}${sep}${datePart}(\\d+)${escape(config.suffix || '')}$`;
+  // Mirror buildDisplayId's filter(Boolean).join(sep) so configs with an
+  // empty prefix (or no date part / no suffix) still match. Inserting `sep`
+  // unconditionally between parts produced a regex that couldn't match
+  // codes lacking a leading prefix.
+  const parts = [
+    config.prefix ? escape(config.prefix) : '',
+    hasDate ? escape(periodKey) : '',
+    '(\\d+)',
+    config.suffix ? escape(config.suffix) : '',
+  ].filter(Boolean);
+  const pattern = `^${parts.join(sep)}$`;
   const rows = await tx.manyOrNone(
     `SELECT code FROM ${s}.${pgp.as.name(baseTable)} WHERE code ~ $1`,
     [pattern],

--- a/apps/server/tests/contract/emails.test.js
+++ b/apps/server/tests/contract/emails.test.js
@@ -77,7 +77,7 @@ describe('Email CRUD — /api/core/v1/emails', () => {
     const res = await request(app)
       .post('/api/core/v1/emails')
       .set('Cookie', cookies)
-      .send({ source_id: employeeSourceId, email: 'work@emtest.com', label: 'work', is_primary: false });
+      .send({ source_id: employeeSourceId, email: 'work@emtest.com', label: 'home', is_primary: false });
 
     expect(res.status).toBe(201);
     expect(res.body.email).toBe('work@emtest.com');
@@ -171,7 +171,7 @@ describe('Email CRUD — /api/core/v1/emails', () => {
     const first = await request(app)
       .post('/api/core/v1/emails')
       .set('Cookie', cookies)
-      .send({ source_id: employeeSourceId, email: 'primary-a@emtest.com', label: 'work', is_primary: true });
+      .send({ source_id: employeeSourceId, email: 'primary-a@emtest.com', label: 'office', is_primary: true });
     expect(first.status).toBe(201);
     expect(first.body.is_primary).toBe(true);
 

--- a/apps/server/tests/contract/emails.test.js
+++ b/apps/server/tests/contract/emails.test.js
@@ -69,7 +69,7 @@ describe('Email CRUD — /api/core/v1/emails', () => {
     const empRes = await request(app)
       .post('/api/core/v1/employees')
       .set('Cookie', cookies)
-      .send({ first_name: 'Email', last_name: 'Tester', email: 'tester@emtest.com' });
+      .send({ first_name: 'Email', last_name: 'Tester', email: 'tester@emtest.com', roles: ['admin'] });
     employeeSourceId = empRes.body.source_id;
   }, 30000);
 

--- a/apps/server/tests/contract/employeeFlatReconciliation.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliation.test.js
@@ -96,7 +96,7 @@ function parentRow({ id = '', code = '', firstName = '', lastName = '', extras =
     is_app_user: isPrimary ? false : '',
     is_primary_contact: isPrimary ? false : '',
     is_billing_contact: isPrimary ? false : '',
-    roles: isPrimary ? '{}' : '',
+    roles: isPrimary ? '{admin}' : '',
     status: isPrimary ? 'active' : '',
     password: '',
     email: '', email_label: '', email_is_primary: '', email_is_login: '',
@@ -252,7 +252,7 @@ describe('Flat employee import — per-row reconciliation', () => {
   test('cross-source email collision is a blocking error with type-only context (R8)', async () => {
     // Create a second employee owning a distinct email
     const create = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
-      first_name: 'Gina', last_name: 'Garcia', code: 'FR-002',
+      first_name: 'Gina', last_name: 'Garcia', code: 'FR-002', roles: ['admin'],
     });
     expect(create.status).toBe(201);
     const ginaSourceId = create.body.source_id;
@@ -395,6 +395,96 @@ describe('Flat employee import — per-row reconciliation', () => {
     const offices = allEmails.filter((r) => r.label === 'office');
     expect(offices).toHaveLength(1);
     expect(offices[0].id).toBe(homeEmailIdBefore);
+  });
+
+  test('import auto-allocates employee code from numbering config when enabled', async () => {
+    // Enable employee numbering for FRECON.
+    const configRes = await request(app)
+      .get('/api/core/v1/numbering-config/where?id_type=employee')
+      .set('Cookie', cookies);
+    expect(configRes.status).toBe(200);
+    const empConfigId = configRes.body.records?.[0]?.id;
+    expect(empConfigId).toBeDefined();
+
+    const enableRes = await request(app)
+      .put(`/api/core/v1/numbering-config/update?id=${empConfigId}`)
+      .set('Cookie', cookies)
+      .send({ is_enabled: true });
+    expect(enableRes.status).toBe(200);
+
+    // Import a new employee with NO code — numbering should fill it in
+    // following the configured pattern (prefix 'EMP', padding 4).
+    const buf = await buildFlat([
+      parentRow({
+        firstName: 'Numbered', lastName: 'New',
+        extras: {},
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'numbering-new');
+    expect(res.status).toBe(201);
+
+    const emp = await db.oneOrNone(
+      `SELECT code FROM frecon.employees WHERE first_name = 'Numbered' AND last_name = 'New'`,
+    );
+    expect(emp).not.toBeNull();
+    expect(emp.code).toBeTruthy();
+    expect(emp.code).toMatch(/^EMP/);
+  });
+
+  test('import overrides spreadsheet-supplied code with numbering config when numbering is enabled', async () => {
+    // User scenario: numbering enabled (increment 10), spreadsheet contains
+    // hand-typed codes like EMP-9999. Expected: importer ignores the typed
+    // codes and follows the sequence allocator instead.
+    const configRes = await request(app)
+      .get('/api/core/v1/numbering-config/where?id_type=employee')
+      .set('Cookie', cookies);
+    const empConfigId = configRes.body.records?.[0]?.id;
+    await request(app)
+      .put(`/api/core/v1/numbering-config/update?id=${empConfigId}`)
+      .set('Cookie', cookies)
+      .send({ is_enabled: true, increment: 10 });
+
+    const buf = await buildFlat([
+      parentRow({
+        code: 'EMP-9999', firstName: 'TypedCode', lastName: 'Override',
+        extras: {},
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'override-supplied');
+    expect(res.status).toBe(201);
+
+    const emp = await db.oneOrNone(
+      `SELECT code FROM frecon.employees WHERE first_name = 'TypedCode' AND last_name = 'Override'`,
+    );
+    expect(emp).not.toBeNull();
+    expect(emp.code).toBeTruthy();
+    expect(emp.code).not.toBe('EMP-9999');
+    expect(emp.code).toMatch(/^EMP-\d{4}$/);
+  });
+
+  test('import allocates code for existing employee that has no code when numbering is enabled', async () => {
+    // Create an employee with code intentionally null (via direct DB write to
+    // bypass the controller's auto-allocation), then import a row that doesn't
+    // supply a code. The numbering allocator should fill it in on the update.
+    const codeless = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
+      first_name: 'Codeless', last_name: 'OnUpdate', roles: ['admin'],
+    });
+    expect(codeless.status).toBe(201);
+    // Force the code back to NULL so the import path's update branch is tested.
+    await db.none(`UPDATE frecon.employees SET code = NULL WHERE id = $1`, [codeless.body.id]);
+
+    const buf = await buildFlat([
+      parentRow({
+        id: codeless.body.id, firstName: 'Codeless', lastName: 'OnUpdate',
+        extras: {},
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'allocate-on-update');
+    expect(res.status).toBe(201);
+
+    const after = await db.oneOrNone(`SELECT code FROM frecon.employees WHERE id = $1`, [codeless.body.id]);
+    expect(after.code).toBeTruthy();
+    expect(after.code).toMatch(/^EMP/);
   });
 
   test('parent field edit stamps updated_by on the parent row', async () => {

--- a/apps/server/tests/contract/employeeFlatReconciliation.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliation.test.js
@@ -152,7 +152,14 @@ describe('Flat employee import — per-row reconciliation', () => {
     expect(personalEmailIdBefore).toBeTruthy();
   });
 
-  test('no-change re-import preserves child ids (R3)', async () => {
+  test('no-change re-import preserves child ids AND parent updated_at (R3)', async () => {
+    // Snapshot parent + child updated_at before re-import.
+    const employeeBefore = await db.oneOrNone(`SELECT id, updated_at FROM frecon.employees WHERE id = $1`, [employeeId]);
+    const emailsBefore = await db.any(
+      `SELECT id, label, updated_at FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY label`,
+      [employeeSourceId],
+    );
+
     const buf = await buildFlat([
       parentRow({
         id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
@@ -164,15 +171,30 @@ describe('Flat employee import — per-row reconciliation', () => {
     ]);
     const res = await postImport(buf, cookies, 'nochange');
     expect(res.status).toBe(201);
+    // No-change re-import must report zero writes — the parent NO-OP detection
+    // and the slot-keyed child reconciler should both produce zero updates.
+    expect(res.body.inserted).toBe(0);
+    expect(res.body.updated).toBe(0);
 
+    // Child ids unchanged
     const active = await db.any(
-      `SELECT id, label FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY label`,
+      `SELECT id, label, updated_at FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY label`,
       [employeeSourceId],
     );
     expect(active.map((r) => r.id).sort()).toEqual([homeEmailIdBefore, personalEmailIdBefore].sort());
 
+    // No soft-deletes
     const archived = await db.any(`SELECT id FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NOT NULL`, [employeeSourceId]);
     expect(archived).toHaveLength(0);
+
+    // updated_at preserved on parent and every child row (no implicit writes)
+    const employeeAfter = await db.oneOrNone(`SELECT updated_at FROM frecon.employees WHERE id = $1`, [employeeId]);
+    expect(employeeAfter.updated_at.toISOString()).toBe(employeeBefore.updated_at.toISOString());
+
+    const beforeByLabel = new Map(emailsBefore.map((r) => [r.label, r.updated_at.toISOString()]));
+    for (const row of active) {
+      expect(row.updated_at.toISOString()).toBe(beforeByLabel.get(row.label));
+    }
   });
 
   test('edit one email + omit the other: updates in place, omitted row left alone (R4, R6)', async () => {
@@ -291,9 +313,9 @@ describe('Flat employee import — per-row reconciliation', () => {
     expect(typeof res.body.noops).toBe('number');
     expect(typeof res.body.omitted).toBe('number');
     expect(res.body.errors).toEqual([]);
-    // Parent counts as 1 update (existing); both child emails NOOP
-    expect(res.body.updates).toBe(1);
-    expect(res.body.noops).toBe(2);
+    // Parent unchanged → NO-OP (not a forced "update"). Both child emails also NO-OP.
+    expect(res.body.updates).toBe(0);
+    expect(res.body.noops).toBe(3);
     expect(res.body.inserts).toBe(0);
 
     // State unchanged after preview

--- a/apps/server/tests/contract/employeeFlatReconciliation.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliation.test.js
@@ -208,10 +208,19 @@ describe('Flat employee import — per-row reconciliation', () => {
     const res = await postImport(buf, cookies, 'edit-omit');
     expect(res.status).toBe(201);
 
-    // home email: same id, new value
-    const home = await db.oneOrNone(`SELECT id, email FROM frecon.emails WHERE id = $1`, [homeEmailIdBefore]);
+    // home email: same id, new value, audit fields stamped to the importing user
+    const home = await db.oneOrNone(
+      `SELECT id, email, updated_by, updated_at, created_at FROM frecon.emails WHERE id = $1`,
+      [homeEmailIdBefore],
+    );
     expect(home).not.toBeNull();
     expect(home.email).toBe('frank.home-NEW@frecon.com');
+    expect(home.updated_by).not.toBeNull();
+    expect(home.updated_at.getTime()).toBeGreaterThan(home.created_at.getTime());
+
+    // Parent: should also be stamped if anything changed. For this test no
+    // parent column changed, so updated_by may stay null — only the child
+    // assertion is meaningful here.
 
     // personal email: untouched, still active under its original id
     const personal = await db.oneOrNone(
@@ -222,6 +231,7 @@ describe('Flat employee import — per-row reconciliation', () => {
     expect(personal.email).toBe('frank.personal@frecon.com');
     expect(personal.deactivated_at).toBeNull();
   });
+
 
   test('intra-file duplicate slot is a blocking error (R7)', async () => {
     const buf = await buildFlat([
@@ -344,5 +354,69 @@ describe('Flat employee import — per-row reconciliation', () => {
     const realRes = await postImport(buf, cookies, 'real-err');
     expect(realRes.status).toBe(422);
     expect(realRes.body.errors.length).toBeGreaterThan(0);
+  });
+
+  test('slot rename (label change with same email value) updates in place — no DB unique violation', async () => {
+    // 2c regression: changing an email row's label while keeping the value
+    // must update the existing row (label rename), not insert a duplicate.
+    // Before the value-match fallback, the importer tried INSERT and crashed
+    // with 23505 because (email) WHERE deactivated_at IS NULL is unique.
+
+    // Build a clean baseline: Frank's home email value as it currently is.
+    const home = await db.oneOrNone(
+      `SELECT id, email, label FROM frecon.emails WHERE id = $1`,
+      [homeEmailIdBefore],
+    );
+    expect(home).not.toBeNull();
+    const homeValue = home.email;
+
+    const buf = await buildFlat([
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { email: homeValue, email_label: 'office', email_is_primary: true, email_is_login: false },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'slot-rename');
+    expect(res.status).toBe(201);
+
+    const after = await db.oneOrNone(
+      `SELECT id, label, email FROM frecon.emails WHERE id = $1`,
+      [homeEmailIdBefore],
+    );
+    expect(after).not.toBeNull();
+    expect(after.label).toBe('office');
+    expect(after.email).toBe(homeValue);
+
+    // No new row was inserted for that source — original row id was reused.
+    const allEmails = await db.any(
+      `SELECT id, label FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NULL`,
+      [employeeSourceId],
+    );
+    const offices = allEmails.filter((r) => r.label === 'office');
+    expect(offices).toHaveLength(1);
+    expect(offices[0].id).toBe(homeEmailIdBefore);
+  });
+
+  test('parent field edit stamps updated_by on the parent row', async () => {
+    // Run last in this describe block: this test mutates Frank's parent
+    // fields and must not interfere with prior NO-OP / preview assertions.
+    const buf = await buildFlat([
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { position: 'Engineer' },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'parent-edit');
+    expect(res.status).toBe(201);
+    expect(res.body.updated).toBe(1);
+
+    const after = await db.oneOrNone(
+      `SELECT position, updated_by, updated_at, created_at FROM frecon.employees WHERE id = $1`,
+      [employeeId],
+    );
+    expect(after.position).toBe('Engineer');
+    expect(after.updated_by).not.toBeNull();
+    expect(after.updated_by).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(after.updated_at.getTime()).toBeGreaterThan(after.created_at.getTime());
   });
 });

--- a/apps/server/tests/contract/employeeFlatReconciliation.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliation.test.js
@@ -1,0 +1,326 @@
+/**
+ * @file Contract tests for flat-format employee import per-row reconciliation
+ * @module tests/contract/employeeFlatReconciliation
+ *
+ * Covers the rules from /Users/ian/.claude/plans/explain-why-when-updating-rustling-hellman.md:
+ *   - No-change re-import preserves child ids (R3).
+ *   - Editing one row's value updates in place; omitted rows are left alone (R4, R6).
+ *   - Intra-file duplicate slot is a blocking error (R7).
+ *   - Cross-source value collision is a blocking error with type-only context (R8).
+ *   - Issue cap at 100 + sentinel (R9).
+ *   - Mandatory preview returns counts and does not write (R10).
+ *   - Preview errors block real import.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(cookies, code) {
+  await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', cookies)
+    .send({
+      tenant_code: code,
+      company: `${code} Reconcile Corp`,
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'Test',
+      admin_last_name: 'Admin',
+      admin_email: `admin@${code.toLowerCase()}.com`,
+      admin_password: 'ReconcilePass123!',
+      billing_address: { address_line_1: '1 Test St', country_code: 'US' },
+    });
+}
+
+const FLAT_HEADERS = [
+  'id', 'code', 'first_name', 'last_name', 'position', 'department',
+  'is_app_user', 'is_primary_contact', 'is_billing_contact', 'roles', 'status', 'password',
+  'email', 'email_label', 'email_is_primary', 'email_is_login',
+  'phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary',
+  'address_label', 'address_line_1', 'address_line_2', 'address_line_3',
+  'address_city', 'address_state_province', 'address_postal_code', 'address_country_code',
+  'tax_country_code', 'tax_type', 'tax_value',
+];
+
+async function buildFlat(rows) {
+  const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+  const wb = WorkbookBuilder.create();
+  wb.sheet('Employees').setHeaders(FLAT_HEADERS).addObjects(rows);
+  return writeXlsx(wb.build());
+}
+
+async function postImport(buf, cookies, label, { preview = false } = {}) {
+  const tmpPath = join(tmpdir(), `flat-${label}-${Date.now()}.xlsx`);
+  writeFileSync(tmpPath, buf);
+  const url = `/api/core/v1/employees/import-xls${preview ? '?preview=1' : ''}`;
+  try {
+    return await request(app).post(url).set('Cookie', cookies).attach('file', tmpPath);
+  } finally {
+    unlinkSync(tmpPath);
+  }
+}
+
+function parentRow({ id = '', code = '', firstName = '', lastName = '', extras = {} } = {}) {
+  // Continuation rows must have ALL parent cols blank so groupFlatRows() detects them.
+  // Only the first row of a group should carry parent values.
+  const isPrimary = !!(id || code || firstName || lastName);
+  return {
+    id, code, first_name: firstName, last_name: lastName,
+    position: '', department: '',
+    is_app_user: isPrimary ? false : '',
+    is_primary_contact: isPrimary ? false : '',
+    is_billing_contact: isPrimary ? false : '',
+    roles: isPrimary ? '{}' : '',
+    status: isPrimary ? 'active' : '',
+    password: '',
+    email: '', email_label: '', email_is_primary: '', email_is_login: '',
+    phone_country_code: '', phone_type: '', phone_number: '', phone_is_primary: '',
+    address_label: '', address_line_1: '', address_line_2: '', address_line_3: '',
+    address_city: '', address_state_province: '', address_postal_code: '', address_country_code: '',
+    tax_country_code: '', tax_type: '', tax_value: '',
+    ...extras,
+  };
+}
+
+describe('Flat employee import — per-row reconciliation', () => {
+  let cookies;
+  let employeeId;
+  let homeEmailIdBefore;
+  let personalEmailIdBefore;
+  let employeeSourceId;
+
+  beforeAll(async () => {
+    const rootCookies = await loginRoot();
+    await provisionTenant(rootCookies, 'FRECON');
+    const loginRes = await request(app).post('/api/auth/login').send({ email: 'admin@frecon.com', password: 'ReconcilePass123!' });
+    cookies = loginRes.headers['set-cookie'];
+  }, 30000);
+
+  test('initial import creates employee with two emails (distinct labels)', async () => {
+    const buf = await buildFlat([
+      parentRow({
+        code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { email: 'frank.home@frecon.com', email_label: 'home', email_is_primary: true, email_is_login: false },
+      }),
+      parentRow({
+        extras: { email: 'frank.personal@frecon.com', email_label: 'personal', email_is_primary: false, email_is_login: false },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'initial');
+    expect(res.status).toBe(201);
+    expect(res.body.inserted).toBe(1);
+
+    const employee = await db.oneOrNone(`SELECT id, source_id FROM frecon.employees WHERE code = 'FR-001'`);
+    expect(employee).not.toBeNull();
+    employeeId = employee.id;
+    employeeSourceId = employee.source_id;
+
+    const emails = await db.any(
+      `SELECT id, email, label FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY label`,
+      [employeeSourceId],
+    );
+    expect(emails).toHaveLength(2);
+    homeEmailIdBefore = emails.find((e) => e.label === 'home').id;
+    personalEmailIdBefore = emails.find((e) => e.label === 'personal').id;
+    expect(homeEmailIdBefore).toBeTruthy();
+    expect(personalEmailIdBefore).toBeTruthy();
+  });
+
+  test('no-change re-import preserves child ids (R3)', async () => {
+    const buf = await buildFlat([
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { email: 'frank.home@frecon.com', email_label: 'home', email_is_primary: true, email_is_login: false },
+      }),
+      parentRow({
+        extras: { email: 'frank.personal@frecon.com', email_label: 'personal', email_is_primary: false, email_is_login: false },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'nochange');
+    expect(res.status).toBe(201);
+
+    const active = await db.any(
+      `SELECT id, label FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY label`,
+      [employeeSourceId],
+    );
+    expect(active.map((r) => r.id).sort()).toEqual([homeEmailIdBefore, personalEmailIdBefore].sort());
+
+    const archived = await db.any(`SELECT id FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NOT NULL`, [employeeSourceId]);
+    expect(archived).toHaveLength(0);
+  });
+
+  test('edit one email + omit the other: updates in place, omitted row left alone (R4, R6)', async () => {
+    const buf = await buildFlat([
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { email: 'frank.home-NEW@frecon.com', email_label: 'home', email_is_primary: true, email_is_login: false },
+      }),
+      // personal email row intentionally omitted
+    ]);
+    const res = await postImport(buf, cookies, 'edit-omit');
+    expect(res.status).toBe(201);
+
+    // home email: same id, new value
+    const home = await db.oneOrNone(`SELECT id, email FROM frecon.emails WHERE id = $1`, [homeEmailIdBefore]);
+    expect(home).not.toBeNull();
+    expect(home.email).toBe('frank.home-NEW@frecon.com');
+
+    // personal email: untouched, still active under its original id
+    const personal = await db.oneOrNone(
+      `SELECT id, email, deactivated_at FROM frecon.emails WHERE id = $1`,
+      [personalEmailIdBefore],
+    );
+    expect(personal).not.toBeNull();
+    expect(personal.email).toBe('frank.personal@frecon.com');
+    expect(personal.deactivated_at).toBeNull();
+  });
+
+  test('intra-file duplicate slot is a blocking error (R7)', async () => {
+    const buf = await buildFlat([
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { email: 'a@frecon.com', email_label: 'work', email_is_primary: false, email_is_login: false },
+      }),
+      parentRow({
+        extras: { email: 'b@frecon.com', email_label: 'work', email_is_primary: false, email_is_login: false },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'dup-slot');
+    expect(res.status).toBe(422);
+    const dup = res.body.errors.find((e) => /Duplicate emails label/i.test(e.message || ''));
+    expect(dup).toBeDefined();
+  });
+
+  test('cross-source email collision is a blocking error with type-only context (R8)', async () => {
+    // Create a second employee owning a distinct email
+    const create = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
+      first_name: 'Gina', last_name: 'Garcia', code: 'FR-002',
+    });
+    expect(create.status).toBe(201);
+    const ginaSourceId = create.body.source_id;
+    const addEmail = await request(app).post('/api/core/v1/emails').set('Cookie', cookies).send({
+      source_id: ginaSourceId, email: 'shared@frecon.com', label: 'shared', is_primary: false,
+    });
+    expect(addEmail.status).toBe(201);
+
+    // Now try to import Frank with the same email value under a different slot
+    const buf = await buildFlat([
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { email: 'shared@frecon.com', email_label: 'office', email_is_primary: false, email_is_login: false },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'cross-source');
+    expect(res.status).toBe(422);
+    const collision = res.body.errors.find((e) => /already in use by another/i.test(e.message || ''));
+    expect(collision).toBeDefined();
+    expect(collision.message).toMatch(/employee/i);
+    expect(String(collision.value).toLowerCase()).toBe('shared@frecon.com');
+
+    // Frank's emails unchanged (home was edited in prior test; personal still original)
+    const frank = await db.any(`SELECT email FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY email`, [employeeSourceId]);
+    expect(frank.map((r) => r.email)).toEqual(['frank.home-NEW@frecon.com', 'frank.personal@frecon.com']);
+  });
+
+  test('issue cap at 100 with a sentinel entry (R9)', async () => {
+    const rows = [];
+    for (let i = 0; i < 150; i++) {
+      const isFirst = i === 0;
+      rows.push(parentRow({
+        code: isFirst ? 'FR-CAP' : '',
+        firstName: isFirst ? 'Cap' : '',
+        lastName: isFirst ? 'Test' : '',
+        extras: { email: 'not-an-email', email_label: `lbl-${i}`, email_is_primary: false, email_is_login: false },
+      }));
+    }
+    const buf = await buildFlat(rows);
+    const res = await postImport(buf, cookies, 'cap');
+    expect(res.status).toBe(422);
+    expect(res.body.errors.length).toBe(101);
+    expect(res.body.errors[100].message).toMatch(/Issue limit reached \(100\)/);
+  });
+
+  test('mandatory preview returns counts and does not write (R10)', async () => {
+    // Build a clean re-import for Frank with the values currently in the DB
+    const buf = await buildFlat([
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { email: 'frank.home-NEW@frecon.com', email_label: 'home', email_is_primary: true, email_is_login: false },
+      }),
+      parentRow({
+        extras: { email: 'frank.personal@frecon.com', email_label: 'personal', email_is_primary: false, email_is_login: false },
+      }),
+    ]);
+    // Snapshot state before preview
+    const before = await db.any(
+      `SELECT id, email FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY id`,
+      [employeeSourceId],
+    );
+
+    const res = await postImport(buf, cookies, 'preview', { preview: true });
+    expect(res.status).toBe(200);
+    expect(res.body.preview).toBe(true);
+    expect(typeof res.body.inserts).toBe('number');
+    expect(typeof res.body.updates).toBe('number');
+    expect(typeof res.body.noops).toBe('number');
+    expect(typeof res.body.omitted).toBe('number');
+    expect(res.body.errors).toEqual([]);
+    // Parent counts as 1 update (existing); both child emails NOOP
+    expect(res.body.updates).toBe(1);
+    expect(res.body.noops).toBe(2);
+    expect(res.body.inserts).toBe(0);
+
+    // State unchanged after preview
+    const after = await db.any(
+      `SELECT id, email FROM frecon.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY id`,
+      [employeeSourceId],
+    );
+    expect(after).toEqual(before);
+  });
+
+  test('preview errors block real import (defensive)', async () => {
+    const buf = await buildFlat([
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { email: 'a@frecon.com', email_label: 'work', email_is_primary: false, email_is_login: false },
+      }),
+      parentRow({
+        extras: { email: 'b@frecon.com', email_label: 'work', email_is_primary: false, email_is_login: false },
+      }),
+    ]);
+
+    const previewRes = await postImport(buf, cookies, 'preview-err', { preview: true });
+    expect(previewRes.status).toBe(422);
+    expect(previewRes.body.errors.length).toBeGreaterThan(0);
+
+    const realRes = await postImport(buf, cookies, 'real-err');
+    expect(realRes.status).toBe(422);
+    expect(realRes.body.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/server/tests/contract/employeeFlatReconciliation.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliation.test.js
@@ -487,6 +487,119 @@ describe('Flat employee import — per-row reconciliation', () => {
     expect(after.code).toMatch(/^EMP/);
   });
 
+  test('2e — add a new child row to an existing employee (append continuation)', async () => {
+    // Frank still has personal email; add a new "office" address as a
+    // continuation row. Existing children stay untouched; one new INSERT.
+    const buf = await buildFlat([
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: {
+          email: 'frank.home-NEW@frecon.com', email_label: 'home',
+          email_is_primary: true, email_is_login: false,
+        },
+      }),
+      parentRow({
+        extras: {
+          address_label: 'office', address_line_1: '123 Office Way',
+          address_city: 'Portland', address_state_province: 'OR',
+          address_postal_code: '97201', address_country_code: 'US',
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'add-child');
+    expect(res.status).toBe(201);
+
+    const addresses = await db.any(
+      `SELECT label FROM frecon.addresses WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY label`,
+      [employeeSourceId],
+    );
+    expect(addresses.map((a) => a.label)).toContain('office');
+  });
+
+  test('6a — blank slot key (email_label missing) is a blocking error', async () => {
+    const buf = await buildFlat([
+      parentRow({
+        id: '', code: 'FR-6A', firstName: 'Sixa', lastName: 'Slot',
+        extras: { email: 'sixa@frecon.com', email_label: '', email_is_primary: true, email_is_login: false },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, '6a');
+    expect(res.status).toBe(422);
+    expect(res.body.errors.some((e) => /label is required/i.test(e.message || ''))).toBe(true);
+
+    const emp = await db.oneOrNone(`SELECT id FROM frecon.employees WHERE code = 'FR-6A'`);
+    expect(emp).toBeNull();
+  });
+
+  test('6b — invalid email format is a blocking error', async () => {
+    const buf = await buildFlat([
+      parentRow({
+        id: '', code: 'FR-6B', firstName: 'Sixb', lastName: 'BadEmail',
+        extras: { email: 'not-an-email', email_label: 'work', email_is_primary: true, email_is_login: false },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, '6b');
+    expect(res.status).toBe(422);
+    expect(res.body.errors.some((e) => /invalid email format/i.test(e.message || ''))).toBe(true);
+
+    const emp = await db.oneOrNone(`SELECT id FROM frecon.employees WHERE code = 'FR-6B'`);
+    expect(emp).toBeNull();
+  });
+
+  test('6c — required name field missing is a blocking error with row context', async () => {
+    const buf = await buildFlat([
+      parentRow({
+        id: '', code: 'FR-6C', firstName: '', lastName: 'NoFirst',
+      }),
+    ]);
+    const res = await postImport(buf, cookies, '6c');
+    expect(res.status).toBe(422);
+    const err = res.body.errors.find((e) => /first name is required/i.test(e.message || ''));
+    expect(err).toBeDefined();
+    expect(err.row).toBeTruthy();    // row-keyed, not generic
+
+    const emp = await db.oneOrNone(`SELECT id FROM frecon.employees WHERE code = 'FR-6C'`);
+    expect(emp).toBeNull();
+  });
+
+  test('7a — mixed file: insert + update + unchanged in one import', async () => {
+    // Frank gets a field edit; bring in a brand-new employee in the same file;
+    // a second existing employee unchanged. Verify preview classifies all three
+    // distinctly and the writer honors the mix.
+    const newCode = `MIX-${Date.now()}`;
+    const buf = await buildFlat([
+      // Frank — UPDATE (different department)
+      parentRow({
+        id: employeeId, code: 'FR-001', firstName: 'Frank', lastName: 'Reconciler',
+        extras: { position: 'Engineer', department: 'Platform' },
+      }),
+      // Gina — UNCHANGED (created in the cross-source test earlier)
+      parentRow({ firstName: 'Gina', lastName: 'Garcia', code: 'FR-002' }),
+      // Brand-new employee — INSERT
+      parentRow({
+        id: '', code: newCode, firstName: 'Maya', lastName: 'Mixed',
+        extras: { roles: '{admin}' },
+      }),
+    ]);
+
+    const preview = await postImport(buf, cookies, '7a-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body.inserts).toBeGreaterThanOrEqual(1);
+    expect(preview.body.updates).toBeGreaterThanOrEqual(1);
+
+    const res = await postImport(buf, cookies, '7a');
+    expect(res.status).toBe(201);
+
+    // Numbering may be enabled by earlier tests; query by name instead of
+    // the supplied code (which the allocator can override).
+    const maya = await db.oneOrNone(
+      `SELECT id FROM frecon.employees WHERE first_name = 'Maya' AND last_name = 'Mixed'`,
+    );
+    expect(maya).not.toBeNull();
+    const frank = await db.oneOrNone(`SELECT department FROM frecon.employees WHERE id = $1`, [employeeId]);
+    expect(frank.department).toBe('Platform');
+  });
+
   test('parent field edit stamps updated_by on the parent row', async () => {
     // Run last in this describe block: this test mutates Frank's parent
     // fields and must not interfere with prior NO-OP / preview assertions.

--- a/apps/server/tests/contract/employeeFlatReconciliation.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliation.test.js
@@ -2,7 +2,7 @@
  * @file Contract tests for flat-format employee import per-row reconciliation
  * @module tests/contract/employeeFlatReconciliation
  *
- * Covers the rules from /Users/ian/.claude/plans/explain-why-when-updating-rustling-hellman.md:
+ * Behavior locked in:
  *   - No-change re-import preserves child ids (R3).
  *   - Editing one row's value updates in place; omitted rows are left alone (R4, R6).
  *   - Intra-file duplicate slot is a blocking error (R7).

--- a/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
@@ -1,0 +1,424 @@
+/**
+ * @file Contract tests for L1/L2/L2b/C3 bypass-bug fixes in flat employee import
+ * @module tests/contract/employeeFlatReconciliationLoginCascade
+ *
+ * Covers the rules from /Users/ian/.claude/plans/explain-why-when-updating-rustling-hellman.md:
+ *   - L1.a — login email value change syncs to portal_users.
+ *   - L1.b — login email value change to a portal_user in another tenant → 422.
+ *   - L2   — cannot unset is_login on active app user via import → 422.
+ *   - L2.swap — service-level test that vendor_contact login-email change is detected.
+ *   - L2b.archive — archiving an active app-user employee locks portal_user.
+ *   - L2b.restore — restoring an archived app-user employee unlocks portal_user.
+ *   - L2b.toggle-off — is_app_user true → false on UPDATE locks portal_user.
+ *   - L2b.toggle-on — is_app_user false → true on UPDATE provisions portal_user.
+ *   - L4.two-logins — two is_login: true rows for one source → 422.
+ *   - L4.dup-set    — setting is_login true when another login row exists → 422.
+ *   - C3 — cross-source collision against an archived employee's active email → 422.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function loginAs(email, password) {
+  const res = await request(app).post('/api/auth/login').send({ email, password });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(cookies, code, adminEmail = null, adminPassword = 'CascadePass123!') {
+  await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', cookies)
+    .send({
+      tenant_code: code,
+      company: `${code} Cascade Corp`,
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'Test',
+      admin_last_name: 'Admin',
+      admin_email: adminEmail || `admin@${code.toLowerCase()}.com`,
+      admin_password: adminPassword,
+      billing_address: { address_line_1: '1 Test St', country_code: 'US' },
+    });
+}
+
+const FLAT_HEADERS = [
+  'id', 'code', 'first_name', 'last_name', 'position', 'department',
+  'is_app_user', 'is_primary_contact', 'is_billing_contact', 'roles', 'status', 'password',
+  'email', 'email_label', 'email_is_primary', 'email_is_login',
+  'phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary',
+  'address_label', 'address_line_1', 'address_line_2', 'address_line_3',
+  'address_city', 'address_state_province', 'address_postal_code', 'address_country_code',
+  'tax_country_code', 'tax_type', 'tax_value',
+];
+
+function row({ id = '', code = '', firstName = '', lastName = '', extras = {} } = {}) {
+  const isPrimary = !!(id || code || firstName || lastName);
+  return {
+    id, code, first_name: firstName, last_name: lastName,
+    position: '', department: '',
+    is_app_user: isPrimary ? false : '',
+    is_primary_contact: isPrimary ? false : '',
+    is_billing_contact: isPrimary ? false : '',
+    roles: isPrimary ? '{}' : '',
+    status: isPrimary ? 'active' : '',
+    password: '',
+    email: '', email_label: '', email_is_primary: '', email_is_login: '',
+    phone_country_code: '', phone_type: '', phone_number: '', phone_is_primary: '',
+    address_label: '', address_line_1: '', address_line_2: '', address_line_3: '',
+    address_city: '', address_state_province: '', address_postal_code: '', address_country_code: '',
+    tax_country_code: '', tax_type: '', tax_value: '',
+    ...extras,
+  };
+}
+
+async function buildFlat(rows) {
+  const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+  const wb = WorkbookBuilder.create();
+  wb.sheet('Employees').setHeaders(FLAT_HEADERS).addObjects(rows);
+  return writeXlsx(wb.build());
+}
+
+async function postImport(buf, cookies, label, { preview = false } = {}) {
+  const tmpPath = join(tmpdir(), `cascade-${label}-${Date.now()}.xlsx`);
+  writeFileSync(tmpPath, buf);
+  const url = `/api/core/v1/employees/import-xls${preview ? '?preview=1' : ''}`;
+  try {
+    return await request(app).post(url).set('Cookie', cookies).attach('file', tmpPath);
+  } finally {
+    unlinkSync(tmpPath);
+  }
+}
+
+async function makeAppUserEmployee(cookies, { code, firstName, lastName, email, password = 'EmpPass1!Pass' }) {
+  const res = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
+    code,
+    first_name: firstName,
+    last_name: lastName,
+    email,
+    is_app_user: true,
+    roles: ['admin'],
+    password,
+  });
+  expect(res.status).toBe(201);
+  return res.body;
+}
+
+describe('Flat employee import — login + app-user cascade fixes', () => {
+  let cookies;
+
+  beforeAll(async () => {
+    const rootCookies = await loginRoot();
+    await provisionTenant(rootCookies, 'FCAS');
+    cookies = await loginAs('admin@fcas.com', 'CascadePass123!');
+  }, 30000);
+
+  test('L1.a — login email value change via import syncs portal_users.email', async () => {
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'L1A', firstName: 'Lara', lastName: 'Login', email: 'lara@fcas.com',
+    });
+
+    const before = await db.oneOrNone(`SELECT email FROM admin.portal_users WHERE email = $1`, ['lara@fcas.com']);
+    expect(before).not.toBeNull();
+
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'L1A', firstName: 'Lara', lastName: 'Login',
+        extras: {
+          is_app_user: true, roles: '{admin}',
+          email: 'lara.new@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l1a');
+    expect(res.status).toBe(201);
+
+    const after = await db.oneOrNone(`SELECT email FROM admin.portal_users WHERE email = $1`, ['lara.new@fcas.com']);
+    expect(after).not.toBeNull();
+    const old = await db.oneOrNone(`SELECT email FROM admin.portal_users WHERE email = $1`, ['lara@fcas.com']);
+    expect(old).toBeNull();
+  });
+
+  test('L1.b — login email value change to a portal_user in another tenant returns 422', async () => {
+    const rootCookies = await loginRoot();
+    await provisionTenant(rootCookies, 'FCAS2', 'shared@cross.com', 'CrossPass123!');
+
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'L1B', firstName: 'Liam', lastName: 'Borrower', email: 'liam@fcas.com',
+    });
+
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'L1B', firstName: 'Liam', lastName: 'Borrower',
+        extras: {
+          is_app_user: true, roles: '{admin}',
+          email: 'shared@cross.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l1b');
+    expect(res.status).toBe(422);
+    const collision = res.body.errors.find((e) => /already in use by another portal user/i.test(e.message || ''));
+    expect(collision).toBeDefined();
+
+    // portal_users for Liam unchanged
+    const still = await db.oneOrNone(`SELECT email FROM admin.portal_users WHERE email = $1`, ['liam@fcas.com']);
+    expect(still).not.toBeNull();
+  });
+
+  test('L2 — cannot unset is_login on active app user via import returns 422', async () => {
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'L2', firstName: 'Lily', lastName: 'Locked', email: 'lily@fcas.com',
+    });
+
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'L2', firstName: 'Lily', lastName: 'Locked',
+        extras: {
+          is_app_user: true, roles: '{admin}',
+          email: 'lily@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: false,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l2');
+    expect(res.status).toBe(422);
+    const err = res.body.errors.find((e) => /Cannot remove the login flag/i.test(e.message || ''));
+    expect(err).toBeDefined();
+
+    // portal_user still active
+    const pu = await db.oneOrNone(
+      `SELECT pu.deactivated_at FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id
+       WHERE pu.email = $1`,
+      ['lily@fcas.com'],
+    );
+    expect(pu.deactivated_at).toBeNull();
+  });
+
+  test('L2.swap — loginEmailSync service exposes canUnsetLogin/syncLoginEmail helpers', async () => {
+    // Defensive coverage: the service module is exported and callable. Real
+    // vendor_contact flat-import path doesn't exist yet (multi-sheet only).
+    const { syncLoginEmail, canUnsetLogin, ENTITY_TABLE_BY_SOURCE_TYPE } = await import('../../src/lib/loginEmailSync.js');
+    expect(typeof syncLoginEmail).toBe('function');
+    expect(typeof canUnsetLogin).toBe('function');
+    expect(ENTITY_TABLE_BY_SOURCE_TYPE.vendor_contact).toBe('vendor_contacts');
+  });
+
+  test('L2b.archive — archiving active app-user employee via import locks portal_user', async () => {
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'L2BA', firstName: 'Ada', lastName: 'Archive', email: 'ada@fcas.com',
+    });
+
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'L2BA', firstName: 'Ada', lastName: 'Archive',
+        extras: {
+          is_app_user: true, roles: '{admin}', status: 'archived',
+          email: 'ada@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l2ba');
+    expect(res.status).toBe(201);
+
+    const pu = await db.oneOrNone(
+      `SELECT pu.status, pu.deactivated_at FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id
+       WHERE pu.email = $1`,
+      ['ada@fcas.com'],
+    );
+    expect(pu.status).toBe('locked');
+    expect(pu.deactivated_at).not.toBeNull();
+  });
+
+  test('L2b.restore — restoring archived app-user employee via import unlocks portal_user', async () => {
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'L2BR', firstName: 'Ron', lastName: 'Restore', email: 'ron@fcas.com',
+    });
+
+    // Archive via the controller first
+    await request(app).delete(`/api/core/v1/employees/archive?id=${emp.id}`).set('Cookie', cookies).send({});
+
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'L2BR', firstName: 'Ron', lastName: 'Restore',
+        extras: {
+          is_app_user: true, roles: '{admin}', status: 'active',
+          email: 'ron@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l2br');
+    expect(res.status).toBe(201);
+
+    const pu = await db.oneOrNone(
+      `SELECT pu.status, pu.deactivated_at FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants b ON b.portal_user_id = pu.id
+       WHERE pu.email = $1 AND pu.deactivated_at IS NULL`,
+      ['ron@fcas.com'],
+    );
+    expect(pu).not.toBeNull();
+    expect(pu.status).toBe('active');
+  });
+
+  test('L2b.toggle-off — is_app_user true → false via UPDATE archives portal_user', async () => {
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'L2BT', firstName: 'Tina', lastName: 'Toggle', email: 'tina@fcas.com',
+    });
+
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'L2BT', firstName: 'Tina', lastName: 'Toggle',
+        extras: {
+          is_app_user: false, roles: '{admin}',
+          email: 'tina@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l2bt-off');
+    expect(res.status).toBe(201);
+
+    const pu = await db.oneOrNone(
+      `SELECT pu.status, pu.deactivated_at FROM admin.portal_users pu
+       WHERE pu.email = $1`,
+      ['tina@fcas.com'],
+    );
+    expect(pu.status).toBe('locked');
+    expect(pu.deactivated_at).not.toBeNull();
+  });
+
+  test('L2b.toggle-on — is_app_user false → true via UPDATE provisions portal_user', async () => {
+    // Create a non-app-user employee with an email
+    const create = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
+      code: 'L2BTON', first_name: 'Nora', last_name: 'NewLogin', email: 'nora@fcas.com',
+    });
+    expect(create.status).toBe(201);
+
+    // Make sure no portal_user exists yet
+    const before = await db.oneOrNone(`SELECT id FROM admin.portal_users WHERE email = $1`, ['nora@fcas.com']);
+    expect(before).toBeNull();
+
+    // Flip the login flag on the existing 'work' email row
+    const emails = await db.any(`SELECT id, email FROM fcas.emails WHERE email = $1`, ['nora@fcas.com']);
+    expect(emails.length).toBe(1);
+    await db.none(`UPDATE fcas.emails SET is_login = true WHERE id = $1`, [emails[0].id]);
+
+    const buf = await buildFlat([
+      row({
+        id: create.body.id, code: 'L2BTON', firstName: 'Nora', lastName: 'NewLogin',
+        extras: {
+          is_app_user: true, roles: '{admin}',
+          email: 'nora@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l2bt-on');
+    expect(res.status).toBe(201);
+
+    const pu = await db.oneOrNone(`SELECT id, status FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`, ['nora@fcas.com']);
+    expect(pu).not.toBeNull();
+  });
+
+  test('L4.two-logins — two is_login: true rows for one source in the file returns 422', async () => {
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'L4TWO', firstName: 'Tara', lastName: 'TwoLogin', email: 'tara@fcas.com',
+    });
+
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'L4TWO', firstName: 'Tara', lastName: 'TwoLogin',
+        extras: {
+          is_app_user: true, roles: '{admin}',
+          email: 'tara@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+      row({
+        extras: {
+          email: 'tara.alt@fcas.com', email_label: 'home', email_is_primary: false, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l4two');
+    expect(res.status).toBe(422);
+    const err = res.body.errors.find((e) => /Only one login email is allowed/i.test(e.message || ''));
+    expect(err).toBeDefined();
+  });
+
+  test('L4.dup-set — setting is_login true on a second row when another already has it returns 422', async () => {
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'L4DUP', firstName: 'Daisy', lastName: 'Dup', email: 'daisy@fcas.com',
+    });
+
+    // Add a second email row (not a login) via the API
+    await request(app).post('/api/core/v1/emails').set('Cookie', cookies).send({
+      source_id: emp.source_id, email: 'daisy.alt@fcas.com', label: 'home', is_primary: false,
+    });
+
+    // Import flips the 'home' row to is_login: true while 'work' is still is_login: true in the DB.
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'L4DUP', firstName: 'Daisy', lastName: 'Dup',
+        extras: {
+          is_app_user: true, roles: '{admin}',
+          email: 'daisy.alt@fcas.com', email_label: 'home', email_is_primary: false, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l4dup');
+    expect(res.status).toBe(422);
+    const err = res.body.errors.find((e) => /Only one login email is allowed/i.test(e.message || ''));
+    expect(err).toBeDefined();
+  });
+
+  test('C3 — cross-source collision against an archived employee\'s active email returns 422', async () => {
+    const bennett = await makeAppUserEmployee(cookies, {
+      code: 'C3BEN', firstName: 'Bea', lastName: 'Bennett', email: 'bea@fcas.com',
+    });
+    // Archive Bennett through the controller. Children stay active by design (Option A).
+    await request(app).delete(`/api/core/v1/employees/archive?id=${bennett.id}`).set('Cookie', cookies).send({});
+
+    // Try to import a brand-new employee with Bennett's email.
+    const buf = await buildFlat([
+      row({
+        code: 'C3SMI', firstName: 'Sam', lastName: 'Smith',
+        extras: {
+          email: 'bea@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: false,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'c3');
+    expect(res.status).toBe(422);
+    const collision = res.body.errors.find((e) => /already in use by another/i.test(e.message || ''));
+    expect(collision).toBeDefined();
+    expect(collision.message).toMatch(/employee/i);
+
+    // Smith was not created
+    const smith = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'C3SMI'`);
+    expect(smith).toBeNull();
+  });
+});

--- a/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
@@ -344,7 +344,7 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
       row({
         id: create.body.id, code: 'L2BTON', firstName: 'Nora', lastName: 'NewLogin',
         extras: {
-          is_app_user: true, roles: '{admin}',
+          is_app_user: true, roles: '{admin}', password: 'NoraToggleOn1!',
           email: 'nora@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
         },
       }),
@@ -414,8 +414,17 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
         },
       }),
     ]);
+
+    // Preview must classify password-only rotation as an update, not a no-op.
+    // (`password` is stripped from the transformed parent so _diffParent
+    // doesn't see it.)
+    const previewRes = await postImport(buf, cookies, 'pwrot-preview', { preview: true });
+    expect(previewRes.status).toBe(200);
+    expect(previewRes.body.updates).toBeGreaterThanOrEqual(1);
+
     const res = await postImport(buf, cookies, 'pwrot');
     expect(res.status).toBe(201);
+    expect(res.body.updated).toBeGreaterThanOrEqual(1);
 
     const after = await db.oneOrNone(
       `SELECT password_hash FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`,
@@ -803,6 +812,83 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
     const emp = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'P8C'`);
     expect(emp).toBeNull();
     const pu = await db.oneOrNone(`SELECT id FROM admin.portal_users WHERE email = 'cara.8c@fcas.com'`);
+    expect(pu).toBeNull();
+  });
+
+  test('8d — new app user with blank password cell is a blocking error', async () => {
+    const buf = await buildFlat([
+      row({
+        code: 'P8D', firstName: 'Drew', lastName: 'EightD',
+        extras: {
+          is_app_user: true, roles: '{admin}',     // no password
+          email: 'drew.8d@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, '8d');
+    expect(res.status).toBe(422);
+    expect(res.body.errors.some((e) => /password is required to provision/i.test(e.message || ''))).toBe(true);
+
+    const emp = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'P8D'`);
+    expect(emp).toBeNull();
+  });
+
+  test('9b — toggle is_app_user false→true on employee with no prior binding requires a password', async () => {
+    // Plain employee, never an app user, no portal_user binding.
+    const createRes = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
+      code: 'P9B', first_name: 'Nina', last_name: 'NineB', email: 'nina.9b@fcas.com', roles: ['admin'],
+    });
+    expect(createRes.status).toBe(201);
+    // Flip the login flag on her existing email so the row passes the
+    // login-email-required check.
+    await db.none(`UPDATE fcas.emails SET is_login = true WHERE email = $1`, ['nina.9b@fcas.com']);
+
+    const buf = await buildFlat([
+      row({
+        id: createRes.body.id, code: 'P9B', firstName: 'Nina', lastName: 'NineB',
+        extras: {
+          is_app_user: true, roles: '{admin}',     // no password
+          email: 'nina.9b@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, '9b');
+    expect(res.status).toBe(422);
+    expect(res.body.errors.some((e) => /password is required to enable app user/i.test(e.message || ''))).toBe(true);
+
+    // She wasn't toggled and no portal_user was provisioned.
+    const emp = await db.oneOrNone(`SELECT is_app_user FROM fcas.employees WHERE code = 'P9B'`);
+    expect(emp.is_app_user).toBe(false);
+    const pu = await db.oneOrNone(`SELECT id FROM admin.portal_users WHERE email = 'nina.9b@fcas.com'`);
+    expect(pu).toBeNull();
+  });
+
+  test('8f — two new app-user rows in same file with same login email is a blocking error', async () => {
+    const buf = await buildFlat([
+      row({
+        code: 'P8F1', firstName: 'First', lastName: 'Eight8F',
+        extras: {
+          is_app_user: true, roles: '{admin}', password: 'First8F1!',
+          email: 'dupe.8f@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+      row({
+        code: 'P8F2', firstName: 'Second', lastName: 'Eight8F',
+        extras: {
+          is_app_user: true, roles: '{admin}', password: 'Second8F1!',
+          email: 'dupe.8f@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, '8f');
+    expect(res.status).toBe(422);
+    const dupes = res.body.errors.filter((e) => /appears on multiple rows/i.test(e.message || ''));
+    expect(dupes.length).toBeGreaterThanOrEqual(2);   // both rows flagged
+
+    // Nothing landed.
+    const created = await db.any(`SELECT code FROM fcas.employees WHERE code IN ('P8F1','P8F2')`);
+    expect(created).toEqual([]);
+    const pu = await db.oneOrNone(`SELECT id FROM admin.portal_users WHERE email = 'dupe.8f@fcas.com'`);
     expect(pu).toBeNull();
   });
 });

--- a/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
@@ -344,6 +344,84 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
     expect(pu).not.toBeNull();
   });
 
+  test('controller restore preserves password — archive then re-enable via PUT does NOT reset password_hash', async () => {
+    // Same regression as the import path, but exercising the controller's
+    // #provisionAppUser restore branch directly.
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'PWCTL', firstName: 'Casey', lastName: 'Ctl', email: 'casey@fcas.com',
+      password: 'CaseyOriginalPass1!',
+    });
+
+    const before = await db.oneOrNone(
+      `SELECT password_hash FROM admin.portal_users WHERE email = $1`,
+      ['casey@fcas.com'],
+    );
+    expect(before?.password_hash).toBeTruthy();
+
+    // Archive then restore the employee via the API.
+    await request(app).delete(`/api/core/v1/employees/archive?id=${emp.id}`).set('Cookie', cookies).send({});
+    const restoreRes = await request(app).patch(`/api/core/v1/employees/restore?id=${emp.id}`).set('Cookie', cookies).send({});
+    expect([200, 201]).toContain(restoreRes.status);
+
+    // Now toggle is_app_user back on via PUT (no password supplied — the
+    // existing hash must be preserved).
+    const toggleRes = await request(app)
+      .put(`/api/core/v1/employees/update?id=${emp.id}`)
+      .set('Cookie', cookies)
+      .send({ is_app_user: true, roles: ['admin'] });
+    expect(toggleRes.status).toBe(200);
+
+    const after = await db.oneOrNone(
+      `SELECT password_hash, deactivated_at FROM admin.portal_users WHERE email = $1`,
+      ['casey@fcas.com'],
+    );
+    expect(after).not.toBeNull();
+    expect(after.deactivated_at).toBeNull();
+    expect(after.password_hash).toBe(before.password_hash);
+  });
+
+  test('L2b.restore preserves password — archive then re-enable via import does NOT reset password_hash', async () => {
+    // Regression: enableAppUser's archived-binding restore path used to
+    // auto-bcrypt a throwaway random password and overwrite portal_users.password_hash,
+    // silently invalidating the user's existing password.
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'PWPRES', firstName: 'Penny', lastName: 'PwPreserve', email: 'penny@fcas.com',
+      password: 'PennyOriginalPass1!',
+    });
+
+    // Capture the original password_hash.
+    const before = await db.oneOrNone(
+      `SELECT password_hash FROM admin.portal_users WHERE email = $1`,
+      ['penny@fcas.com'],
+    );
+    expect(before?.password_hash).toBeTruthy();
+
+    // Archive via the controller (cascades portal_user lock).
+    await request(app).delete(`/api/core/v1/employees/archive?id=${emp.id}`).set('Cookie', cookies).send({});
+
+    // Re-enable via import (status: active on an archived app-user employee).
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'PWPRES', firstName: 'Penny', lastName: 'PwPreserve',
+        extras: {
+          is_app_user: true, roles: '{admin}', status: 'active',
+          email: 'penny@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'pw-pres');
+    expect(res.status).toBe(201);
+
+    // Portal user is back online and the password_hash is byte-for-byte preserved.
+    const after = await db.oneOrNone(
+      `SELECT password_hash, status, deactivated_at FROM admin.portal_users WHERE email = $1`,
+      ['penny@fcas.com'],
+    );
+    expect(after).not.toBeNull();
+    expect(after.deactivated_at).toBeNull();
+    expect(after.password_hash).toBe(before.password_hash);
+  });
+
   test('L4.two-logins — two is_login: true rows for one source in the file returns 422', async () => {
     const emp = await makeAppUserEmployee(cookies, {
       code: 'L4TWO', firstName: 'Tara', lastName: 'TwoLogin', email: 'tara@fcas.com',
@@ -420,5 +498,59 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
     // Smith was not created
     const smith = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'C3SMI'`);
     expect(smith).toBeNull();
+  });
+
+  test('role validation — import rejects is_app_user employee with no roles', async () => {
+    const buf = await buildFlat([
+      row({
+        code: 'RNONE', firstName: 'Rita', lastName: 'NoRole',
+        extras: {
+          is_app_user: true, roles: '{}',
+          email: 'rita@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'rnone');
+    expect(res.status).toBe(422);
+    const err = res.body.errors.find((e) => /Roles must be assigned/i.test(e.message || ''));
+    expect(err).toBeDefined();
+
+    const rita = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'RNONE'`);
+    expect(rita).toBeNull();
+  });
+
+  test('role validation — import rejects is_app_user employee with unknown role code', async () => {
+    const buf = await buildFlat([
+      row({
+        code: 'RBAD', firstName: 'Ruth', lastName: 'BadRole',
+        extras: {
+          is_app_user: true, roles: '{bogus}',
+          email: 'ruth@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'rbad');
+    expect(res.status).toBe(422);
+    const err = res.body.errors.find((e) => /Unknown role code/i.test(e.message || ''));
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/bogus/);
+
+    const ruth = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'RBAD'`);
+    expect(ruth).toBeNull();
+  });
+
+  test('role validation — controller rejects is_app_user create with unknown role code', async () => {
+    const res = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
+      code: 'RCAPI', first_name: 'Rae', last_name: 'ApiBad',
+      email: 'rae@fcas.com',
+      is_app_user: true,
+      roles: ['bogus'],
+      password: 'EmpPass1!Pass',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Unknown role code/i);
+
+    const rae = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'RCAPI'`);
+    expect(rae).toBeNull();
   });
 });

--- a/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
@@ -243,8 +243,20 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
         },
       }),
     ]);
+    // Preview must classify the archive transition as an update, not a NO-OP,
+    // even when no other parent column changed. (`status` is a synthetic
+    // spreadsheet column stripped before the field-diff.)
+    const preview = await postImport(buf, cookies, 'l2ba-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    // The parent row's status active→archived must classify as an update,
+    // not a NO-OP. (`status` is a synthetic spreadsheet column stripped
+    // before the field-level diff.) Child email row is unchanged → counted
+    // as a NO-OP under the children, which is correct.
+    expect(preview.body.updates).toBeGreaterThanOrEqual(1);
+
     const res = await postImport(buf, cookies, 'l2ba');
     expect(res.status).toBe(201);
+    expect(res.body.updated).toBe(1);
 
     const pu = await db.oneOrNone(
       `SELECT pu.status, pu.deactivated_at FROM admin.portal_users pu
@@ -342,6 +354,140 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
 
     const pu = await db.oneOrNone(`SELECT id, status FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`, ['nora@fcas.com']);
     expect(pu).not.toBeNull();
+  });
+
+  test('L2b.toggle-on with password — import-supplied password is honored on toggle-on', async () => {
+    // Create a non-app-user employee with an email
+    const create = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
+      code: 'L2BPW', first_name: 'Pat', last_name: 'PwToggle', email: 'pat@fcas.com', roles: ['admin'],
+    });
+    expect(create.status).toBe(201);
+
+    // Flip the login flag on the existing 'work' email row
+    const emails = await db.any(`SELECT id FROM fcas.emails WHERE email = $1`, ['pat@fcas.com']);
+    await db.none(`UPDATE fcas.emails SET is_login = true WHERE id = $1`, [emails[0].id]);
+
+    // Import an UPDATE that flips is_app_user on AND supplies a password.
+    const buf = await buildFlat([
+      row({
+        id: create.body.id, code: 'L2BPW', firstName: 'Pat', lastName: 'PwToggle',
+        extras: {
+          is_app_user: true, roles: '{admin}', password: 'PatSuppliedPass1!',
+          email: 'pat@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'l2bpw');
+    expect(res.status).toBe(201);
+
+    // The portal_user must accept the supplied password.
+    const bcrypt = (await import('bcrypt')).default;
+    const pu = await db.oneOrNone(
+      `SELECT password_hash FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`,
+      ['pat@fcas.com'],
+    );
+    expect(pu).not.toBeNull();
+    expect(await bcrypt.compare('PatSuppliedPass1!', pu.password_hash)).toBe(true);
+  });
+
+  test('password rotation — import supplies new password for already-active app user', async () => {
+    // Provision an app-user employee with an initial password.
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'PWROT', firstName: 'Rosa', lastName: 'Rotate', email: 'rosa@fcas.com',
+      password: 'RosaOriginal1!',
+    });
+
+    const bcrypt = (await import('bcrypt')).default;
+    const before = await db.oneOrNone(
+      `SELECT password_hash FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`,
+      ['rosa@fcas.com'],
+    );
+    expect(await bcrypt.compare('RosaOriginal1!', before.password_hash)).toBe(true);
+
+    // Re-import the same employee (already an app user) with a different password.
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'PWROT', firstName: 'Rosa', lastName: 'Rotate',
+        extras: {
+          is_app_user: true, roles: '{admin}', password: 'RosaRotated2!',
+          email: 'rosa@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'pwrot');
+    expect(res.status).toBe(201);
+
+    const after = await db.oneOrNone(
+      `SELECT password_hash FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`,
+      ['rosa@fcas.com'],
+    );
+    expect(await bcrypt.compare('RosaRotated2!', after.password_hash)).toBe(true);
+    expect(await bcrypt.compare('RosaOriginal1!', after.password_hash)).toBe(false);
+  });
+
+  test('password preserved on no-change re-import — blank password column does NOT reset password_hash', async () => {
+    // Provision an app-user employee with an initial password.
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'PWKEEP', firstName: 'Kira', lastName: 'Keep', email: 'kira@fcas.com',
+      password: 'KiraKeep1!',
+    });
+
+    const before = await db.oneOrNone(
+      `SELECT password_hash FROM admin.portal_users WHERE email = $1`,
+      ['kira@fcas.com'],
+    );
+
+    // Re-import with password column blank — must not touch password_hash.
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'PWKEEP', firstName: 'Kira', lastName: 'Keep',
+        extras: {
+          is_app_user: true, roles: '{admin}',
+          email: 'kira@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'pwkeep');
+    expect(res.status).toBe(201);
+
+    const after = await db.oneOrNone(
+      `SELECT password_hash FROM admin.portal_users WHERE email = $1`,
+      ['kira@fcas.com'],
+    );
+    expect(after.password_hash).toBe(before.password_hash);
+  });
+
+  test('contradiction — password supplied with is_app_user=false is a blocking error', async () => {
+    // Existing app-user employee; spreadsheet says is_app_user=false AND
+    // supplies a password. Importer must refuse rather than silently demote
+    // and drop the password.
+    const emp = await makeAppUserEmployee(cookies, {
+      code: 'PWCON', firstName: 'Connie', lastName: 'Conflict', email: 'connie@fcas.com',
+      password: 'ConnieOriginal1!',
+    });
+
+    const buf = await buildFlat([
+      row({
+        id: emp.id, code: 'PWCON', firstName: 'Connie', lastName: 'Conflict',
+        extras: {
+          is_app_user: false, roles: '{admin}', password: 'NewPw2!',
+          email: 'connie@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, 'pwcon');
+    expect(res.status).toBe(422);
+    const err = res.body.errors.find((e) => /password cannot be supplied while is_app_user is false/i.test(e.message || ''));
+    expect(err).toBeDefined();
+
+    // Nothing changed: still active, password_hash still matches original.
+    const bcrypt = (await import('bcrypt')).default;
+    const after = await db.oneOrNone(
+      `SELECT password_hash, deactivated_at FROM admin.portal_users WHERE email = $1`,
+      ['connie@fcas.com'],
+    );
+    expect(after.deactivated_at).toBeNull();
+    expect(await bcrypt.compare('ConnieOriginal1!', after.password_hash)).toBe(true);
   });
 
   test('controller restore preserves password — archive then re-enable via PUT does NOT reset password_hash', async () => {
@@ -552,5 +698,111 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
 
     const rae = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'RCAPI'`);
     expect(rae).toBeNull();
+  });
+
+  // ─── Section 8: provisioning app users via the INSERT path ─────────────
+  //
+  // 4/5/6 exercise UPDATE branches (login-email mechanics, archive cascade,
+  // existing-app-user toggles). These tests cover the brand-new path: a
+  // file row with no id, is_app_user=true, password + login email supplied.
+
+  test('8a — single new app user with password is provisioned via import', async () => {
+    const buf = await buildFlat([
+      row({
+        code: 'P8A', firstName: 'Pat', lastName: 'EightA',
+        extras: {
+          is_app_user: true, roles: '{admin}', password: 'PatEightA1!',
+          email: 'pat.8a@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, '8a');
+    expect(res.status).toBe(201);
+
+    const emp = await db.oneOrNone(`SELECT id, is_app_user FROM fcas.employees WHERE code = 'P8A'`);
+    expect(emp).not.toBeNull();
+    expect(emp.is_app_user).toBe(true);
+
+    const pu = await db.oneOrNone(
+      `SELECT id, status, password_hash FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL`,
+      ['pat.8a@fcas.com'],
+    );
+    expect(pu).not.toBeNull();
+    expect(pu.status).toBe('invited');
+
+    const bcrypt = (await import('bcrypt')).default;
+    expect(await bcrypt.compare('PatEightA1!', pu.password_hash)).toBe(true);
+
+    const binding = await db.oneOrNone(
+      `SELECT * FROM admin.portal_user_tenants
+       WHERE portal_user_id = $1 AND entity_type = 'employee' AND entity_id = $2
+       AND deactivated_at IS NULL`,
+      [pu.id, emp.id],
+    );
+    expect(binding).not.toBeNull();
+    expect(binding.status).toBe('active');
+  });
+
+  test('8b — bulk provision is transactional: one bad row rolls back all', async () => {
+    const buf = await buildFlat([
+      row({
+        code: 'P8B1', firstName: 'BulkOne', lastName: 'EightB',
+        extras: {
+          is_app_user: true, roles: '{admin}', password: 'BulkOne1!',
+          email: 'bulk.one@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+      row({
+        code: 'P8B2', firstName: 'BulkTwo', lastName: 'EightB',
+        extras: {
+          // Bogus role on row 2 — must reject the whole import.
+          is_app_user: true, roles: '{nonexistent_role}', password: 'BulkTwo1!',
+          email: 'bulk.two@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+      row({
+        code: 'P8B3', firstName: 'BulkThree', lastName: 'EightB',
+        extras: {
+          is_app_user: true, roles: '{admin}', password: 'BulkThree1!',
+          email: 'bulk.three@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: true,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, '8b');
+    expect(res.status).toBe(422);
+    expect(res.body.errors.some((e) => /unknown role/i.test(e.message || ''))).toBe(true);
+
+    // None of the three rows landed.
+    const created = await db.any(`SELECT code FROM fcas.employees WHERE code IN ('P8B1','P8B2','P8B3')`);
+    expect(created).toEqual([]);
+    const pus = await db.any(
+      `SELECT email FROM admin.portal_users WHERE email IN ('bulk.one@fcas.com','bulk.two@fcas.com','bulk.three@fcas.com')`,
+    );
+    expect(pus).toEqual([]);
+  });
+
+  test('8c — is_app_user=true with no login email is a blocking error', async () => {
+    // Row has is_app_user=true, valid role, valid password, but the email
+    // row's is_login flag is false (no login email anywhere).
+    const buf = await buildFlat([
+      row({
+        code: 'P8C', firstName: 'Cara', lastName: 'EightC',
+        extras: {
+          is_app_user: true, roles: '{admin}', password: 'CaraEightC1!',
+          email: 'cara.8c@fcas.com', email_label: 'work', email_is_primary: true, email_is_login: false,
+        },
+      }),
+    ]);
+    const res = await postImport(buf, cookies, '8c');
+    expect(res.status).toBe(422);
+    expect(
+      res.body.errors.some((e) => /login email is required/i.test(e.message || '')),
+    ).toBe(true);
+
+    // Nothing landed.
+    const emp = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'P8C'`);
+    expect(emp).toBeNull();
+    const pu = await db.oneOrNone(`SELECT id FROM admin.portal_users WHERE email = 'cara.8c@fcas.com'`);
+    expect(pu).toBeNull();
   });
 });

--- a/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
@@ -2,7 +2,7 @@
  * @file Contract tests for L1/L2/L2b/C3 bypass-bug fixes in flat employee import
  * @module tests/contract/employeeFlatReconciliationLoginCascade
  *
- * Covers the rules from /Users/ian/.claude/plans/explain-why-when-updating-rustling-hellman.md:
+ * Behavior locked in:
  *   - L1.a — login email value change syncs to portal_users.
  *   - L1.b — login email value change to a portal_user in another tenant → 422.
  *   - L2   — cannot unset is_login on active app user via import → 422.
@@ -667,7 +667,7 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
     ]);
     const res = await postImport(buf, cookies, 'rnone');
     expect(res.status).toBe(422);
-    const err = res.body.errors.find((e) => /Roles must be assigned/i.test(e.message || ''));
+    const err = res.body.errors.find((e) => /at least one role/i.test(e.message || ''));
     expect(err).toBeDefined();
 
     const rita = await db.oneOrNone(`SELECT id FROM fcas.employees WHERE code = 'RNONE'`);

--- a/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
+++ b/apps/server/tests/contract/employeeFlatReconciliationLoginCascade.test.js
@@ -85,7 +85,7 @@ function row({ id = '', code = '', firstName = '', lastName = '', extras = {} } 
     is_app_user: isPrimary ? false : '',
     is_primary_contact: isPrimary ? false : '',
     is_billing_contact: isPrimary ? false : '',
-    roles: isPrimary ? '{}' : '',
+    roles: isPrimary ? '{admin}' : '',
     status: isPrimary ? 'active' : '',
     password: '',
     email: '', email_label: '', email_is_primary: '', email_is_login: '',
@@ -315,7 +315,7 @@ describe('Flat employee import — login + app-user cascade fixes', () => {
   test('L2b.toggle-on — is_app_user false → true via UPDATE provisions portal_user', async () => {
     // Create a non-app-user employee with an email
     const create = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
-      code: 'L2BTON', first_name: 'Nora', last_name: 'NewLogin', email: 'nora@fcas.com',
+      code: 'L2BTON', first_name: 'Nora', last_name: 'NewLogin', email: 'nora@fcas.com', roles: ['admin'],
     });
     expect(create.status).toBe(201);
 

--- a/apps/server/tests/contract/employees.test.js
+++ b/apps/server/tests/contract/employees.test.js
@@ -69,6 +69,7 @@ describe('Employee CRUD — /api/core/v1/employees', () => {
       position: 'Engineer',
       department: 'Engineering',
       email: 'jane@etest.com',
+      roles: ['admin'],
     });
 
     expect(res.status).toBe(201);

--- a/apps/server/tests/contract/employees.test.js
+++ b/apps/server/tests/contract/employees.test.js
@@ -147,26 +147,31 @@ describe('Employee CRUD — /api/core/v1/employees', () => {
     expect(restoreRes.status).toBe(200);
   });
 
-  // ── Multi-sheet xlsx import: app-user provisioning sources email from the Emails child sheet ──
-  // Regression test for issue #13: after email normalization the parent Employees sheet no longer
-  // carries an `email` column; the login email must come from the Emails child sheet.
+  // ── Flat xlsx import: app-user provisioning sources email from the child email columns ──
+  // Regression test for issue #13: the parent Employees sheet does not carry an `email`
+  // column; the login email comes from the child email columns of the flat format.
   async function buildEmployeeWorkbook({ ref, code, firstName, lastName, email }) {
     const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
     const wb = WorkbookBuilder.create();
 
-    wb.sheet('Employees')
-      .setHeaders(['id', 'code', 'first_name', 'last_name', 'is_app_user', 'roles', 'status', 'password'])
-      .addRow([ref, code, firstName, lastName, true, '{admin}', 'active', 'XlsImport123!']);
-
-    const emailsSheet = wb.sheet('Emails').setHeaders(['employee_id', 'email', 'label', 'is_primary', 'is_login']);
-    if (email) emailsSheet.addRow([ref, email, 'work', true, true]);
-
-    wb.sheet('Phone Numbers').setHeaders(['employee_id', 'country_code', 'phone_type', 'phone_number', 'is_primary']);
-    wb.sheet('Addresses').setHeaders([
-      'employee_id', 'label', 'address_line_1', 'address_line_2', 'address_line_3',
-      'city', 'state_province', 'postal_code', 'country_code',
-    ]);
-    wb.sheet('Tax Identifiers').setHeaders(['employee_id', 'country_code', 'tax_type', 'tax_value']);
+    const headers = [
+      'id', 'code', 'first_name', 'last_name', 'position', 'department',
+      'is_app_user', 'is_primary_contact', 'is_billing_contact', 'roles', 'status', 'password',
+      'email', 'email_label', 'email_is_primary', 'email_is_login',
+      'phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary',
+      'address_label', 'address_line_1', 'address_line_2', 'address_line_3',
+      'address_city', 'address_state_province', 'address_postal_code', 'address_country_code',
+      'tax_country_code', 'tax_type', 'tax_value',
+    ];
+    const row = [
+      ref, code, firstName, lastName, '', '',
+      true, false, false, '{admin}', 'active', 'XlsImport123!',
+      email || '', email ? 'work' : '', email ? true : '', email ? true : '',
+      '', '', '', '',
+      '', '', '', '', '', '', '', '',
+      '', '', '',
+    ];
+    wb.sheet('Employees').setHeaders(headers).addRow(row);
 
     return writeXlsx(wb.build());
   }
@@ -181,7 +186,7 @@ describe('Employee CRUD — /api/core/v1/employees', () => {
     }
   }
 
-  test('multi-sheet import sources login email from Emails child sheet (issue #13)', async () => {
+  test('flat import sources login email from child email columns (issue #13)', async () => {
     const buf = await buildEmployeeWorkbook({
       ref: 'EMP-XLS-1', code: 'AA001', firstName: 'Alice', lastName: 'Anderson', email: 'alice@etest.com',
     });
@@ -208,7 +213,7 @@ describe('Employee CRUD — /api/core/v1/employees', () => {
     expect(portalUser.status).toBe('invited');
   });
 
-  test('multi-sheet import without an Emails row skips provisioning and disables is_app_user', async () => {
+  test('flat import without an email cell skips provisioning and disables is_app_user', async () => {
     const buf = await buildEmployeeWorkbook({
       ref: 'EMP-XLS-2', code: 'CC001', firstName: 'Carol', lastName: 'Carter', email: null,
     });

--- a/apps/server/tests/contract/employees.test.js
+++ b/apps/server/tests/contract/employees.test.js
@@ -214,24 +214,19 @@ describe('Employee CRUD — /api/core/v1/employees', () => {
     expect(portalUser.status).toBe('invited');
   });
 
-  test('flat import without an email cell skips provisioning and disables is_app_user', async () => {
+  test('flat import with is_app_user=true and no login email is a blocking error', async () => {
+    // Previously the importer silently coerced is_app_user to false. That
+    // was a footgun — it created an employee record but no portal_user, with
+    // no signal to the importer. Now blocked at pre-validation.
     const buf = await buildEmployeeWorkbook({
       ref: 'EMP-XLS-2', code: 'CC001', firstName: 'Carol', lastName: 'Carter', email: null,
     });
     const res = await postImport(buf, 'no-email');
 
-    expect(res.status).toBe(201);
-    expect(res.body.inserted).toBe(1);
-    expect(res.body.appUserSkipped).toBe(1);
+    expect(res.status).toBe(422);
+    expect(res.body.errors.some((e) => /login email is required/i.test(e.message || ''))).toBe(true);
 
-    const employee = await db.oneOrNone(`SELECT id, is_app_user FROM etest.employees WHERE code = 'CC001'`);
-    expect(employee).not.toBeNull();
-    expect(employee.is_app_user).toBe(false);
-
-    const binding = await db.oneOrNone(
-      `SELECT id FROM admin.portal_user_tenants WHERE entity_type = 'employee' AND entity_id = $1 AND deactivated_at IS NULL`,
-      [employee.id],
-    );
-    expect(binding).toBeNull();
+    const employee = await db.oneOrNone(`SELECT id FROM etest.employees WHERE code = 'CC001'`);
+    expect(employee).toBeNull();
   });
 });

--- a/apps/server/tests/contract/importCrossTenantEmail.test.js
+++ b/apps/server/tests/contract/importCrossTenantEmail.test.js
@@ -63,18 +63,24 @@ async function buildEmployeeWorkbook({ ref, code, firstName, lastName, email }) 
   const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
   const wb = WorkbookBuilder.create();
 
-  wb.sheet('Employees')
-    .setHeaders(['id', 'code', 'first_name', 'last_name', 'is_app_user', 'roles', 'status', 'password'])
-    .addRow([ref, code, firstName, lastName, true, '{admin}', 'active', 'XlsImport123!']);
-
-  wb.sheet('Emails').setHeaders(['employee_id', 'email', 'label', 'is_primary', 'is_login']).addRow([ref, email, 'work', true, true]);
-
-  wb.sheet('Phone Numbers').setHeaders(['employee_id', 'country_code', 'phone_type', 'phone_number', 'is_primary']);
-  wb.sheet('Addresses').setHeaders([
-    'employee_id', 'label', 'address_line_1', 'address_line_2', 'address_line_3',
-    'city', 'state_province', 'postal_code', 'country_code',
-  ]);
-  wb.sheet('Tax Identifiers').setHeaders(['employee_id', 'country_code', 'tax_type', 'tax_value']);
+  const headers = [
+    'id', 'code', 'first_name', 'last_name', 'position', 'department',
+    'is_app_user', 'is_primary_contact', 'is_billing_contact', 'roles', 'status', 'password',
+    'email', 'email_label', 'email_is_primary', 'email_is_login',
+    'phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary',
+    'address_label', 'address_line_1', 'address_line_2', 'address_line_3',
+    'address_city', 'address_state_province', 'address_postal_code', 'address_country_code',
+    'tax_country_code', 'tax_type', 'tax_value',
+  ];
+  const row = [
+    ref, code, firstName, lastName, '', '',
+    true, false, false, '{admin}', 'active', 'XlsImport123!',
+    email, 'work', true, true,
+    '', '', '', '',
+    '', '', '', '', '', '', '', '',
+    '', '', '',
+  ];
+  wb.sheet('Employees').setHeaders(headers).addRow(row);
 
   return writeXlsx(wb.build());
 }

--- a/apps/server/tests/contract/partialUniqueIndexes.test.js
+++ b/apps/server/tests/contract/partialUniqueIndexes.test.js
@@ -194,7 +194,7 @@ describe('Partial unique indexes — emails / tax_identifiers / phone_numbers', 
     ).rejects.toMatchObject({ code: '23502' });
   });
 
-  test('tax_identifiers: same source may hold multiple values for the same country/type', async () => {
+  test('tax_identifiers: one row per (source, country_code, tax_type) — second active insert is rejected', async () => {
     const src = await makeSource(schema, tenantId, 'TaxSrcMultiVAT');
 
     await db.none(
@@ -203,12 +203,13 @@ describe('Partial unique indexes — emails / tax_identifiers / phone_numbers', 
       [tenantId, src.id],
     );
 
+    // Second active row with the same (source_id, country_code, tax_type) violates the partial unique index.
     await expect(
       db.none(
         `INSERT INTO ${DB.pgp.as.name(schema)}.tax_identifiers (tenant_id, source_id, country_code, tax_type, tax_value)
          VALUES ($1, $2, 'GB', 'VAT', 'GB987654321')`,
         [tenantId, src.id],
       ),
-    ).resolves.toBeNull();
+    ).rejects.toMatchObject({ code: '23505' });
   });
 });

--- a/apps/server/tests/contract/phoneNumbers.test.js
+++ b/apps/server/tests/contract/phoneNumbers.test.js
@@ -67,7 +67,7 @@ describe('Phone Number CRUD — /api/core/v1/phone-numbers', () => {
     const empRes = await request(app)
       .post('/api/core/v1/employees')
       .set('Cookie', cookies)
-      .send({ first_name: 'Phone', last_name: 'Tester', email: 'tester@phtest.com' });
+      .send({ first_name: 'Phone', last_name: 'Tester', email: 'tester@phtest.com', roles: ['admin'] });
     employeeSourceId = empRes.body.source_id;
   }, 30000);
 

--- a/apps/server/tests/integration/tenantLifecycle.test.js
+++ b/apps/server/tests/integration/tenantLifecycle.test.js
@@ -241,6 +241,7 @@ describe('Employee auto-numbering — backfill on enable', () => {
         first_name: 'Bob',
         last_name: 'Smith',
         email: 'bob@numco.com',
+        roles: ['admin'],
       });
 
     expect(res.status).toBe(201);
@@ -257,6 +258,7 @@ describe('Employee auto-numbering — backfill on enable', () => {
         last_name: 'Jones',
         email: 'alice@numco.com',
         code: 'CUSTOM01',
+        roles: ['admin'],
       });
 
     expect(res.status).toBe(201);


### PR DESCRIPTION
## Summary

Rewrites the flat-format import path for employees (and the shared infrastructure used by clients/contacts/companies) to fix a long list of correctness bugs surfaced during smoke testing. Adds a mandatory preview step, replaces the destructive child-row upsert with per-row slot-based reconciliation, and hardens the app-user provisioning + login-email + password code paths.

### Server

- **Per-row reconciliation** replaces the prior soft-delete-and-reinsert behavior for child rows (emails, phones, addresses, tax_ids). Slot keys: `label`, `phone_type`, `(country_code, tax_type)`. Value-key fallback handles slot renames without colliding with the email partial-unique index.
- **Mandatory preview step** — every flat-format import endpoint accepts `?preview=1` and returns `{inserts, updates, noops, omitted, errors}` without writing. UI calls preview first, then real import.
- **Preview classifier** now detects archive/restore transitions and password rotations (both stripped from the parent diff) so the count matches the writer's actual behavior.
- **Cross-source value collision pre-check** (R8): blocks importing a row whose child value already belongs to another source on an active row.
- **Issue cap at 100 errors + 1 sentinel** so a malformed file doesn't OOM the response.
- **Partial unique indexes** on emails/addresses (`label`), phones (`phone_type`), tax_ids (`country_code, tax_type`) — all scoped `WHERE deactivated_at IS NULL`.
- **Login-email sync** (L1): editing an app-user employee's login email value via import updates `admin.portal_users.email` to match. Cross-tenant collision is a 422.
- **Login-email guardrails** (L2/L4): cannot unset `is_login` while the parent is an active app user; at most one `is_login: true` row per entity, enforced across file + DB state.
- **App-user cascade on parent transitions** (L2b): archive/restore + `is_app_user` toggle cascades to `admin.portal_users` lock/unlock and binding lifecycle.
- **Password handling**:
  - Toggle-on honors the spreadsheet's password column (was generating a random one).
  - Already-active app users get their password rotated when a new password is supplied.
  - Blank password on a no-change re-import preserves the existing hash (no silent invalidation).
  - Restore via import preserves the existing hash unless caller supplies a preHash.
  - Password supplied with `is_app_user=false` is a contradiction → 422.
  - Password required when provisioning a new portal_user (INSERT path always; UPDATE toggle-on when no archived binding to restore).
- **is_app_user=true on INSERT requires an `is_login: true` email row** — was silently coercing `is_app_user` to false otherwise.
- **Intra-file login-email collision** check — two new app-user rows in the same file with the same login email value → 422, both rows flagged.
- **Numbering allocator** scans the target table on first allocation and starts above any pre-existing max-serial so manually-typed codes (e.g. tenant bootstrap data) don't collide with the sequence.
- **`_resolveOwnEntities`** falls back to `code` match when the spreadsheet's `id` is blank or stale; stamps the resolved id onto the parent so the writer finds the right record. Mismatched id+code emits a blocking error rather than silently picking one.
- **`coerceRow`** normalizes blank boolean cells to `false` (prevents opaque 23502 on `is_billing_contact` etc.).
- **Required-field pre-validation** walks the model's notNull columns and surfaces row-keyed errors before the bulkInsert — replaces the generic "A required field cannot be empty" message that had no row context.
- **Role validation** — every employee/client parent must have non-empty `roles[]` with codes that exist in the tenant's `roles` table, regardless of `is_app_user` state.
- **Audit consistency** — all 11 `sources` insert sites in axerra now include `updated_by` alongside `created_by` (pg-schemata's single-row `insert` doesn't auto-fill `updated_by`; fix planned upstream + axerra-side cleanup tracked separately).
- **Drop legacy multi-sheet auto-detect** from Employees/Clients/Contacts/Companies — flat path is canonical.
- New service modules: `loginEmailSync.js`, `employeeAppUserSync.js`, `employeeRoleValidator.js`. Controllers and the importer share the same primitives instead of duplicating the rules.

### Client

- Three-step ImportDialog flow: file → preview → import. Preview shows New / Updates / Unchanged / Omitted counts plus blocking errors with sheet/row/column/value/message.
- `importXls` API helpers thread `?preview=1` for Employees, Clients, Contacts, Companies pages.
- Gates `useTenantPreferences` on an authenticated session to suppress a noisy 401 on login pages.

### Tests

- **653 tests passing** (was 617 before this branch; 36 new contract tests across two files).
- New files:
  - `tests/contract/employeeFlatReconciliation.test.js` — core reconciliation, preview, NO-OP detection, slot rename, mixed-file, validation (6a–c), 2e add-child, numbering allocation paths.
  - `tests/contract/employeeFlatReconciliationLoginCascade.test.js` — L1/L2/L2b/L4/C3 + role validation + password rotation/preservation + 8a–f + 9b.
- Updated existing tests that asserted the old "silent coerce is_app_user → false" behavior.

### Smoke matrix referenced during this work

Sections 1–9 of the manual smoke matrix. Roughly 30+ scenarios touched live; 3 confirmed code failures (5a archive preview count, 8f intra-file login collision, 9c password rotation preview count) all fixed and locked with contract tests in the same pass.

## Test plan

- [x] `npm -w apps/server run lint` — clean (one pre-existing unrelated warning)
- [x] `npm -w apps/server test` — 653/653 passing
- [ ] CI: lint + arch:check + test-fast + test-integration on this branch
- [ ] Manual smoke walk of the live UI against an SRH tenant: sections 1–9
- [ ] Verify ImportDialog three-step flow visually for Employees, Clients, Contacts, Companies

## Out of scope (tracked separately)

- pg-schemata `insert`/`bulkInsert` `updated_by` auto-fill (upstream PR)
- ALS (`AsyncLocalStorage`) integration for ambient `userId` + `schema` context
- Removing the 11 manual `updated_by: createdBy` sites once ALS lands
- Multi-sheet import preview (Vendors + VendorContacts)
- Simple-table preview shim (PaymentTerms, ChartOfAccounts, etc.)
- Tenants import preview — separate design pass
- Cross-source merge/transfer tool (PRD #3)
- Phase 3 — login-time role enforcement