### PR TITLE
feat: combined vendor import preview with parent/child noop-skip on commit

### DIFF
--- a/apps/client/src/components/shared/ImportDialog.jsx
+++ b/apps/client/src/components/shared/ImportDialog.jsx
@@ -27,6 +27,20 @@ import UploadFileIcon from '@mui/icons-material/UploadFile';
 import FormDialog from './FormDialog.jsx';
 import SecondaryButton from './SecondaryButton.jsx';
 
+function PreviewBucket({ label, counts }) {
+  return (
+    <Stack spacing={0.25}>
+      <Typography variant="body2" sx={{ fontWeight: 600 }}>{label}</Typography>
+      <Typography variant="body2">New rows: <strong>{counts.inserts}</strong></Typography>
+      <Typography variant="body2">Updates in place: <strong>{counts.updates}</strong></Typography>
+      <Typography variant="body2">Unchanged: <strong>{counts.noops}</strong></Typography>
+      {typeof counts.omitted === 'number' && (
+        <Typography variant="body2">Existing rows not in file (left unchanged): <strong>{counts.omitted}</strong></Typography>
+      )}
+    </Stack>
+  );
+}
+
 export default function ImportDialog({
   open,
   title = 'Import Spreadsheet',
@@ -128,12 +142,19 @@ export default function ImportDialog({
           <Typography variant="subtitle2" gutterBottom>
             Preview — review before importing:
           </Typography>
-          <Stack spacing={0.5}>
-            <Typography variant="body2">New rows: <strong>{previewData.inserts}</strong></Typography>
-            <Typography variant="body2">Updates in place: <strong>{previewData.updates}</strong></Typography>
-            <Typography variant="body2">Unchanged: <strong>{previewData.noops}</strong></Typography>
-            <Typography variant="body2">Existing rows not in file (left unchanged): <strong>{previewData.omitted}</strong></Typography>
-          </Stack>
+          {previewData.vendors && previewData.contacts ? (
+            <Stack spacing={1.5}>
+              <PreviewBucket label="Vendors" counts={previewData.vendors} />
+              <PreviewBucket label="Vendor Contacts" counts={previewData.contacts} />
+            </Stack>
+          ) : (
+            <Stack spacing={0.5}>
+              <Typography variant="body2">New rows: <strong>{previewData.inserts}</strong></Typography>
+              <Typography variant="body2">Updates in place: <strong>{previewData.updates}</strong></Typography>
+              <Typography variant="body2">Unchanged: <strong>{previewData.noops}</strong></Typography>
+              <Typography variant="body2">Existing rows not in file (left unchanged): <strong>{previewData.omitted}</strong></Typography>
+            </Stack>
+          )}
         </Alert>
       )}
 

--- a/apps/client/src/components/shared/ImportDialog.jsx
+++ b/apps/client/src/components/shared/ImportDialog.jsx
@@ -17,6 +17,7 @@ import { useState, useCallback, useEffect } from 'react';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
 import Stack from '@mui/material/Stack';
+import Divider from '@mui/material/Divider';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -143,7 +144,12 @@ export default function ImportDialog({
             Preview — review before importing:
           </Typography>
           {previewData.vendors && previewData.contacts ? (
-            <Stack spacing={1.5}>
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={{ xs: 1.5, sm: 4 }}
+              divider={<Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', sm: 'block' } }} />}
+              sx={{ alignItems: 'flex-start' }}
+            >
               <PreviewBucket label="Vendors" counts={previewData.vendors} />
               <PreviewBucket label="Vendor Contacts" counts={previewData.contacts} />
             </Stack>

--- a/apps/client/src/pages/Core/VendorsPage.jsx
+++ b/apps/client/src/pages/Core/VendorsPage.jsx
@@ -265,7 +265,15 @@ export default function VendorsPage() {
     setImportErrors(null);
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const vIns = result.inserted || 0;
+      const vUpd = result.updated || 0;
+      const cIns = result.contactsInserted || 0;
+      const cUpd = result.contactsUpdated || 0;
+      const allZero = !vIns && !vUpd && !cIns && !cUpd;
+      const message = allZero
+        ? 'Import complete — no changes'
+        : `Vendors: ${vIns} new, ${vUpd} updated • Contacts: ${cIns} new, ${cUpd} updated`;
+      toast(message);
       importDialog.close();
     } catch (err) {
       const validationErrors = err.payload?.errors;
@@ -475,6 +483,7 @@ export default function VendorsPage() {
         title="Import Vendors"
         loading={importMut.isPending}
         errors={importErrors}
+        onPreview={(fd) => vendorApi.importCombinedXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />

--- a/apps/client/src/services/vendorApi.js
+++ b/apps/client/src/services/vendorApi.js
@@ -25,7 +25,8 @@ export const vendorApi = {
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
   importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
-  importCombinedXls: (formData) => client.post(`${BASE}/import-combined-xls`, formData),
+  importCombinedXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-combined-xls${preview ? '?preview=1' : ''}`, formData),
   exportCombinedXls: (body = {}) => client.post(`${BASE}/export-combined-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -2562,9 +2562,10 @@ function _arrayEq(a, b) {
  *     normally differs from the prior `updated_by`.
  * @private
  */
-function _diffParent(transformed, existing) {
+function _diffParent(transformed, existing, { caseSensitive = false } = {}) {
   const SKIP = new Set(['id', 'tenant_id', 'created_at', 'created_by', 'updated_at', 'updated_by']);
   const changes = {};
+  const eq = caseSensitive ? _strictEq : _normEq;
   for (const [col, val] of Object.entries(transformed)) {
     if (SKIP.has(col)) continue;
     const cur = existing[col];
@@ -2572,16 +2573,30 @@ function _diffParent(transformed, existing) {
       if (!_arrayEq(val, cur)) changes[col] = val;
       continue;
     }
-    if (!_normEq(val, cur)) changes[col] = val;
+    if (!eq(val, cur)) changes[col] = val;
   }
   return changes;
+}
+
+/**
+ * Case-preserving variant of `_normEq`: still conflates null / undefined /
+ * empty-string and trims strings, but compares strings byte-for-byte so
+ * case-only edits surface as real diffs. Used by callers that opt into
+ * `{ caseSensitive: true }` on `diffParent`.
+ * @private
+ */
+function _strictEq(a, b) {
+  const na = a == null || a === '' ? null : typeof a === 'string' ? a.trim() : a;
+  const nb = b == null || b === '' ? null : typeof b === 'string' ? b.trim() : b;
+  return na === nb;
 }
 
 /**
  * Public re-export of the parent-row diff used by flat-import preview paths.
  * Returns the subset of `transformed` whose values differ from `existing`,
  * ignoring id / tenant_id / audit columns. Used by Vendors._importFlatCombined
- * to classify per-parent insert / update / noop without writing.
+ * to classify per-parent insert / update / noop without writing. Pass
+ * `{ caseSensitive: true }` when case-only edits must count as changes.
  */
 export const diffParent = _diffParent;
 

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -2578,6 +2578,14 @@ function _diffParent(transformed, existing) {
 }
 
 /**
+ * Public re-export of the parent-row diff used by flat-import preview paths.
+ * Returns the subset of `transformed` whose values differ from `existing`,
+ * ignoring id / tenant_id / audit columns. Used by Vendors._importFlatCombined
+ * to classify per-parent insert / update / noop without writing.
+ */
+export const diffParent = _diffParent;
+
+/**
  * Coerce + transform a parent row exactly the way the write path does. Result
  * is the row that would be sent to model.updateWhere or model.bulkInsert.
  * @private

--- a/apps/server/src/system/core/controllers/vendorsController.js
+++ b/apps/server/src/system/core/controllers/vendorsController.js
@@ -97,23 +97,31 @@ class VendorsController extends BaseController {
   }
 
   /**
-   * POST /import-combined-xls — import vendors + vendor contacts from a combined workbook.
-   * Auto-detects format: 10-sheet combined or legacy 5-sheet vendor-only.
+   * POST /import-combined-xls — import vendors + vendor contacts from the
+   * flat 2-sheet workbook (Vendors sheet + Vendor Contacts sheet).
+   *
+   * Pass `?preview=1` to receive a counts-only classification (vendors +
+   * contacts buckets) without any DB writes.
    */
   async importCombinedXls(req, res) {
     const file = req.file;
     if (!file) return res.status(400).json({ error: 'No file uploaded' });
 
     const tenantCode = req.user?.tenant_code;
-    const index = Number(req.body?.sheetIndex ?? 0);
+    const previewOnly = req.query.preview === '1' || req.query.preview === 'true';
 
     try {
-      const result = await this.model(this.getSchema(req)).importCombinedSpreadsheet(file.path, index, (row) => ({
-        ...row,
-        tenant_code: tenantCode,
-        created_by: req.user?.id || null,
-      }));
-      if (result.errors) return res.status(422).json(result);
+      const result = await this.model(this.getSchema(req)).importCombinedSpreadsheet(
+        file.path,
+        (row) => ({
+          ...row,
+          tenant_code: tenantCode,
+          created_by: req.user?.id || null,
+        }),
+        { previewOnly },
+      );
+      if (result?.errors?.length) return res.status(422).json(result);
+      if (result?.preview) return res.status(200).json(result);
       res.json(result);
     } catch (err) {
       this.handleError(err, res, 'importing', this.errorLabel);

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -182,15 +182,24 @@ const _childKeyForModel = (model) =>
 
 /**
  * Normalize a child column value for set-comparison. Conflates null /
- * undefined / empty-string, lowercases + trims strings, and coerces booleans
- * to 1/0 so comparisons survive the round-trip through the spreadsheet
- * (which may carry bools as strings) and pg-schemata coercion.
+ * undefined / empty-string, trims strings, and coerces literal `'true'` /
+ * `'false'` strings to booleans so the comparison survives the round-trip
+ * through tablsx (which can hand back booleans as strings) and pg-schemata
+ * coercion. Case is preserved — case-sensitive fields like `address_line_1`,
+ * `city`, and `label` must surface case-only edits as real changes.
  */
 function _normChildVal(v) {
-  if (v === true) return 1;
-  if (v === false) return 0;
-  if (v == null || v === '') return null;
-  return typeof v === 'string' ? v.trim().toLowerCase() : v;
+  if (v === true) return true;
+  if (v === false) return false;
+  if (v == null) return null;
+  if (typeof v === 'string') {
+    const t = v.trim();
+    if (t === '') return null;
+    if (/^true$/i.test(t)) return true;
+    if (/^false$/i.test(t)) return false;
+    return t;
+  }
+  return v;
 }
 
 /**
@@ -515,6 +524,8 @@ export default class Vendors extends TableModel {
       const buckets = await this._classifyCombinedForPreview({
         db,
         s,
+        schema,
+        pgp,
         vendorGroups,
         contactGroups,
         callbackFn,
@@ -591,7 +602,6 @@ export default class Vendors extends TableModel {
           } else {
             await t.none(`UPDATE ${s}.vendors SET deactivated_at = NULL WHERE id = $1 AND deactivated_at IS NOT NULL`, [id]);
           }
-          updatedCount++;
         }
 
         // Always populate the ref maps so cross-sheet contact resolution and
@@ -600,9 +610,13 @@ export default class Vendors extends TableModel {
         vendorRefToId.set(id, id);
         vendorIdToSourceId.set(id, existing.source_id);
 
+        // Child wholesale-replace also counts as an update: the count must
+        // reflect every DB write, not just parent-field changes.
+        let childReplaced = false;
         if (existing.source_id) {
-          await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+          childReplaced = await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
         }
+        if (parentChanged || childReplaced) updatedCount++;
       }
 
       _tVendorUpdates = Date.now();
@@ -757,12 +771,13 @@ export default class Vendors extends TableModel {
           } else {
             await t.none(`UPDATE ${s}.vendor_contacts SET deactivated_at = NULL WHERE id = $1 AND deactivated_at IS NOT NULL`, [id]);
           }
-          contactsUpdated++;
         }
 
+        let childReplaced = false;
         if (existing.source_id) {
-          await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+          childReplaced = await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
         }
+        if (parentChanged || childReplaced) contactsUpdated++;
       }
 
       // Run contact inserts
@@ -888,13 +903,75 @@ export default class Vendors extends TableModel {
   }
 
   /**
-   * Upsert flat children for an updated parent: when the file's child set for
-   * a given cfg matches what's already in the DB (by `cfg.cols`), skip the
-   * wholesale-replace so child rows don't get recycled with new ids and bumped
-   * audit timestamps on a no-op re-import. Otherwise soft-delete the existing
-   * active set and bulk-insert the file's set.
+   * Transform the file's child rows for a single cfg into the same shape
+   * `bulkInsert` would persist. Shared by the commit (`_upsertFlatChildren`)
+   * and the preview classifier (`_anyChildrenDiffer`) so both sides compare
+   * the exact same values.
+   */
+  async _transformFlatChildSet(cfg, fileRows, sourceId, childModel, callbackFn, tenantId) {
+    const out = [];
+    for (const row of fileRows) {
+      const { _rowNum: _, ...rest } = row;
+      const base = { ...rest, source_id: sourceId };
+      const transformed = callbackFn ? await callbackFn(base) : base;
+      delete transformed.tenant_code;
+      if (tenantId) transformed.tenant_id = tenantId;
+      coerceChildRow(transformed, childModel);
+      out.push(transformed);
+    }
+    // Enforce single is_primary per source (partial unique index).
+    if (out.length > 1) {
+      let seenPrimary = false;
+      for (const r of out) {
+        if (r.is_primary) {
+          if (seenPrimary) r.is_primary = false;
+          else seenPrimary = true;
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * No-write check: would `_upsertFlatChildren` replace any of this parent's
+   * child sets? Iterates the cfgs the same way, transforms the file rows,
+   * loads the DB's current active set, and returns true on the first cfg
+   * whose set differs. Used by the preview classifier to keep preview /
+   * commit aligned on child-only changes, and (indirectly) by the commit
+   * path's updated-count accounting via `_upsertFlatChildren`'s return.
+   */
+  async _anyChildrenDiffer({ t, db, s, schema, pgp, sourceId, fileChildren, childConfig, callbackFn, tenantId }) {
+    const handle = t || db;
+    for (const cfg of childConfig) {
+      const key = cfg.model === 'phoneNumbers' ? 'phones' : cfg.model === 'taxIdentifiers' ? 'taxIds' : cfg.model;
+      const rawRows = fileChildren?.[key];
+      if (!rawRows || !rawRows.length) continue;
+
+      const childModel = db(cfg.model, schema);
+      if (t) childModel.tx = t;
+      const tableName = childModel._schema?.table || cfg.model;
+      const tName = pgp.as.name(tableName);
+
+      const toInsert = await this._transformFlatChildSet(cfg, rawRows, sourceId, childModel, callbackFn, tenantId);
+      const existing = await handle.any(
+        `SELECT * FROM ${s}.${tName} WHERE source_id = $1 AND deactivated_at IS NULL`,
+        [sourceId],
+      );
+      if (!_sameChildSet(toInsert, existing, cfg.cols)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Upsert flat children for an updated parent: per cfg, skip the wholesale
+   * soft-delete + bulk-insert when the file's set matches the DB's current
+   * active set on `cfg.cols` so child rows don't get recycled on a no-op
+   * re-import. Returns `true` when at least one cfg was actually replaced —
+   * the parent loops use that to count child-only changes as updates so the
+   * commit's `updated` / `contactsUpdated` counters reflect every DB write.
    */
   async _upsertFlatChildren(t, s, schema, db, pgp, sourceId, children, childConfig, callbackFn, tenantId) {
+    let anyReplaced = false;
     for (const cfg of childConfig) {
       const key = cfg.model === 'phoneNumbers' ? 'phones' : cfg.model === 'taxIdentifiers' ? 'taxIds' : cfg.model;
       const childRows = children[key];
@@ -905,33 +982,7 @@ export default class Vendors extends TableModel {
       const tableName = childModel._schema?.table || cfg.model;
       const tName = pgp.as.name(tableName);
 
-      // Transform incoming rows first so the diff compares post-coercion
-      // values against the DB's typed values (matches what bulkInsert would
-      // persist).
-      const toInsert = [];
-      for (const row of childRows) {
-        const { _rowNum: _, ...rest } = row;
-        const base = { ...rest, source_id: sourceId };
-        const transformed = callbackFn ? await callbackFn(base) : base;
-        delete transformed.tenant_code;
-        if (tenantId) transformed.tenant_id = tenantId;
-        coerceChildRow(transformed, childModel);
-        toInsert.push(transformed);
-      }
-
-      // Enforce single is_primary per source (partial unique index).
-      if (toInsert.length > 1) {
-        let seenPrimary = false;
-        for (const r of toInsert) {
-          if (r.is_primary) {
-            if (seenPrimary) r.is_primary = false;
-            else seenPrimary = true;
-          }
-        }
-      }
-
-      // Skip the wholesale replace when the incoming set matches the DB's
-      // current active set on the cfg's content columns.
+      const toInsert = await this._transformFlatChildSet(cfg, childRows, sourceId, childModel, callbackFn, tenantId);
       const existing = await t.any(
         `SELECT * FROM ${s}.${tName} WHERE source_id = $1 AND deactivated_at IS NULL`,
         [sourceId],
@@ -945,7 +996,9 @@ export default class Vendors extends TableModel {
       if (toInsert.length) {
         await childModel.bulkInsert(toInsert);
       }
+      anyReplaced = true;
     }
+    return anyReplaced;
   }
 
   /**
@@ -1032,12 +1085,13 @@ export default class Vendors extends TableModel {
 
   /**
    * Classify what `_importFlatCombined` would do without touching the DB.
-   * Returns parent-level counts for vendors and contacts. Children are not
-   * counted separately — the combined import always replaces a parent's
-   * children wholesale, so a parent classified as "update" or "noop" carries
-   * its child set with it.
+   * Returns parent-level counts for vendors and contacts. Parents with no
+   * field-level diff but whose child set differs from the DB count as
+   * updates (not noops) to mirror what `_upsertFlatChildren` would do on
+   * commit — preview must not promise "no changes" when a child wholesale
+   * replace is about to fire.
    */
-  async _classifyCombinedForPreview({ db, s, vendorGroups, contactGroups, callbackFn, tenantId }) {
+  async _classifyCombinedForPreview({ db, s, schema, pgp, vendorGroups, contactGroups, callbackFn, tenantId }) {
     const stripContactCols = ['status', 'deactivated_at', 'password'];
 
     const vendors = { inserts: 0, updates: 0, noops: 0, omitted: 0 };
@@ -1065,7 +1119,18 @@ export default class Vendors extends TableModel {
       delete transformed.tenant_code;
       if (tenantId) transformed.tenant_id = tenantId;
       const changes = diffParent(transformed, existing);
-      if (Object.keys(changes).length > 0 || willBeArchived !== wasArchived) vendors.updates += 1;
+      const parentChanged = Object.keys(changes).length > 0 || willBeArchived !== wasArchived;
+      const childrenDiffer = existing.source_id
+        ? await this._anyChildrenDiffer({
+            db, s, schema, pgp,
+            sourceId: existing.source_id,
+            fileChildren: group.children,
+            childConfig: VENDOR_CHILD_ARRAYS_CONFIG,
+            callbackFn,
+            tenantId,
+          })
+        : false;
+      if (parentChanged || childrenDiffer) vendors.updates += 1;
       else vendors.noops += 1;
     }
 
@@ -1098,7 +1163,18 @@ export default class Vendors extends TableModel {
       // normally.
       if (transformed.vendor_id && !isUuid(transformed.vendor_id)) delete transformed.vendor_id;
       const changes = diffParent(transformed, existing);
-      if (Object.keys(changes).length > 0 || willBeArchived !== wasArchived) contacts.updates += 1;
+      const parentChanged = Object.keys(changes).length > 0 || willBeArchived !== wasArchived;
+      const childrenDiffer = existing.source_id
+        ? await this._anyChildrenDiffer({
+            db, s, schema, pgp,
+            sourceId: existing.source_id,
+            fileChildren: group.children,
+            childConfig: CONTACT_CHILD_ARRAYS_CONFIG,
+            callbackFn,
+            tenantId,
+          })
+        : false;
+      if (parentChanged || childrenDiffer) contacts.updates += 1;
       else contacts.noops += 1;
     }
 

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -590,7 +590,7 @@ export default class Vendors extends TableModel {
       for (const { transformed, isArchived, group } of toUpdate) {
         const { id, ...changes } = transformed;
         const existing = existingVendors.get(id);
-        const parentDiff = diffParent(transformed, existing);
+        const parentDiff = diffParent(transformed, existing, { caseSensitive: true });
         const wasArchived = !!existing.deactivated_at;
         const archiveChanged = wasArchived !== isArchived;
         const parentChanged = Object.keys(parentDiff).length > 0 || archiveChanged;
@@ -759,7 +759,7 @@ export default class Vendors extends TableModel {
         const existing = existingContacts.get(transformed.id);
         const { id, vendor_id: _vid, ...changes } = transformed;
         const { vendor_id: _diffVid, ...transformedForDiff } = transformed;
-        const parentDiff = diffParent(transformedForDiff, existing);
+        const parentDiff = diffParent(transformedForDiff, existing, { caseSensitive: true });
         const wasArchived = !!existing.deactivated_at;
         const archiveChanged = wasArchived !== isArchived;
         const parentChanged = Object.keys(parentDiff).length > 0 || archiveChanged;
@@ -1118,7 +1118,7 @@ export default class Vendors extends TableModel {
       const transformed = callbackFn ? await callbackFn({ ...vendorData }) : { ...vendorData };
       delete transformed.tenant_code;
       if (tenantId) transformed.tenant_id = tenantId;
-      const changes = diffParent(transformed, existing);
+      const changes = diffParent(transformed, existing, { caseSensitive: true });
       const parentChanged = Object.keys(changes).length > 0 || willBeArchived !== wasArchived;
       const childrenDiffer = existing.source_id
         ? await this._anyChildrenDiffer({
@@ -1162,7 +1162,7 @@ export default class Vendors extends TableModel {
       // is built during writes). If a stable UUID is provided it'll be diffed
       // normally.
       if (transformed.vendor_id && !isUuid(transformed.vendor_id)) delete transformed.vendor_id;
-      const changes = diffParent(transformed, existing);
+      const changes = diffParent(transformed, existing, { caseSensitive: true });
       const parentChanged = Object.keys(changes).length > 0 || willBeArchived !== wasArchived;
       const childrenDiffer = existing.source_id
         ? await this._anyChildrenDiffer({

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -16,7 +16,6 @@ import vendorsSchema from '../schemas/vendorsSchema.js';
 import {
   exportSourceEntity,
   importSourceEntity,
-  importChildSheet,
   parseSheet,
   isUuid,
   coerceRow,
@@ -30,6 +29,7 @@ import {
   validateChildEnums,
   getEnumColumns,
   parseDbImportError,
+  diffParent,
   PHONE_HEADERS,
   ADDRESS_HEADERS,
   TAX_ID_HEADERS,
@@ -179,6 +179,34 @@ async function getDb() {
 /** Map child model name → group key produced by groupFlatRows extractors */
 const _childKeyForModel = (model) =>
   model === 'phoneNumbers' ? 'phones' : model === 'taxIdentifiers' ? 'taxIds' : model;
+
+/**
+ * Normalize a child column value for set-comparison. Conflates null /
+ * undefined / empty-string, lowercases + trims strings, and coerces booleans
+ * to 1/0 so comparisons survive the round-trip through the spreadsheet
+ * (which may carry bools as strings) and pg-schemata coercion.
+ */
+function _normChildVal(v) {
+  if (v === true) return 1;
+  if (v === false) return 0;
+  if (v == null || v === '') return null;
+  return typeof v === 'string' ? v.trim().toLowerCase() : v;
+}
+
+/**
+ * Order-insensitive set equality between two child collections, comparing
+ * only the columns in `cols`. Used by `_upsertFlatChildren` to skip the
+ * wholesale soft-delete + re-insert when the file's child set matches the
+ * DB's current active set.
+ */
+function _sameChildSet(incoming, existing, cols) {
+  if (incoming.length !== existing.length) return false;
+  const fp = (row) => cols.map((c) => JSON.stringify(_normChildVal(row[c]))).join('|');
+  const a = incoming.map(fp).sort();
+  const b = existing.map(fp).sort();
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
 
 /**
  * Build childEnums config (key + enumMap + flatColByCol) for validateChildEnums
@@ -338,28 +366,41 @@ export default class Vendors extends TableModel {
 
   /**
    * Import from a combined workbook (vendors + vendor_contacts).
-   * Auto-detects format:
-   *   - <= 2 sheets: new flat repeated-row format
-   *   - 3-5 sheets: legacy vendor-only (5-sheet)
-   *   - >= 6 sheets: legacy combined multi-sheet format
+   *
+   * Only the flat 2-sheet shape is supported (Vendors sheet + Vendor Contacts
+   * sheet — the shape `exportCombinedSpreadsheet` produces). The pre-2025
+   * legacy multi-sheet formats (5-sheet vendor-only, 6+-sheet combined) were
+   * removed when the preview path landed.
+   *
+   * Pass `{ previewOnly: true }` to receive a classification payload without
+   * writes: `{ preview: true, vendors: {inserts, updates, noops, omitted},
+   * contacts: {...}, errors: [] }`.
    */
-  async importCombinedSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null) {
+  async importCombinedSpreadsheet(filePath, callbackFn = null, { previewOnly = false } = {}) {
     const { WorkbookReader } = await import('@nap-sft/tablsx');
     const buffer = readFileSync(filePath);
     const reader = WorkbookReader.fromBuffer(buffer);
 
-    if (reader.sheetCount <= 2) {
-      return this._importFlatCombined(reader, callbackFn);
+    if (reader.sheetCount > 2) {
+      return {
+        errors: [
+          {
+            sheet: reader.sheetNames?.[0] || 'Vendors',
+            row: 0,
+            column: '',
+            value: '',
+            message: 'Workbook must be in the flat 2-sheet format (Vendors + Vendor Contacts).',
+          },
+        ],
+      };
     }
-    if (reader.sheetCount < 6) {
-      return importSourceEntity(this, filePath, _sheetIndex, callbackFn, CONFIG);
-    }
-    return this._importLegacyCombined(reader, filePath, _sheetIndex, callbackFn);
+
+    return this._importFlatCombined(reader, callbackFn, { previewOnly });
   }
 
   // ── Flat import (2-sheet repeated-row format) ─────────────────────────────
 
-  async _importFlatCombined(reader, callbackFn) {
+  async _importFlatCombined(reader, callbackFn, { previewOnly = false } = {}) {
     const { db, pgp } = await getDb();
     const schema = this._schema.dbSchema;
     const s = pgp.as.name(schema);
@@ -414,6 +455,11 @@ export default class Vendors extends TableModel {
       } else if (!isUuid(val)) {
         g.parent.payment_term_id = ptIdByLabel.get(String(val).trim()) || null;
       }
+      // Normalize blank code to null. The vendors table has a unique
+      // (tenant_id, code) constraint; two rows with code='' collide on
+      // insert. Numbering allocation runs after bulkInsert, so blanks
+      // must arrive as null for it to fill them in.
+      if (typeof g.parent.code === 'string' && !g.parent.code.trim()) g.parent.code = null;
     }
 
     // Parse contacts before the transaction so we can validate everything upfront
@@ -454,7 +500,28 @@ export default class Vendors extends TableModel {
       })),
       ...validateChildEnums(contactGroups, { sheetName: contactSheetName, childEnums: contactChildEnums }),
     ];
-    if (errors.length) return { errors };
+    if (errors.length) {
+      return previewOnly
+        ? {
+            preview: true,
+            vendors: { inserts: 0, updates: 0, noops: 0, omitted: 0 },
+            contacts: { inserts: 0, updates: 0, noops: 0, omitted: 0 },
+            errors,
+          }
+        : { errors };
+    }
+
+    if (previewOnly) {
+      const buckets = await this._classifyCombinedForPreview({
+        db,
+        s,
+        vendorGroups,
+        contactGroups,
+        callbackFn,
+        tenantId,
+      });
+      return { preview: true, vendors: buckets.vendors, contacts: buckets.contacts, errors: [] };
+    }
 
     let insertedCount = 0;
     let updatedCount = 0;
@@ -475,12 +542,14 @@ export default class Vendors extends TableModel {
       const uuidIds = vendorGroups.filter((g) => isUuid(g.parent.id)).map((g) => g.parent.id);
       const existingVendors = new Map();
       if (uuidIds.length) {
+        // Pull full rows so the per-row diff can skip noop updates and keep
+        // the preview's "0 writes" promise.
         const existing = await t.any(
-          `SELECT id, source_id FROM ${s}.vendors WHERE id IN ($1:csv)`,
+          `SELECT * FROM ${s}.vendors WHERE id IN ($1:csv)`,
           [uuidIds],
         );
         for (const row of existing) {
-          existingVendors.set(row.id, row.source_id);
+          existingVendors.set(row.id, row);
         }
       }
 
@@ -504,23 +573,35 @@ export default class Vendors extends TableModel {
         }
       }
 
-      // Run updates
+      // Run updates — skip rows whose transformed values match the DB. This
+      // keeps the preview's "0 writes" promise honest and avoids churning
+      // `updated_at` / `updated_by` on every existing vendor on a re-import.
       for (const { transformed, isArchived, group } of toUpdate) {
         const { id, ...changes } = transformed;
-        await this.updateWhere([{ id }], changes, { includeDeactivated: true });
-        if (isArchived) {
-          await t.none(`UPDATE ${s}.vendors SET deactivated_at = NOW() WHERE id = $1 AND deactivated_at IS NULL`, [id]);
-        } else {
-          await t.none(`UPDATE ${s}.vendors SET deactivated_at = NULL WHERE id = $1 AND deactivated_at IS NOT NULL`, [id]);
-        }
-        vendorRefToId.set(id, id);
-        vendorIdToSourceId.set(id, existingVendors.get(id));
-        updatedCount++;
+        const existing = existingVendors.get(id);
+        const parentDiff = diffParent(transformed, existing);
+        const wasArchived = !!existing.deactivated_at;
+        const archiveChanged = wasArchived !== isArchived;
+        const parentChanged = Object.keys(parentDiff).length > 0 || archiveChanged;
 
-        // Upsert children for updated vendor
-        const sourceId = existingVendors.get(id);
-        if (sourceId) {
-          await this._upsertFlatChildren(t, s, schema, db, pgp, sourceId, group.children, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+        if (parentChanged) {
+          await this.updateWhere([{ id }], changes, { includeDeactivated: true });
+          if (isArchived) {
+            await t.none(`UPDATE ${s}.vendors SET deactivated_at = NOW() WHERE id = $1 AND deactivated_at IS NULL`, [id]);
+          } else {
+            await t.none(`UPDATE ${s}.vendors SET deactivated_at = NULL WHERE id = $1 AND deactivated_at IS NOT NULL`, [id]);
+          }
+          updatedCount++;
+        }
+
+        // Always populate the ref maps so cross-sheet contact resolution and
+        // child upsert use the correct source_id, even when the parent itself
+        // wasn't written.
+        vendorRefToId.set(id, id);
+        vendorIdToSourceId.set(id, existing.source_id);
+
+        if (existing.source_id) {
+          await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
         }
       }
 
@@ -620,10 +701,10 @@ export default class Vendors extends TableModel {
       const existingContacts = new Map();
       if (contactUuidIds.length) {
         const existing = await t.any(
-          `SELECT id, source_id FROM ${s}.vendor_contacts WHERE id IN ($1:csv)`,
+          `SELECT * FROM ${s}.vendor_contacts WHERE id IN ($1:csv)`,
           [contactUuidIds],
         );
-        for (const row of existing) existingContacts.set(row.id, row.source_id);
+        for (const row of existing) existingContacts.set(row.id, row);
       }
 
       const contactToUpdate = [];
@@ -656,20 +737,31 @@ export default class Vendors extends TableModel {
         }
       }
 
-      // Run contact updates
+      // Run contact updates — same noop-skip semantics as vendors. The
+      // writer doesn't reparent contacts via import (vendor_id is excluded
+      // from the update DTO), so vendor_id is also excluded from the diff
+      // to avoid false-positive updates when only the cross-sheet ref differs.
       for (const { transformed, isArchived, group } of contactToUpdate) {
+        const existing = existingContacts.get(transformed.id);
         const { id, vendor_id: _vid, ...changes } = transformed;
-        await contactModel.updateWhere([{ id }], changes, { includeDeactivated: true });
-        if (isArchived) {
-          await t.none(`UPDATE ${s}.vendor_contacts SET deactivated_at = NOW() WHERE id = $1 AND deactivated_at IS NULL`, [id]);
-        } else {
-          await t.none(`UPDATE ${s}.vendor_contacts SET deactivated_at = NULL WHERE id = $1 AND deactivated_at IS NOT NULL`, [id]);
-        }
-        contactsUpdated++;
+        const { vendor_id: _diffVid, ...transformedForDiff } = transformed;
+        const parentDiff = diffParent(transformedForDiff, existing);
+        const wasArchived = !!existing.deactivated_at;
+        const archiveChanged = wasArchived !== isArchived;
+        const parentChanged = Object.keys(parentDiff).length > 0 || archiveChanged;
 
-        const sourceId = existingContacts.get(id);
-        if (sourceId) {
-          await this._upsertFlatChildren(t, s, schema, db, pgp, sourceId, group.children, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+        if (parentChanged) {
+          await contactModel.updateWhere([{ id }], changes, { includeDeactivated: true });
+          if (isArchived) {
+            await t.none(`UPDATE ${s}.vendor_contacts SET deactivated_at = NOW() WHERE id = $1 AND deactivated_at IS NULL`, [id]);
+          } else {
+            await t.none(`UPDATE ${s}.vendor_contacts SET deactivated_at = NULL WHERE id = $1 AND deactivated_at IS NOT NULL`, [id]);
+          }
+          contactsUpdated++;
+        }
+
+        if (existing.source_id) {
+          await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
         }
       }
 
@@ -796,7 +888,11 @@ export default class Vendors extends TableModel {
   }
 
   /**
-   * Upsert flat children: soft-delete existing, insert new from grouped child arrays.
+   * Upsert flat children for an updated parent: when the file's child set for
+   * a given cfg matches what's already in the DB (by `cfg.cols`), skip the
+   * wholesale-replace so child rows don't get recycled with new ids and bumped
+   * audit timestamps on a no-op re-import. Otherwise soft-delete the existing
+   * active set and bulk-insert the file's set.
    */
   async _upsertFlatChildren(t, s, schema, db, pgp, sourceId, children, childConfig, callbackFn, tenantId) {
     for (const cfg of childConfig) {
@@ -807,14 +903,11 @@ export default class Vendors extends TableModel {
       const childModel = db(cfg.model, schema);
       childModel.tx = t;
       const tableName = childModel._schema?.table || cfg.model;
+      const tName = pgp.as.name(tableName);
 
-      // Soft-delete existing children
-      await t.none(
-        `UPDATE ${s}.${pgp.as.name(tableName)} SET deactivated_at = NOW() WHERE source_id = $1 AND deactivated_at IS NULL`,
-        [sourceId],
-      );
-
-      // Insert new children
+      // Transform incoming rows first so the diff compares post-coercion
+      // values against the DB's typed values (matches what bulkInsert would
+      // persist).
       const toInsert = [];
       for (const row of childRows) {
         const { _rowNum: _, ...rest } = row;
@@ -826,7 +919,7 @@ export default class Vendors extends TableModel {
         toInsert.push(transformed);
       }
 
-      // Enforce single is_primary per source (partial unique index)
+      // Enforce single is_primary per source (partial unique index).
       if (toInsert.length > 1) {
         let seenPrimary = false;
         for (const r of toInsert) {
@@ -837,6 +930,18 @@ export default class Vendors extends TableModel {
         }
       }
 
+      // Skip the wholesale replace when the incoming set matches the DB's
+      // current active set on the cfg's content columns.
+      const existing = await t.any(
+        `SELECT * FROM ${s}.${tName} WHERE source_id = $1 AND deactivated_at IS NULL`,
+        [sourceId],
+      );
+      if (_sameChildSet(toInsert, existing, cfg.cols)) continue;
+
+      await t.none(
+        `UPDATE ${s}.${tName} SET deactivated_at = NOW() WHERE source_id = $1 AND deactivated_at IS NULL`,
+        [sourceId],
+      );
       if (toInsert.length) {
         await childModel.bulkInsert(toInsert);
       }
@@ -923,222 +1028,81 @@ export default class Vendors extends TableModel {
     }
   }
 
-  // ── Legacy multi-sheet import (backward compatibility) ────────────────────
+  // ── Preview classifier (no writes) ────────────────────────────────────────
 
-  async _importLegacyCombined(reader, filePath, _sheetIndex, callbackFn) {
-    const { db, pgp } = await getDb();
-    const schema = this._schema.dbSchema;
-    const s = pgp.as.name(schema);
+  /**
+   * Classify what `_importFlatCombined` would do without touching the DB.
+   * Returns parent-level counts for vendors and contacts. Children are not
+   * counted separately — the combined import always replaces a parent's
+   * children wholesale, so a parent classified as "update" or "noop" carries
+   * its child set with it.
+   */
+  async _classifyCombinedForPreview({ db, s, vendorGroups, contactGroups, callbackFn, tenantId }) {
+    const stripContactCols = ['status', 'deactivated_at', 'password'];
 
-    // Phase 1: Import vendors + vendor children using standard import
-    const vendorResult = await importSourceEntity(this, filePath, _sheetIndex, callbackFn, CONFIG);
+    const vendors = { inserts: 0, updates: 0, noops: 0, omitted: 0 };
+    const contacts = { inserts: 0, updates: 0, noops: 0, omitted: 0 };
 
-    // Phase 2: Import vendor contacts from sheet 5
-    const contactRows = parseSheet(reader, 5);
-    if (!contactRows.length) return { ...vendorResult, contactsInserted: 0, contactsUpdated: 0 };
-
-    let contactsInserted = 0;
-    let contactsUpdated = 0;
-    const contactRefToSourceId = new Map();
-
-    let tenantId;
-    const sampleRow = callbackFn ? await callbackFn({}) : {};
-    if (sampleRow.tenant_code) {
-      const tenantRec = await db.oneOrNone(
-        'SELECT id FROM admin.tenants WHERE tenant_code = $1 AND deactivated_at IS NULL',
-        [sampleRow.tenant_code.toUpperCase()],
-      );
-      tenantId = tenantRec?.id;
+    // Vendors ─────────────────────────────────────────────────────────────
+    const vendorUuidIds = vendorGroups.filter((g) => isUuid(g.parent.id)).map((g) => g.parent.id);
+    const existingVendors = new Map();
+    if (vendorUuidIds.length) {
+      const rows = await db.any(`SELECT * FROM ${s}.vendors WHERE id IN ($1:csv)`, [vendorUuidIds]);
+      for (const row of rows) existingVendors.set(row.id, row);
     }
 
-    const stripCols = ['status', 'deactivated_at', 'password'];
-
-    try {
-    await db.tx(async (t) => {
-      const contactModel = db('vendorContacts', schema);
-      contactModel.tx = t;
-
-      const uuidIds = contactRows.filter((r) => isUuid(r.id)).map((r) => r.id);
-      const existingSet = new Set();
-      if (uuidIds.length) {
-        const existing = await t.any(
-          `SELECT id, source_id FROM ${s}.vendor_contacts WHERE id IN ($1:csv)`,
-          [uuidIds],
-        );
-        for (const row of existing) {
-          existingSet.add(row.id);
-          contactRefToSourceId.set(row.id, row.source_id);
-        }
+    for (const group of vendorGroups) {
+      const existing = existingVendors.get(group.parent.id);
+      if (!existing) {
+        vendors.inserts += 1;
+        continue;
       }
-
-      const toUpdate = [];
-      const toInsert = [];
-      for (const row of contactRows) {
-        const isArchived = String(row.status).toLowerCase() === 'archived';
-        const password = row.password || null;
-        for (const col of stripCols) delete row[col];
-
-        const transformed = callbackFn ? await callbackFn({ ...row }) : { ...row };
-        for (const col of stripCols) delete transformed[col];
-        delete transformed.tenant_code;
-        if (tenantId) transformed.tenant_id = tenantId;
-        coerceRow(transformed, CONTACT_CONFIG.boolCols, CONTACT_CONFIG.hasRoles);
-
-        if (existingSet.has(row.id)) {
-          transformed._archive = isArchived;
-          toUpdate.push(transformed);
-        } else {
-          transformed._ref = row.id || null;
-          transformed._archive = isArchived;
-          transformed._password = password;
-          delete transformed.id;
-          toInsert.push(transformed);
-        }
-      }
-
-      for (const row of toUpdate) {
-        const { id, vendor_id: _vid, tenant_code: _tc, _archive, ...changes } = row;
-        await contactModel.updateWhere([{ id }], changes, { includeDeactivated: true });
-        if (_archive) {
-          await t.none(`UPDATE ${s}.vendor_contacts SET deactivated_at = NOW() WHERE id = $1 AND deactivated_at IS NULL`, [id]);
-        } else {
-          await t.none(`UPDATE ${s}.vendor_contacts SET deactivated_at = NULL WHERE id = $1 AND deactivated_at IS NOT NULL`, [id]);
-        }
-        contactsUpdated++;
-      }
-
-      let insertResults = [];
-      let sourceByParentId = new Map();
-      let tid;
-      let createdBy;
-
-      if (toInsert.length) {
-        const cleanInserts = toInsert.map(({ _ref, _archive, _password, tenant_code: _tc, ...rest }) => rest);
-
-        insertResults = await contactModel.bulkInsert(cleanInserts, CONTACT_CONFIG.returningCols);
-        contactsInserted = insertResults.length;
-
-        const sourcesModel = db('sources', schema);
-        sourcesModel.tx = t;
-
-        tid = cleanInserts[0]?.tenant_id;
-        // createdBy stays for provisionAppUser below — raw INSERT into
-        // admin.portal_users bypasses pg-schemata's audit resolver.
-        createdBy = cleanInserts[0]?.created_by || null;
-
-        const sourceRecords = insertResults.map((rec) => ({
-          tenant_id: tid,
-          table_id: rec.id,
-          source_type: CONTACT_CONFIG.sourceType,
-          label: CONTACT_CONFIG.buildLabel(rec),
-        }));
-
-        const sourceResults = await sourcesModel.bulkInsert(sourceRecords, ['id', 'table_id']);
-        sourceByParentId = new Map(sourceResults.map((sr) => [sr.table_id, sr.id]));
-
-        // ── Batch: link source_id for contacts ─────────────────────
-        const contactSourceLinks = insertResults
-          .map((rec) => ({ id: rec.id, source_id: sourceByParentId.get(rec.id) }))
-          .filter((r) => r.source_id);
-        if (contactSourceLinks.length) {
-          const vals = contactSourceLinks.map((r) => pgp.as.format('($1::uuid, $2::uuid)', [r.id, r.source_id])).join(', ');
-          await t.none(`UPDATE ${s}.vendor_contacts AS v SET source_id = vals.source_id FROM (VALUES ${vals}) AS vals(id, source_id) WHERE v.id = vals.id`);
-        }
-
-        // Build ref map (JS only)
-        for (let i = 0; i < insertResults.length; i++) {
-          const ref = toInsert[i]._ref;
-          const sourceId = sourceByParentId.get(insertResults[i].id);
-          if (ref && sourceId) contactRefToSourceId.set(ref, sourceId);
-        }
-
-        // ── Batch: archive inserted contacts ───────────────────────
-        const contactArchiveIds = insertResults.filter((_, i) => toInsert[i]._archive).map((r) => r.id);
-        if (contactArchiveIds.length) {
-          await t.none(`UPDATE ${s}.vendor_contacts SET deactivated_at = NOW() WHERE id IN ($1:csv)`, [contactArchiveIds]);
-        }
-      }
-
-      for (let ci = 0; ci < CONTACT_CONFIG.childSheets.length; ci++) {
-        const sheetIdx = 6 + ci;
-        if (reader.sheetCount > sheetIdx) {
-          await importChildSheet(reader, sheetIdx, contactRefToSourceId, CONTACT_CONFIG.childSheets[ci].modelName, schema, CONTACT_CONFIG.linkColName, callbackFn, tenantId, t);
-        }
-      }
-
-      if (CONTACT_CONFIG.appUserProvisioning && insertResults.length) {
-        const crypto = await import('node:crypto');
-
-        // Identify app-user contacts and their source_ids
-        const appUserCandidates = [];
-        for (let i = 0; i < insertResults.length; i++) {
-          if (!toInsert[i].is_app_user) continue;
-          const sourceId = sourceByParentId.get(insertResults[i].id);
-          if (!sourceId) continue;
-          appUserCandidates.push({ index: i, sourceId });
-        }
-
-        if (appUserCandidates.length) {
-          // Batch email lookup
-          const candidateSourceIds = appUserCandidates.map((c) => c.sourceId);
-          const emailRows = await t.any(
-            `SELECT DISTINCT ON (source_id) source_id, email
-             FROM ${s}.emails
-             WHERE source_id IN ($1:csv) AND deactivated_at IS NULL
-             ORDER BY source_id, is_login DESC, is_primary DESC, created_at`,
-            [candidateSourceIds],
-          );
-          const emailBySourceId = new Map(emailRows.map((r) => [r.source_id, r.email]));
-
-          // Build password list and pre-hash in parallel
-          const toProvision = [];
-          for (const { index, sourceId } of appUserCandidates) {
-            const email = emailBySourceId.get(sourceId);
-            if (!email) {
-              await t.none(`UPDATE ${s}.vendor_contacts SET is_app_user = false WHERE id = $1`, [insertResults[index].id]);
-              continue;
-            }
-            const clearPassword = toInsert[index]._password || crypto.randomBytes(12).toString('base64url');
-            toProvision.push({ index, email, clearPassword });
-          }
-
-          if (toProvision.length) {
-            const hashMap = await batchHashPasswords(toProvision.map((p) => ({ index: p.index, password: p.clearPassword })));
-            const entityType = CONTACT_CONFIG.appUserProvisioning.entityType;
-
-            for (const { index, email } of toProvision) {
-              const existing = await t.oneOrNone(
-                'SELECT id FROM admin.portal_users WHERE email = $1 AND deactivated_at IS NULL',
-                [email],
-              );
-              if (existing) continue;
-              const inserted = await t.one(
-                `INSERT INTO admin.portal_users (email, password_hash, status, created_by)
-                 VALUES ($1, $2, 'invited', $3)
-                 RETURNING id`,
-                [email, hashMap.get(index), createdBy],
-              );
-              await t.none(
-                `INSERT INTO admin.portal_user_tenants
-                   (portal_user_id, tenant_id, entity_type, entity_id, status, created_by)
-                 VALUES ($1, $2, $3, $4, 'active', $5)`,
-                [inserted.id, tid, entityType, insertResults[index].id, createdBy],
-              );
-            }
-          }
-        }
-      }
-    });
-    } catch (err) {
-      const dataErrors = parseDbImportError(err);
-      if (dataErrors) return { errors: dataErrors };
-      throw err;
+      const willBeArchived = String(group.parent.status || '').toLowerCase() === 'archived';
+      const wasArchived = !!existing.deactivated_at;
+      const { _rowNum: _rn, ...vendorData } = { ...group.parent };
+      delete vendorData.status;
+      const transformed = callbackFn ? await callbackFn({ ...vendorData }) : { ...vendorData };
+      delete transformed.tenant_code;
+      if (tenantId) transformed.tenant_id = tenantId;
+      const changes = diffParent(transformed, existing);
+      if (Object.keys(changes).length > 0 || willBeArchived !== wasArchived) vendors.updates += 1;
+      else vendors.noops += 1;
     }
 
-    return {
-      ...vendorResult,
-      contactsInserted,
-      contactsUpdated,
-    };
+    // Contacts ────────────────────────────────────────────────────────────
+    const contactUuidIds = contactGroups.filter((g) => isUuid(g.parent.id)).map((g) => g.parent.id);
+    const existingContacts = new Map();
+    if (contactUuidIds.length) {
+      const rows = await db.any(`SELECT * FROM ${s}.vendor_contacts WHERE id IN ($1:csv)`, [contactUuidIds]);
+      for (const row of rows) existingContacts.set(row.id, row);
+    }
+
+    for (const group of contactGroups) {
+      const existing = existingContacts.get(group.parent.id);
+      if (!existing) {
+        contacts.inserts += 1;
+        continue;
+      }
+      const willBeArchived = String(group.parent.status || '').toLowerCase() === 'archived';
+      const wasArchived = !!existing.deactivated_at;
+      const { _rowNum: _crn, ...contactData } = { ...group.parent };
+      for (const col of stripContactCols) delete contactData[col];
+      const transformed = callbackFn ? await callbackFn({ ...contactData }) : { ...contactData };
+      for (const col of stripContactCols) delete transformed[col];
+      delete transformed.tenant_code;
+      if (tenantId) transformed.tenant_id = tenantId;
+      coerceRow(transformed, CONTACT_CONFIG.boolCols, CONTACT_CONFIG.hasRoles);
+      // vendor_id refs pointing at to-be-inserted vendors aren't resolvable
+      // yet — skip the column for the diff (the commit-side resolution map
+      // is built during writes). If a stable UUID is provided it'll be diffed
+      // normally.
+      if (transformed.vendor_id && !isUuid(transformed.vendor_id)) delete transformed.vendor_id;
+      const changes = diffParent(transformed, existing);
+      if (Object.keys(changes).length > 0 || willBeArchived !== wasArchived) contacts.updates += 1;
+      else contacts.noops += 1;
+    }
+
+    return { vendors, contacts };
   }
+
 }

--- a/apps/server/tests/contract/vendorsCombinedImport.test.js
+++ b/apps/server/tests/contract/vendorsCombinedImport.test.js
@@ -1,0 +1,498 @@
+/**
+ * @file Contract tests for the combined Vendors + VendorContacts import
+ * @module tests/contract/vendorsCombinedImport
+ *
+ * Behavior locked in:
+ *   - `?preview=1` returns a two-bucket payload (vendors + contacts) without writing.
+ *   - The commit path writes the expected inserted/updated counts.
+ *   - A re-commit reflects in vendor preview as all-noops.
+ *   - A workbook with more than 2 sheets is rejected with a format error.
+ *   - Update path: changing a vendor field shows up as one update; row persists.
+ *   - Archive transition via `status='archived'` sets `deactivated_at`.
+ *   - Restore transition via `status='active'` clears `deactivated_at`.
+ *   - Child reconciliation: re-importing a vendor with new child rows soft-deletes
+ *     all prior children for that source and inserts the new set (wholesale replace).
+ *   - App-user provisioning: a new contact with `is_app_user=true` + an email
+ *     yields a `portal_users` row plus an active `portal_user_tenants` binding.
+ *   - Preview/commit parity: a round-trip workbook (UUIDs preserved, content
+ *     unchanged, child sets identical) reports zero writes from commit and
+ *     leaves vendor / contact / email `updated_at` untouched.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(cookies, code) {
+  await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', cookies)
+    .send({
+      tenant_code: code,
+      company: `${code} Vendor Combo Corp`,
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'Test',
+      admin_last_name: 'Admin',
+      admin_email: `admin@${code.toLowerCase()}.com`,
+      admin_password: 'ComboPass123!',
+      billing_address: { address_line_1: '1 Combo St', country_code: 'US' },
+    });
+}
+
+const VENDOR_HEADERS = [
+  'id', 'code', 'name', 'payment_term_id', 'notes', 'status',
+  'email', 'email_label', 'email_is_primary',
+  'phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary',
+  'address_label', 'address_line_1', 'address_line_2', 'address_line_3',
+  'address_city', 'address_state_province', 'address_postal_code', 'address_country_code',
+  'tax_country_code', 'tax_type', 'tax_value',
+];
+
+const CONTACT_HEADERS = [
+  'vendor_id', 'id', 'first_name', 'last_name', 'position', 'department',
+  'is_app_user', 'roles', 'status', 'password',
+  'email', 'email_label', 'email_is_primary', 'email_is_login',
+  'phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary',
+];
+
+function blankVendor(extras = {}) {
+  return Object.fromEntries(VENDOR_HEADERS.map((h) => [h, extras[h] ?? '']));
+}
+function blankContact(extras = {}) {
+  return Object.fromEntries(CONTACT_HEADERS.map((h) => [h, extras[h] ?? '']));
+}
+
+async function buildWorkbook(vendorRows, contactRows, { extraSheets = 0 } = {}) {
+  const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+  const wb = WorkbookBuilder.create();
+  wb.sheet('Vendors').setHeaders(VENDOR_HEADERS).addObjects(vendorRows);
+  wb.sheet('Vendor Contacts').setHeaders(CONTACT_HEADERS).addObjects(contactRows);
+  for (let i = 0; i < extraSheets; i++) {
+    wb.sheet(`Extra ${i}`).setHeaders(['col']).addObjects([{ col: 'x' }]);
+  }
+  return writeXlsx(wb.build());
+}
+
+async function postImport(buf, cookies, label, { preview = false } = {}) {
+  const tmpPath = join(tmpdir(), `vcombo-${label}-${Date.now()}.xlsx`);
+  writeFileSync(tmpPath, buf);
+  const url = `/api/core/v1/vendors/import-combined-xls${preview ? '?preview=1' : ''}`;
+  try {
+    return await request(app).post(url).set('Cookie', cookies).attach('file', tmpPath);
+  } finally {
+    unlinkSync(tmpPath);
+  }
+}
+
+describe('Vendors combined import — preview + commit', () => {
+  let cookies;
+
+  beforeAll(async () => {
+    const rootCookies = await loginRoot();
+    await provisionTenant(rootCookies, 'VCOMBO');
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@vcombo.com', password: 'ComboPass123!' });
+    cookies = loginRes.headers['set-cookie'];
+  }, 30000);
+
+  // Non-UUID ids in the source workbook act as in-file refs that the
+  // importer maps to the inserted vendor UUIDs. Contacts cite their vendor
+  // via the same ref string.
+  const ACME_REF = 'acme-ref';
+  const BETA_REF = 'beta-ref';
+
+  test('preview returns two-bucket payload and writes nothing', async () => {
+    const vendorsBefore = await db.any('SELECT count(*)::int AS n FROM vcombo.vendors');
+    const contactsBefore = await db.any('SELECT count(*)::int AS n FROM vcombo.vendor_contacts');
+
+    const buf = await buildWorkbook(
+      [
+        blankVendor({ id: ACME_REF, name: 'Acme Supplies', status: 'active', email: 'sales@acme.test', email_label: 'work', email_is_primary: true }),
+        blankVendor({ id: BETA_REF, name: 'Beta Tools', status: 'active' }),
+      ],
+      [
+        blankContact({ vendor_id: ACME_REF, first_name: 'Alice', last_name: 'Adams', status: 'active' }),
+      ],
+    );
+
+    const res = await postImport(buf, cookies, 'preview1', { preview: true });
+    expect(res.status).toBe(200);
+    expect(res.body.preview).toBe(true);
+    expect(res.body.errors).toEqual([]);
+    expect(res.body.vendors).toEqual({ inserts: 2, updates: 0, noops: 0, omitted: 0 });
+    expect(res.body.contacts).toEqual({ inserts: 1, updates: 0, noops: 0, omitted: 0 });
+
+    const vendorsAfter = await db.any('SELECT count(*)::int AS n FROM vcombo.vendors');
+    const contactsAfter = await db.any('SELECT count(*)::int AS n FROM vcombo.vendor_contacts');
+    expect(vendorsAfter[0].n).toBe(vendorsBefore[0].n);
+    expect(contactsAfter[0].n).toBe(contactsBefore[0].n);
+  });
+
+  test('commit writes vendors + contacts; re-commit is a noop', async () => {
+    const buf = await buildWorkbook(
+      [
+        blankVendor({ id: ACME_REF, name: 'Acme Supplies', status: 'active', email: 'sales@acme.test', email_label: 'work', email_is_primary: true }),
+        blankVendor({ id: BETA_REF, name: 'Beta Tools', status: 'active' }),
+      ],
+      [
+        blankContact({ vendor_id: ACME_REF, first_name: 'Alice', last_name: 'Adams', status: 'active' }),
+      ],
+    );
+
+    const commitRes = await postImport(buf, cookies, 'commit1');
+    if (commitRes.status !== 200) {
+      // Surface the response body so debugging doesn't require a re-run.
+      throw new Error(`commit returned ${commitRes.status}: ${JSON.stringify(commitRes.body)}`);
+    }
+    expect(commitRes.body.inserted).toBe(2);
+    expect(commitRes.body.contactsInserted).toBe(1);
+    expect(commitRes.body.updated || 0).toBe(0);
+    expect(commitRes.body.contactsUpdated || 0).toBe(0);
+
+    // Roundtrip via export → re-import as preview should classify everything
+    // as noops. Build an "exported-style" workbook by reading what we just
+    // wrote and reposting it.
+    const vendors = await db.any('SELECT id, code, name FROM vcombo.vendors ORDER BY name');
+    const contacts = await db.any('SELECT id, vendor_id, first_name, last_name FROM vcombo.vendor_contacts ORDER BY last_name');
+    expect(vendors.map((v) => v.name)).toEqual(['Acme Supplies', 'Beta Tools']);
+    expect(contacts).toHaveLength(1);
+
+    const acme = vendors.find((v) => v.name === 'Acme Supplies');
+    const beta = vendors.find((v) => v.name === 'Beta Tools');
+
+    const round = await buildWorkbook(
+      [
+        blankVendor({ id: acme.id, code: acme.code || '', name: 'Acme Supplies', status: 'active', email: 'sales@acme.test', email_label: 'work', email_is_primary: true }),
+        blankVendor({ id: beta.id, code: beta.code || '', name: 'Beta Tools', status: 'active' }),
+      ],
+      [
+        blankContact({ vendor_id: acme.id, id: contacts[0].id, first_name: 'Alice', last_name: 'Adams', status: 'active' }),
+      ],
+    );
+
+    const previewRes = await postImport(round, cookies, 'roundpreview', { preview: true });
+    expect(previewRes.status).toBe(200);
+    expect(previewRes.body.vendors).toEqual({ inserts: 0, updates: 0, noops: 2, omitted: 0 });
+    expect(previewRes.body.contacts).toEqual({ inserts: 0, updates: 0, noops: 1, omitted: 0 });
+  });
+
+  test('update path — changing a vendor field reports updated:1 and persists', async () => {
+    const acme = await db.one(`SELECT id FROM vcombo.vendors WHERE name = $1`, ['Acme Supplies']);
+
+    const buf = await buildWorkbook(
+      [
+        blankVendor({ id: acme.id, name: 'Acme Supplies LLC', status: 'active' }),
+      ],
+      [],
+    );
+
+    const res = await postImport(buf, cookies, 'update1');
+    if (res.status !== 200) {
+      throw new Error(`update returned ${res.status}: ${JSON.stringify(res.body)}`);
+    }
+    expect(res.body.inserted).toBe(0);
+    expect(res.body.updated).toBe(1);
+
+    const after = await db.one(`SELECT name FROM vcombo.vendors WHERE id = $1`, [acme.id]);
+    expect(after.name).toBe('Acme Supplies LLC');
+  });
+
+  test('archive transition — status=archived sets deactivated_at', async () => {
+    const beta = await db.one(`SELECT id FROM vcombo.vendors WHERE name = $1`, ['Beta Tools']);
+
+    const buf = await buildWorkbook(
+      [
+        blankVendor({ id: beta.id, name: 'Beta Tools', status: 'archived' }),
+      ],
+      [],
+    );
+
+    const res = await postImport(buf, cookies, 'archive1');
+    if (res.status !== 200) {
+      throw new Error(`archive returned ${res.status}: ${JSON.stringify(res.body)}`);
+    }
+    expect(res.body.updated).toBe(1);
+
+    const after = await db.one(
+      `SELECT deactivated_at FROM vcombo.vendors WHERE id = $1`,
+      [beta.id],
+    );
+    expect(after.deactivated_at).not.toBeNull();
+  });
+
+  test('restore transition — status=active clears deactivated_at on the previously archived row', async () => {
+    const beta = await db.one(`SELECT id FROM vcombo.vendors WHERE name = $1`, ['Beta Tools']);
+
+    const buf = await buildWorkbook(
+      [
+        blankVendor({ id: beta.id, name: 'Beta Tools', status: 'active' }),
+      ],
+      [],
+    );
+
+    const res = await postImport(buf, cookies, 'restore1');
+    if (res.status !== 200) {
+      throw new Error(`restore returned ${res.status}: ${JSON.stringify(res.body)}`);
+    }
+    expect(res.body.updated).toBe(1);
+
+    const after = await db.one(
+      `SELECT deactivated_at FROM vcombo.vendors WHERE id = $1`,
+      [beta.id],
+    );
+    expect(after.deactivated_at).toBeNull();
+  });
+
+  test('child reconciliation — re-importing a vendor with new emails wholesale-replaces the child set', async () => {
+    // Acme arrived with one email ('sales@acme.test') in the initial commit.
+    // The combined importer treats children as wholesale-replaced per parent:
+    // when the file includes children for a vendor, every active child for
+    // that vendor's source is soft-deleted and the file's set is re-inserted.
+    const acme = await db.one(
+      `SELECT id, source_id FROM vcombo.vendors WHERE name = $1`,
+      ['Acme Supplies LLC'],
+    );
+
+    const beforeActive = await db.any(
+      `SELECT id, email FROM vcombo.emails WHERE source_id = $1 AND deactivated_at IS NULL`,
+      [acme.source_id],
+    );
+    expect(beforeActive.map((r) => r.email).sort()).toEqual(['sales@acme.test']);
+    const originalEmailId = beforeActive[0].id;
+
+    const buf = await buildWorkbook(
+      [
+        blankVendor({
+          id: acme.id, name: 'Acme Supplies LLC', status: 'active',
+          email: 'sales@acme.test', email_label: 'work', email_is_primary: true,
+        }),
+        // Continuation row — all parent cols blank, just supplies a second
+        // child email. groupFlatRows() attaches it to the prior group. Distinct
+        // label is required: `emails` has a unique partial index on
+        // (source_id, label) so two 'work' emails per source would collide.
+        blankVendor({
+          email: 'purchasing@acme.test', email_label: 'purchasing', email_is_primary: false,
+        }),
+      ],
+      [],
+    );
+
+    const res = await postImport(buf, cookies, 'childReplace');
+    if (res.status !== 200) {
+      throw new Error(`child replace returned ${res.status}: ${JSON.stringify(res.body)}`);
+    }
+
+    const afterActive = await db.any(
+      `SELECT id, email FROM vcombo.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY email`,
+      [acme.source_id],
+    );
+    expect(afterActive.map((r) => r.email)).toEqual(['purchasing@acme.test', 'sales@acme.test']);
+
+    // The original sales@acme.test row was soft-deleted as part of wholesale
+    // replace; the re-inserted sales@acme.test carries a new id.
+    const archived = await db.any(
+      `SELECT id, email FROM vcombo.emails WHERE source_id = $1 AND deactivated_at IS NOT NULL`,
+      [acme.source_id],
+    );
+    expect(archived.map((r) => r.id)).toContain(originalEmailId);
+    const newSalesRow = afterActive.find((r) => r.email === 'sales@acme.test');
+    expect(newSalesRow.id).not.toBe(originalEmailId);
+  });
+
+  test('app-user provisioning — new contact with is_app_user=true gets portal_users + binding', async () => {
+    const acme = await db.one(
+      `SELECT id FROM vcombo.vendors WHERE name = $1`,
+      ['Acme Supplies LLC'],
+    );
+    const tenant = await db.one(
+      `SELECT id FROM admin.tenants WHERE tenant_code = 'VCOMBO'`,
+    );
+
+    const buf = await buildWorkbook(
+      // Need a vendor row so the parent sheet isn't empty; reference Acme by
+      // UUID so it's classified as a noop on the vendor side.
+      [
+        blankVendor({ id: acme.id, name: 'Acme Supplies LLC', status: 'active' }),
+      ],
+      [
+        blankContact({
+          vendor_id: acme.id,
+          first_name: 'Bob', last_name: 'Boss',
+          is_app_user: true, roles: '{admin}', status: 'active',
+          password: 'AppUserPass123!',
+          email: 'bob.boss@vcombo.test', email_label: 'work', email_is_primary: true, email_is_login: true,
+        }),
+      ],
+    );
+
+    const res = await postImport(buf, cookies, 'appUser');
+    if (res.status !== 200) {
+      throw new Error(`app-user provisioning returned ${res.status}: ${JSON.stringify(res.body)}`);
+    }
+    expect(res.body.contactsInserted).toBe(1);
+
+    const bob = await db.one(
+      `SELECT id, source_id, is_app_user FROM vcombo.vendor_contacts WHERE first_name = 'Bob' AND last_name = 'Boss'`,
+    );
+    expect(bob.is_app_user).toBe(true);
+
+    const portalUser = await db.oneOrNone(
+      `SELECT id, email, status FROM admin.portal_users WHERE email = 'bob.boss@vcombo.test'`,
+    );
+    expect(portalUser).not.toBeNull();
+    expect(portalUser.status).toBe('invited');
+
+    const binding = await db.oneOrNone(
+      `SELECT entity_type, entity_id, status, deactivated_at
+       FROM admin.portal_user_tenants
+       WHERE portal_user_id = $1 AND tenant_id = $2`,
+      [portalUser.id, tenant.id],
+    );
+    expect(binding).not.toBeNull();
+    expect(binding.entity_type).toBe('vendor_contact');
+    expect(binding.entity_id).toBe(bob.id);
+    expect(binding.deactivated_at).toBeNull();
+  });
+
+  test('round-trip commit is a noop — zero writes, untouched updated_at on parent + children', async () => {
+    // After all the prior tests the DB holds:
+    //   Acme Supplies LLC (with one 'sales@acme.test' [work] + 'purchasing@acme.test' [purchasing] email)
+    //   Beta Tools (no children)
+    //   Alice Adams (contact on Acme, no children)
+    //   Bob Boss (contact on Acme, is_app_user, one 'bob.boss@vcombo.test' email)
+    // Build a workbook that reproduces that exact state and commit it.
+    // Preview must show zero writes AND the commit's counts must match.
+    const acme = await db.one(
+      `SELECT id, name FROM vcombo.vendors WHERE name = $1`,
+      ['Acme Supplies LLC'],
+    );
+    const beta = await db.one(`SELECT id, name FROM vcombo.vendors WHERE name = $1`, ['Beta Tools']);
+    const alice = await db.one(
+      `SELECT id FROM vcombo.vendor_contacts WHERE first_name = 'Alice' AND last_name = 'Adams'`,
+    );
+    const bob = await db.one(
+      `SELECT id FROM vcombo.vendor_contacts WHERE first_name = 'Bob' AND last_name = 'Boss'`,
+    );
+
+    const buf = await buildWorkbook(
+      [
+        // Acme row 1 carries the first email child.
+        blankVendor({
+          id: acme.id, name: 'Acme Supplies LLC', status: 'active',
+          email: 'purchasing@acme.test', email_label: 'purchasing', email_is_primary: false,
+        }),
+        // Continuation row supplies the second email for Acme.
+        blankVendor({
+          email: 'sales@acme.test', email_label: 'work', email_is_primary: true,
+        }),
+        // Beta has no children.
+        blankVendor({ id: beta.id, name: 'Beta Tools', status: 'active' }),
+      ],
+      [
+        blankContact({
+          vendor_id: acme.id, id: alice.id,
+          first_name: 'Alice', last_name: 'Adams', status: 'active',
+        }),
+        blankContact({
+          vendor_id: acme.id, id: bob.id,
+          first_name: 'Bob', last_name: 'Boss',
+          is_app_user: true, roles: '{admin}', status: 'active',
+          email: 'bob.boss@vcombo.test', email_label: 'work', email_is_primary: true, email_is_login: true,
+        }),
+      ],
+    );
+
+    // Preview: must report zero writes coming.
+    const previewRes = await postImport(buf, cookies, 'rt-preview', { preview: true });
+    expect(previewRes.status).toBe(200);
+    expect(previewRes.body.vendors).toEqual({ inserts: 0, updates: 0, noops: 2, omitted: 0 });
+    expect(previewRes.body.contacts).toEqual({ inserts: 0, updates: 0, noops: 2, omitted: 0 });
+
+    // Snapshot DB timestamps before commit so we can prove nothing got touched.
+    const beforeVendors = await db.any(
+      `SELECT id, updated_at FROM vcombo.vendors WHERE id IN ($1, $2) ORDER BY id`,
+      [acme.id, beta.id],
+    );
+    const beforeContacts = await db.any(
+      `SELECT id, updated_at FROM vcombo.vendor_contacts WHERE id IN ($1, $2) ORDER BY id`,
+      [alice.id, bob.id],
+    );
+    const beforeEmails = await db.any(
+      `SELECT id, updated_at FROM vcombo.emails
+       WHERE source_id IN (SELECT source_id FROM vcombo.vendors WHERE id = $1)
+          OR source_id IN (SELECT source_id FROM vcombo.vendor_contacts WHERE id IN ($2, $3))
+       ORDER BY id`,
+      [acme.id, alice.id, bob.id],
+    );
+
+    // Commit: must match the preview's promise.
+    const commitRes = await postImport(buf, cookies, 'rt-commit');
+    if (commitRes.status !== 200) {
+      throw new Error(`round-trip commit returned ${commitRes.status}: ${JSON.stringify(commitRes.body)}`);
+    }
+    expect(commitRes.body.inserted).toBe(0);
+    expect(commitRes.body.updated).toBe(0);
+    expect(commitRes.body.contactsInserted).toBe(0);
+    expect(commitRes.body.contactsUpdated).toBe(0);
+
+    // And the DB rows weren't churned — same ids, same updated_at.
+    const afterVendors = await db.any(
+      `SELECT id, updated_at FROM vcombo.vendors WHERE id IN ($1, $2) ORDER BY id`,
+      [acme.id, beta.id],
+    );
+    const afterContacts = await db.any(
+      `SELECT id, updated_at FROM vcombo.vendor_contacts WHERE id IN ($1, $2) ORDER BY id`,
+      [alice.id, bob.id],
+    );
+    const afterEmails = await db.any(
+      `SELECT id, updated_at FROM vcombo.emails
+       WHERE source_id IN (SELECT source_id FROM vcombo.vendors WHERE id = $1)
+          OR source_id IN (SELECT source_id FROM vcombo.vendor_contacts WHERE id IN ($2, $3))
+       ORDER BY id`,
+      [acme.id, alice.id, bob.id],
+    );
+    expect(afterVendors).toEqual(beforeVendors);
+    expect(afterContacts).toEqual(beforeContacts);
+    expect(afterEmails).toEqual(beforeEmails);
+  });
+
+  test('workbook with more than 2 sheets is rejected with a format error', async () => {
+    const buf = await buildWorkbook(
+      [blankVendor({ name: 'Should Not Import', status: 'active' })],
+      [],
+      { extraSheets: 5 },
+    );
+
+    const res = await postImport(buf, cookies, 'tooManySheets');
+    expect(res.status).toBe(422);
+    expect(res.body.errors).toBeDefined();
+    expect(res.body.errors[0].message).toMatch(/flat 2-sheet/);
+  });
+});

--- a/apps/server/tests/contract/vendorsCombinedImport.test.js
+++ b/apps/server/tests/contract/vendorsCombinedImport.test.js
@@ -483,6 +483,106 @@ describe('Vendors combined import — preview + commit', () => {
     expect(afterEmails).toEqual(beforeEmails);
   });
 
+  test('child-only change — parent unchanged but child set differs — preview AND commit both count it as an update', async () => {
+    // Acme's parent fields don't change; one of its emails gets a different
+    // value. Preview must classify Acme as an update (not noop) and commit's
+    // `updated` counter must reflect the child wholesale-replace.
+    const acme = await db.one(
+      `SELECT id, source_id FROM vcombo.vendors WHERE name = $1`,
+      ['Acme Supplies LLC'],
+    );
+
+    const buf = await buildWorkbook(
+      [
+        // Parent identical to current DB state.
+        blankVendor({
+          id: acme.id, name: 'Acme Supplies LLC', status: 'active',
+          email: 'sales@acme.test', email_label: 'work', email_is_primary: true,
+        }),
+        // Continuation row: same 'purchasing' label, NEW email value.
+        blankVendor({
+          email: 'procurement@acme.test', email_label: 'purchasing', email_is_primary: false,
+        }),
+      ],
+      [],
+    );
+
+    const preview = await postImport(buf, cookies, 'childOnly-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 1, noops: 0, omitted: 0 });
+
+    const commit = await postImport(buf, cookies, 'childOnly-commit');
+    if (commit.status !== 200) {
+      throw new Error(`child-only commit returned ${commit.status}: ${JSON.stringify(commit.body)}`);
+    }
+    expect(commit.body.updated).toBe(1);
+    expect(commit.body.inserted).toBe(0);
+
+    const activeEmails = await db.any(
+      `SELECT email FROM vcombo.emails WHERE source_id = $1 AND deactivated_at IS NULL ORDER BY email`,
+      [acme.source_id],
+    );
+    expect(activeEmails.map((r) => r.email)).toEqual(['procurement@acme.test', 'sales@acme.test']);
+  });
+
+  test('case-only edit on a child field counts as a real change (not a noop)', async () => {
+    // Seed Acme with an address, then re-import with the same address but
+    // a case-only edit on `address_line_1`. The DB column is case-sensitive
+    // and the user's intent is to update casing, so the diff must surface
+    // it as an update — `_normChildVal` must not lowercase its way past it.
+    const acme = await db.one(
+      `SELECT id, source_id FROM vcombo.vendors WHERE name = $1`,
+      ['Acme Supplies LLC'],
+    );
+
+    // Seed: a single address row with mixed-case street name.
+    const seedBuf = await buildWorkbook(
+      [
+        blankVendor({
+          id: acme.id, name: 'Acme Supplies LLC', status: 'active',
+          address_label: 'office', address_line_1: '123 Main St',
+          address_city: 'Springfield', address_country_code: 'US',
+        }),
+      ],
+      [],
+    );
+    const seedRes = await postImport(seedBuf, cookies, 'caseSeed');
+    expect(seedRes.status).toBe(200);
+
+    // Verify the seed landed with the original casing.
+    const seeded = await db.one(
+      `SELECT id, address_line_1 FROM vcombo.addresses WHERE source_id = $1 AND deactivated_at IS NULL`,
+      [acme.source_id],
+    );
+    expect(seeded.address_line_1).toBe('123 Main St');
+
+    // Re-import with case-only change on address_line_1.
+    const editBuf = await buildWorkbook(
+      [
+        blankVendor({
+          id: acme.id, name: 'Acme Supplies LLC', status: 'active',
+          address_label: 'office', address_line_1: '123 MAIN ST',
+          address_city: 'Springfield', address_country_code: 'US',
+        }),
+      ],
+      [],
+    );
+
+    const preview = await postImport(editBuf, cookies, 'caseEdit-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 1, noops: 0, omitted: 0 });
+
+    const commit = await postImport(editBuf, cookies, 'caseEdit-commit');
+    expect(commit.status).toBe(200);
+    expect(commit.body.updated).toBe(1);
+
+    const after = await db.one(
+      `SELECT address_line_1 FROM vcombo.addresses WHERE source_id = $1 AND deactivated_at IS NULL`,
+      [acme.source_id],
+    );
+    expect(after.address_line_1).toBe('123 MAIN ST');
+  });
+
   test('workbook with more than 2 sheets is rejected with a format error', async () => {
     const buf = await buildWorkbook(
       [blankVendor({ name: 'Should Not Import', status: 'active' })],

--- a/apps/server/tests/contract/vendorsCombinedImport.test.js
+++ b/apps/server/tests/contract/vendorsCombinedImport.test.js
@@ -583,6 +583,46 @@ describe('Vendors combined import — preview + commit', () => {
     expect(after.address_line_1).toBe('123 MAIN ST');
   });
 
+  test('case-only edit on a parent field counts as a real change (not a noop)', async () => {
+    // Same case-sensitivity contract as the child-side fix, but at the
+    // parent level: `diffParent` defaults to case-insensitive comparison
+    // (preserves the flat single-entity behavior), so the combined importer
+    // opts in to caseSensitive: true. A rename 'Acme Supplies LLC' ->
+    // 'acme supplies llc' must persist instead of silently noop-skipping.
+    const acme = await db.one(
+      `SELECT id, name FROM vcombo.vendors WHERE id IN (SELECT id FROM vcombo.vendors WHERE name ILIKE 'acme%' LIMIT 1)`,
+    );
+    const originalName = acme.name;
+    const recased = originalName.toLowerCase();
+    expect(recased).not.toBe(originalName);
+
+    const buf = await buildWorkbook(
+      [
+        blankVendor({ id: acme.id, name: recased, status: 'active' }),
+      ],
+      [],
+    );
+
+    const preview = await postImport(buf, cookies, 'parentCase-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 1, noops: 0, omitted: 0 });
+
+    const commit = await postImport(buf, cookies, 'parentCase-commit');
+    expect(commit.status).toBe(200);
+    expect(commit.body.updated).toBe(1);
+
+    const after = await db.one(`SELECT name FROM vcombo.vendors WHERE id = $1`, [acme.id]);
+    expect(after.name).toBe(recased);
+
+    // Restore the original casing so subsequent tests in the file see the
+    // state they expect.
+    const restoreBuf = await buildWorkbook(
+      [blankVendor({ id: acme.id, name: originalName, status: 'active' })],
+      [],
+    );
+    await postImport(restoreBuf, cookies, 'parentCase-restore');
+  });
+
   test('workbook with more than 2 sheets is rejected with a format error', async () => {
     const buf = await buildWorkbook(
       [blankVendor({ name: 'Should Not Import', status: 'active' })],


### PR DESCRIPTION
## Summary

- Combined vendor + vendor_contacts import gains a mandatory preview step via `?preview=1`. The classifier returns a two-bucket payload (`{vendors: {inserts, updates, noops, omitted}, contacts: {...}}`) without DB writes; `ImportDialog` renders the two buckets side by side.
- Dispatcher collapses to the flat 2-sheet path only. `_importLegacyCombined` (6+ sheets) and the 3–5-sheet `importSourceEntity` fallback are deleted. The exporter already emits the flat 2-sheet shape, so round-trip stays whole; > 2-sheet workbooks now return a 422 format error.
- Commit path honors the preview's promise: parent `updateWhere` is skipped when there's no diff and no archive transition, and `_upsertFlatChildren` skips the wholesale soft-delete + re-insert when the file's child set matches the DB's. A round-trip re-import no longer churns `updated_at` on existing vendor / contact / email rows. Toast wording on `VendorsPage` updated to distinguish inserts from updates (or surface "Import complete — no changes" when everything's zero).

## Test plan

- [x] \`npm run lint\`
- [x] \`npm -w apps/server test\` — 677/677 passing across 68 files
- [x] 9 new contract tests in \`tests/contract/vendorsCombinedImport.test.js\` covering preview, commit, update, archive, restore, child reconciliation, app-user provisioning, > 2-sheet rejection, and round-trip noop parity
- [x] Browser smoke: EmployeesPage single-set dialog regression (Preview → Import toggle, original Alert layout intact), VendorsPage two-bucket dialog renders + commit fires + dialog closes, zero console errors
- [x] Real export → re-import round-trip via the UI (surfaced the noop-overcount bug that this PR fixes)
- [ ] CI: Lint + Architecture Check + Copilot review