### PR TITLE
feat: simple-table import preview shim across 16 entities

### DIFF
--- a/apps/client/src/pages/AP/ApInvoicesPage.jsx
+++ b/apps/client/src/pages/AP/ApInvoicesPage.jsx
@@ -99,7 +99,9 @@ export default function ApInvoicesPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `AP Invoices: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -268,7 +270,7 @@ export default function ApInvoicesPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importDialog.isOpen} title="Import AP Invoices" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import AP Invoices" loading={importMut.isPending} onPreview={(fd) => apInvoiceApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/client/src/pages/AP/CreditMemosPage.jsx
+++ b/apps/client/src/pages/AP/CreditMemosPage.jsx
@@ -97,7 +97,9 @@ export default function CreditMemosPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Credit Memos: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -258,7 +260,7 @@ export default function CreditMemosPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importDialog.isOpen} title="Import Credit Memos" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import Credit Memos" loading={importMut.isPending} onPreview={(fd) => apCreditMemoApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/client/src/pages/AP/PaymentsPage.jsx
+++ b/apps/client/src/pages/AP/PaymentsPage.jsx
@@ -97,7 +97,9 @@ export default function PaymentsPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Payments: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -255,7 +257,7 @@ export default function PaymentsPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importDialog.isOpen} title="Import Payments" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import Payments" loading={importMut.isPending} onPreview={(fd) => paymentApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/client/src/pages/AR/ArInvoicesPage.jsx
+++ b/apps/client/src/pages/AR/ArInvoicesPage.jsx
@@ -103,7 +103,9 @@ export default function ArInvoicesPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `AR Invoices: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -282,7 +284,7 @@ export default function ArInvoicesPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importDialog.isOpen} title="Import AR Invoices" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import AR Invoices" loading={importMut.isPending} onPreview={(fd) => arInvoiceApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/client/src/pages/AR/ReceiptsPage.jsx
+++ b/apps/client/src/pages/AR/ReceiptsPage.jsx
@@ -99,7 +99,9 @@ export default function ReceiptsPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Receipts: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -257,7 +259,7 @@ export default function ReceiptsPage() {
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />
 
-      <ImportDialog open={importDialog.isOpen} title="Import Receipts" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import Receipts" loading={importMut.isPending} onPreview={(fd) => receiptApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ToastSnackbar {...snackProps} />
     </Box>

--- a/apps/client/src/pages/Accounting/ChartOfAccountsPage.jsx
+++ b/apps/client/src/pages/Accounting/ChartOfAccountsPage.jsx
@@ -128,7 +128,9 @@ export default function ChartOfAccountsPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Chart of Accounts: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -268,6 +270,7 @@ export default function ChartOfAccountsPage() {
         open={importDialog.isOpen}
         title="Import Chart of Accounts"
         loading={importMut.isPending}
+        onPreview={(fd) => chartOfAccountsApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={importDialog.close}
       />

--- a/apps/client/src/pages/Accounting/JournalEntriesPage.jsx
+++ b/apps/client/src/pages/Accounting/JournalEntriesPage.jsx
@@ -152,7 +152,9 @@ export default function JournalEntriesPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Journal Entries: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -307,6 +309,7 @@ export default function JournalEntriesPage() {
         open={importDialog.isOpen}
         title="Import Journal Entries"
         loading={importMut.isPending}
+        onPreview={(fd) => journalEntryApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={importDialog.close}
       />

--- a/apps/client/src/pages/Activities/ActivitiesPage.jsx
+++ b/apps/client/src/pages/Activities/ActivitiesPage.jsx
@@ -155,7 +155,9 @@ export default function ActivitiesPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Activities: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -308,6 +310,7 @@ export default function ActivitiesPage() {
         open={importDialog.isOpen}
         title="Import Activities"
         loading={importMut.isPending}
+        onPreview={(fd) => activityApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={importDialog.close}
       />

--- a/apps/client/src/pages/Activities/BudgetManagementPage.jsx
+++ b/apps/client/src/pages/Activities/BudgetManagementPage.jsx
@@ -142,7 +142,9 @@ export default function BudgetManagementPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Budgets: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -336,7 +338,7 @@ export default function BudgetManagementPage() {
         onCancel={versionDialog.close}
       />
 
-      <ImportDialog open={importDialog.isOpen} title="Import Budgets" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import Budgets" loading={importMut.isPending} onPreview={(fd) => budgetApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
 

--- a/apps/client/src/pages/Activities/CategoriesPage.jsx
+++ b/apps/client/src/pages/Activities/CategoriesPage.jsx
@@ -137,7 +137,9 @@ export default function CategoriesPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Categories: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -282,6 +284,7 @@ export default function CategoriesPage() {
         open={importDialog.isOpen}
         title="Import Categories"
         loading={importMut.isPending}
+        onPreview={(fd) => categoryApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={importDialog.close}
       />

--- a/apps/client/src/pages/Activities/CostTrackingPage.jsx
+++ b/apps/client/src/pages/Activities/CostTrackingPage.jsx
@@ -127,7 +127,9 @@ export default function CostTrackingPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Actual Costs: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -288,7 +290,7 @@ export default function CostTrackingPage() {
         </Box>
       </FormDialog>
 
-      <ImportDialog open={importDialog.isOpen} title="Import Actual Costs" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import Actual Costs" loading={importMut.isPending} onPreview={(fd) => actualCostApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
 

--- a/apps/client/src/pages/Activities/DeliverablesPage.jsx
+++ b/apps/client/src/pages/Activities/DeliverablesPage.jsx
@@ -144,7 +144,9 @@ export default function DeliverablesPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Deliverables: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -294,6 +296,7 @@ export default function DeliverablesPage() {
         open={importDialog.isOpen}
         title="Import Deliverables"
         loading={importMut.isPending}
+        onPreview={(fd) => deliverableApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={importDialog.close}
       />

--- a/apps/client/src/pages/BOM/CatalogPage.jsx
+++ b/apps/client/src/pages/BOM/CatalogPage.jsx
@@ -150,7 +150,9 @@ export default function CatalogPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Catalog SKUs: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -300,7 +302,7 @@ export default function CatalogPage() {
         </Box>
       </FormDialog>
 
-      <ImportDialog open={importDialog.isOpen} title="Import Catalog SKUs" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import Catalog SKUs" loading={importMut.isPending} onPreview={(fd) => catalogSkuApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />

--- a/apps/client/src/pages/Projects/ChangeOrdersPage.jsx
+++ b/apps/client/src/pages/Projects/ChangeOrdersPage.jsx
@@ -132,7 +132,9 @@ export default function ChangeOrdersPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Change Orders: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -267,7 +269,7 @@ export default function ChangeOrdersPage() {
         <TextField label="Total Amount" type="number" value={editForm.total_amount} onChange={onEditField('total_amount')} />
       </FormDialog>
 
-      <ImportDialog open={importDialog.isOpen} title="Import Change Orders" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import Change Orders" loading={importMut.isPending} onPreview={(fd) => changeOrderApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />

--- a/apps/client/src/pages/Projects/ProjectsPage.jsx
+++ b/apps/client/src/pages/Projects/ProjectsPage.jsx
@@ -136,7 +136,9 @@ export default function ProjectsPage() {
   const handleImport = useCallback(async (formData) => {
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Projects: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       toast(errMsg(err), 'error');
@@ -278,7 +280,7 @@ export default function ProjectsPage() {
         <TextField label="Notes" multiline minRows={2} value={editForm.notes} onChange={onEditField('notes')} />
       </FormDialog>
 
-      <ImportDialog open={importDialog.isOpen} title="Import Projects" loading={importMut.isPending} onSubmit={handleImport} onCancel={importDialog.close} />
+      <ImportDialog open={importDialog.isOpen} title="Import Projects" loading={importMut.isPending} onPreview={(fd) => projectApi.importXls(fd, { preview: true })} onSubmit={handleImport} onCancel={importDialog.close} />
 
       <ConfirmDialog {...archiveConfirmProps} />
       <ConfirmDialog {...restoreConfirmProps} />

--- a/apps/client/src/pages/Settings/PaymentTermsPage.jsx
+++ b/apps/client/src/pages/Settings/PaymentTermsPage.jsx
@@ -106,7 +106,9 @@ export default function PaymentTermsPage() {
       }
       importDialog.close();
       setImportErrors(null);
-      toast(`Imported ${(result?.inserted ?? 0) + (result?.updated ?? 0)} payment term(s)`);
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Payment Terms: ${ins} new, ${upd} updated`);
     } catch (err) {
       const payload = err?.payload;
       if (payload?.errors) {
@@ -339,6 +341,7 @@ export default function PaymentTermsPage() {
         title="Import Payment Terms"
         loading={importMut.isPending}
         errors={importErrors}
+        onPreview={(fd) => paymentTermApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />

--- a/apps/client/src/services/accountingApi.js
+++ b/apps/client/src/services/accountingApi.js
@@ -23,7 +23,8 @@ export const chartOfAccountsApi = {
   update: (filterParams, changes) => client.put(`${COA}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${COA}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${COA}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${COA}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${COA}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${COA}/export-xls`, body, { responseType: 'blob' }),
 };
 
@@ -39,7 +40,8 @@ export const journalEntryApi = {
   restore: (filterParams) => client.patch(`${JE}/restore${qs(filterParams)}`, {}),
   post: (body) => client.post(`${JE}/post`, body),
   reverse: (body) => client.post(`${JE}/reverse`, body),
-  importXls: (formData) => client.post(`${JE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${JE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${JE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/activityApi.js
+++ b/apps/client/src/services/activityApi.js
@@ -23,7 +23,8 @@ export const activityApi = {
   update: (filterParams, changes) => client.put(`${BASE}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/actualCostApi.js
+++ b/apps/client/src/services/actualCostApi.js
@@ -23,7 +23,8 @@ export const actualCostApi = {
   update: (filterParams, changes) => client.put(`${BASE}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/apApi.js
+++ b/apps/client/src/services/apApi.js
@@ -22,7 +22,8 @@ export const apInvoiceApi = {
   update: (filterParams, changes) => client.put(`${INVOICES}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${INVOICES}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${INVOICES}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${INVOICES}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${INVOICES}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${INVOICES}/export-xls`, body, { responseType: 'blob' }),
 };
 
@@ -48,7 +49,8 @@ export const paymentApi = {
   update: (filterParams, changes) => client.put(`${PAYMENTS}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${PAYMENTS}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${PAYMENTS}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${PAYMENTS}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${PAYMENTS}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${PAYMENTS}/export-xls`, body, { responseType: 'blob' }),
 };
 
@@ -62,6 +64,7 @@ export const apCreditMemoApi = {
   update: (filterParams, changes) => client.put(`${CREDITS}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${CREDITS}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${CREDITS}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${CREDITS}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${CREDITS}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${CREDITS}/export-xls`, body, { responseType: 'blob' }),
 };

--- a/apps/client/src/services/arApi.js
+++ b/apps/client/src/services/arApi.js
@@ -26,7 +26,8 @@ export const arInvoiceApi = {
   archive: (filterParams) => client.del(`${INVOICES}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${INVOICES}/restore${qs(filterParams)}`, {}),
   approve: (filterParams) => client.put(`${INVOICES}/approve${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${INVOICES}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${INVOICES}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${INVOICES}/export-xls`, body, { responseType: 'blob' }),
 };
 
@@ -52,6 +53,7 @@ export const receiptApi = {
   update: (filterParams, changes) => client.put(`${RECEIPTS}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${RECEIPTS}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${RECEIPTS}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${RECEIPTS}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${RECEIPTS}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${RECEIPTS}/export-xls`, body, { responseType: 'blob' }),
 };

--- a/apps/client/src/services/bomApi.js
+++ b/apps/client/src/services/bomApi.js
@@ -23,7 +23,8 @@ export const catalogSkuApi = {
   archive: (filterParams) => client.del(`${CATALOG}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${CATALOG}/restore${qs(filterParams)}`, {}),
   refreshEmbeddings: () => client.post(`${CATALOG}/refresh-embeddings`, {}),
-  importXls: (formData) => client.post(`${CATALOG}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${CATALOG}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${CATALOG}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/budgetApi.js
+++ b/apps/client/src/services/budgetApi.js
@@ -24,7 +24,8 @@ export const budgetApi = {
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
   createNewVersion: (body) => client.post(`${BASE}/new-version`, body),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/categoryApi.js
+++ b/apps/client/src/services/categoryApi.js
@@ -23,7 +23,8 @@ export const categoryApi = {
   update: (filterParams, changes) => client.put(`${BASE}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/changeOrderApi.js
+++ b/apps/client/src/services/changeOrderApi.js
@@ -23,7 +23,8 @@ export const changeOrderApi = {
   update: (filterParams, changes) => client.put(`${BASE}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/deliverableApi.js
+++ b/apps/client/src/services/deliverableApi.js
@@ -23,7 +23,8 @@ export const deliverableApi = {
   update: (filterParams, changes) => client.put(`${BASE}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/paymentTermApi.js
+++ b/apps/client/src/services/paymentTermApi.js
@@ -23,7 +23,8 @@ export const paymentTermApi = {
   update: (filterParams, changes) => client.put(`${BASE}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/client/src/services/projectApi.js
+++ b/apps/client/src/services/projectApi.js
@@ -23,7 +23,8 @@ export const projectApi = {
   update: (filterParams, changes) => client.put(`${BASE}/update${qs(filterParams)}`, changes),
   archive: (filterParams) => client.del(`${BASE}/archive${qs(filterParams)}`, {}),
   restore: (filterParams) => client.patch(`${BASE}/restore${qs(filterParams)}`, {}),
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 };
 

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -832,20 +832,34 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     tenantId = tenantRec?.id ?? null;
   }
 
+  // When the schema has its own `status` column (e.g. journal_entries
+  // 'posted', ap_invoices 'paid', projects 'in_progress'), the spreadsheet's
+  // status cell is a real business value that must flow through to the DB
+  // — destructuring it out as synthetic archive metadata would silently
+  // corrupt workflow state. Only entities WITHOUT a real status column
+  // (PaymentTerms, ChartOfAccounts, etc.) treat the column as the
+  // export-side archived/active marker.
+  const hasStatusColumn = (model._schema?.columns || []).some((c) => c.name === 'status');
+
   // Transform every row up front so both preview and commit see the same
   // post-coercion shape. Carry `_rowNum` + the row's intended archive state
   // alongside the merged row so we can attribute errors and detect archive
   // transitions later.
   const prepared = [];
   for (const raw of rows) {
-    const { _rowNum, status, ...row } = raw;
-    coerceChildRow(row, model);
+    const { _rowNum, ...rest } = raw;
+    let row = rest;
     let archiveTarget; // undefined → leave deactivated_at alone
-    if (typeof status === 'string') {
-      const s = status.toLowerCase().trim();
-      if (s === 'archived') archiveTarget = true;
-      else if (s === 'active') archiveTarget = false;
+    if (!hasStatusColumn) {
+      const { status, ...withoutStatus } = row;
+      row = withoutStatus;
+      if (typeof status === 'string') {
+        const s = status.toLowerCase().trim();
+        if (s === 'archived') archiveTarget = true;
+        else if (s === 'active') archiveTarget = false;
+      }
     }
+    coerceChildRow(row, model);
     const merged = callbackFn ? await callbackFn(row) : row;
     delete merged.tenant_code;
     if (tenantId) merged.tenant_id = tenantId;
@@ -899,6 +913,32 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     }
   }
 
+  // Intra-file duplicate natural-key detection. Two rows with the same
+  // natural-key value would both classify as inserts (or one insert + one
+  // update against the same DB row); commit would fire the first insert
+  // then 422 on the second with a unique-constraint error. Catch it here
+  // so preview surfaces the duplicate up front instead of green-lighting
+  // a commit that will partially fail.
+  const validationErrors = [];
+  if (naturalKey) {
+    const seenAt = new Map(); // value -> first rowNum
+    for (const p of prepared) {
+      const nkVal = p.merged[naturalKey];
+      if (nkVal == null || nkVal === '') continue;
+      if (seenAt.has(nkVal)) {
+        validationErrors.push({
+          sheet: sheetName,
+          row: p.rowNum,
+          column: naturalKey,
+          value: nkVal,
+          message: `Duplicate ${naturalKey} '${nkVal}' in file (also at row ${seenAt.get(nkVal)})`,
+        });
+      } else {
+        seenAt.set(nkVal, p.rowNum);
+      }
+    }
+  }
+
   // Classification pass. Two lookups per row: UUID first (authoritative when
   // present), then natural key as a fallback. Rows that match by natural key
   // have their merged.id rewritten to the existing UUID so the commit path
@@ -936,8 +976,12 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
   }
 
   if (previewOnly) {
-    return { preview: true, inserts, updates, noops, omitted: 0, errors: [] };
+    return { preview: true, inserts, updates, noops, omitted: 0, errors: validationErrors };
   }
+
+  // Validation errors are blocking — surface them before any writes so the
+  // commit doesn't half-apply a workbook the preview already flagged.
+  if (validationErrors.length) return { errors: validationErrors };
 
   // Commit pass. Per-row try/catch so a single bad row doesn't abort the import.
   const errors = [];
@@ -947,7 +991,21 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     if (c.action === 'noop') continue;
     try {
       if (c.action === 'update') {
-        const { id, ...changes } = c.merged;
+        // Strip immutable + audit-create columns so an import never overwrites
+        // a row's `created_by` / `created_at` (BaseController.importXls injects
+        // a fresh `created_by` on every row, and the exported workbook may
+        // carry the original audit fields too — neither should be re-written
+        // on an update). `updated_at` is left to pg-schemata's writer to
+        // manage; `updated_by` flows from the ALS audit resolver, not the row.
+        const {
+          id,
+          tenant_id: _tid,
+          created_by: _cb,
+          created_at: _ca,
+          updated_at: _ua,
+          updated_by: _ub,
+          ...changes
+        } = c.merged;
         await model.updateWhere([{ id }], changes, { includeDeactivated: true });
         updated++;
       } else {
@@ -2779,12 +2837,28 @@ function _diffParent(transformed, existing, { caseSensitive = false } = {}) {
  * empty-string and trims strings, but compares strings byte-for-byte so
  * case-only edits surface as real diffs. Used by callers that opt into
  * `{ caseSensitive: true }` on `diffParent`.
+ *
+ * Also bridges pg-promise's numeric-as-string round-trip: pg returns
+ * `numeric(p,s)` / `bigint` columns as strings, while spreadsheet cells
+ * arrive as JS numbers. When one side is a number and the other a string
+ * that parses cleanly to the same value, treat as equal — otherwise a
+ * round-trip of `total_amount`, `contract_amount`, etc. would classify
+ * every existing row as an update.
  * @private
  */
 function _strictEq(a, b) {
   const na = a == null || a === '' ? null : typeof a === 'string' ? a.trim() : a;
   const nb = b == null || b === '' ? null : typeof b === 'string' ? b.trim() : b;
-  return na === nb;
+  if (na === nb) return true;
+  if (na === null || nb === null) return false;
+  const aIsNum = typeof na === 'number';
+  const bIsNum = typeof nb === 'number';
+  if ((aIsNum && typeof nb === 'string') || (bIsNum && typeof na === 'string')) {
+    const an = aIsNum ? na : Number(na);
+    const bn = bIsNum ? nb : Number(nb);
+    if (!Number.isNaN(an) && !Number.isNaN(bn)) return an === bn;
+  }
+  return false;
 }
 
 /**

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -239,10 +239,10 @@ export function coerceChildRow(row, model) {
     }
     // Blank spreadsheet cells arrive as `''`. For non-text columns
     // (date / uuid / numeric / boolean / timestamp / etc.) pg rejects `''`
-    // as a literal — coerce to null and let the booleans branch above
-    // backfill the schema default on the next pass. Text-shaped columns
-    // (varchar / char / text) keep `''` to preserve the empty-vs-null
-    // distinction some callers rely on.
+    // as a literal — coerce blanks here: booleans land on the schema
+    // default (mirrors the null-branch above), every other non-text type
+    // lands on null. Text-shaped columns (varchar / char / text) keep `''`
+    // so callers that distinguish empty-string from null still can.
     if (val === '' && !/^(varchar|char|text)/i.test(col.type)) {
       row[col.name] = col.type === 'boolean' ? (col.default ?? false) : null;
       continue;
@@ -794,13 +794,25 @@ export async function exportSourceEntity(model, filePath, where, joinType, optio
  * Activities, Categories, Projects, ChangeOrders, etc.):
  *
  *   - Sheet 0 only; one row per record.
- *   - Row classification is a two-stage lookup: (1) UUID `id` matched against
- *     the DB, then (2) the entity's single-column natural unique key (e.g.
- *     `label` for PaymentTerms, `code` for ChartOfAccounts) as a fallback.
- *     Either match resolves to an update path against the existing row;
- *     rows that miss both lookups insert. So a workbook with non-UUID ids
- *     (hand-edited, or ghost UUIDs from a different env) still round-trips
- *     idempotently by natural key.
+ *   - Row classification is a two-stage lookup: (1) UUID `id` matched
+ *     against the DB, then (2) the entity's single-column natural unique
+ *     key as a fallback when the schema declares a single-column
+ *     `constraints.unique` entry — e.g. PaymentTerms (`label`),
+ *     ChartOfAccounts (`code`), CatalogSkus (`catalog_sku`), Categories
+ *     (`code`), Projects (`project_code`). Either lookup match resolves
+ *     to an update path against the existing row; rows that miss both
+ *     lookups insert.
+ *
+ *     **Coverage caveat:** transactional entities without a single-column
+ *     unique constraint (JournalEntries, ApInvoices, ArInvoices, Payments,
+ *     Receipts, ApCreditMemos, Deliverables, Budgets, ActualCosts,
+ *     ChangeOrders) have no natural key to fall back to. For those,
+ *     idempotent round-trip works only via a stable UUID `id` in the
+ *     workbook — a ghost UUID (or a missing/blank id) classifies as an
+ *     insert, which then succeeds (no unique constraint to conflict with)
+ *     and produces a duplicate row. Either rely on the exporter's real
+ *     UUIDs round-tripping, or add a unique constraint to the schema
+ *     before treating those imports as idempotent.
  *   - For matched rows, the writer diffs the transformed row against the
  *     existing DB row via `diffParent(..., { caseSensitive: true })`. No
  *     diff and no archive transition → noop (no write). Otherwise → update,
@@ -2924,6 +2936,10 @@ function _arrayEq(a, b) {
  *   - `updated_at`, `updated_by`   — managed separately by the writer; including
  *     them in the diff would defeat NO-OP detection since the importing user
  *     normally differs from the prior `updated_by`.
+ *   - `deactivated_at`             — archive transitions are driven by the
+ *     importer's explicit `status` parse, not by diffing the timestamp.
+ *     Including it would refresh the original archive timestamp on every
+ *     re-import of an already-archived row.
  * @private
  */
 function _diffParent(transformed, existing, { caseSensitive = false } = {}) {

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -1026,57 +1026,87 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
   // commit doesn't half-apply a workbook the preview already flagged.
   if (validationErrors.length) return { errors: validationErrors };
 
-  // Commit pass. Per-row try/catch collects errors without aborting on the
-  // first failure, so a response can surface multiple issues in one pass.
-  //
-  // Atomicity caveat: pg-schemata's `insert` and `updateWhere` use
-  // `this.db.*` directly rather than honoring `this.tx`, so wrapping this
-  // loop in `db.tx` would be a no-op — writes from earlier rows would
-  // already be committed by the time a later row hits a constraint
-  // violation. Pre-validation (intra-file duplicate-key check above) is
-  // the primary atomicity guard for now. True atomic commit would require
-  // either patching pg-schemata or rewriting this pass against raw
-  // `t.result(...)` queries; tracked as a follow-up.
-  const errors = [];
-  let inserted = 0;
-  let updated = 0;
+  // Build the insert + update batches. We compute the actual write payload
+  // here so the tx callback below is purely "submit + roll back on error".
+  const insertRows = [];
+  const updateRows = [];
   for (const c of classified) {
     if (c.action === 'noop') continue;
-    try {
-      if (c.action === 'update') {
-        // Write only the computed diff. Blank cells in the workbook that
-        // match the existing DB value never appear in the diff, so they
-        // can't clobber non-null DB columns the user didn't intend to
-        // touch. Apply the archive transition explicitly when the row's
-        // status flipped.
-        const changes = { ...c.diff };
-        const wasArchived = !!c.existing.deactivated_at;
-        const willBeArchived = c.archiveTarget === undefined ? wasArchived : !!c.archiveTarget;
-        if (willBeArchived !== wasArchived) {
-          changes.deactivated_at = willBeArchived ? new Date() : null;
-        }
-        if (Object.keys(changes).length === 0) continue; // safety: nothing to write
-        await model.updateWhere([{ id: c.existing.id }], changes, { includeDeactivated: true });
-        updated++;
-      } else {
-        const insertRow = { ...c.merged };
-        delete insertRow.id;
-        if (c.archiveTarget === true) insertRow.deactivated_at = new Date();
-        await model.insert(insertRow);
-        inserted++;
+    if (c.action === 'update') {
+      // Write only the computed diff. Blank cells in the workbook that
+      // match the existing DB value never appear in the diff, so they
+      // can't clobber non-null DB columns the user didn't intend to
+      // touch. Apply the archive transition explicitly when the row's
+      // status flipped.
+      const changes = { ...c.diff };
+      const wasArchived = !!c.existing.deactivated_at;
+      const willBeArchived = c.archiveTarget === undefined ? wasArchived : !!c.archiveTarget;
+      if (willBeArchived !== wasArchived) {
+        changes.deactivated_at = willBeArchived ? new Date() : null;
       }
-    } catch (err) {
-      const parsed = parseDbImportError(err);
-      if (parsed) {
-        for (const e of parsed) pushIssue(errors, { ...e, sheet: sheetName, row: c.rowNum });
-      } else {
-        pushIssue(errors, { sheet: sheetName, row: c.rowNum, column: null, value: null, message: err.message });
-      }
+      if (Object.keys(changes).length === 0) continue; // safety: nothing to write
+      updateRows.push({ id: c.existing.id, ...changes });
+    } else {
+      const insertRow = { ...c.merged };
+      delete insertRow.id;
+      if (c.archiveTarget === true) insertRow.deactivated_at = new Date();
+      insertRows.push(insertRow);
     }
   }
 
+  if (insertRows.length === 0 && updateRows.length === 0) {
+    return { inserted: 0, updated: 0 };
+  }
+
+  // Build per-row UPDATE statements via pg-schemata's column-set helpers
+  // and run them through `t.batch` inside the outer tx. Why not use the
+  // model's `bulkUpdate`? It hardcodes `AND deactivated_at IS NULL` in the
+  // WHERE clause when softDelete is enabled, so it would silently no-op
+  // on already-archived rows — breaking the restore (archived → active)
+  // path entirely. Mirroring its internals here lets us drop the softCheck.
+  const updateQueries = [];
+  for (const row of updateRows) {
+    const { id, ...changes } = row;
+    if (model._auditEnabled?.() && !('updated_by' in changes) && model._resolveAuditActor) {
+      changes.updated_by = model._resolveAuditActor();
+    }
+    const safeUpdates = model.sanitizeDto(changes, { includeImmutable: false });
+    if (Object.keys(safeUpdates).length === 0) continue;
+    const updateCs = new model.pgp.helpers.ColumnSet(Object.keys(safeUpdates), {
+      table: { table: model._schema.table, schema: model._schema.dbSchema },
+    });
+    const setClause = model.pgp.helpers.update(safeUpdates, updateCs);
+    const where = model.pgp.as.format('WHERE id = $1', [id]);
+    updateQueries.push(`${setClause} ${where}`);
+  }
+
+  // Atomic commit. `bulkInsert` honors `this.tx`; the raw update queries
+  // run through `t.batch`. A constraint / FK / check violation on any row
+  // aborts the tx and rolls back every earlier write in the same import.
+  // `model.tx` always resets in `finally` so a thrown error can't leak
+  // the tx onto the shared model instance.
+  const errors = [];
+  try {
+    await model.db.tx(async (t) => {
+      model.tx = t;
+      if (insertRows.length) await model.bulkInsert(insertRows);
+      if (updateQueries.length) {
+        await t.batch(updateQueries.map((q) => t.result(q, [], (r) => r.rowCount)));
+      }
+    });
+  } catch (err) {
+    const parsed = parseDbImportError(err);
+    if (parsed) {
+      for (const e of parsed) pushIssue(errors, { ...e, sheet: sheetName });
+    } else {
+      pushIssue(errors, { sheet: sheetName, row: null, column: null, value: null, message: err.message });
+    }
+  } finally {
+    model.tx = null;
+  }
+
   if (errors.length) return { errors };
-  return { inserted, updated };
+  return { inserted: insertRows.length, updated: updateQueries.length };
 }
 
 /**

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -237,6 +237,16 @@ export function coerceChildRow(row, model) {
       if (col.type === 'boolean') row[col.name] = col.default ?? false;
       continue;
     }
+    // Blank spreadsheet cells arrive as `''`. For non-text columns
+    // (date / uuid / numeric / boolean / timestamp / etc.) pg rejects `''`
+    // as a literal — coerce to null and let the booleans branch above
+    // backfill the schema default on the next pass. Text-shaped columns
+    // (varchar / char / text) keep `''` to preserve the empty-vs-null
+    // distinction some callers rely on.
+    if (val === '' && !/^(varchar|char|text)/i.test(col.type)) {
+      row[col.name] = col.type === 'boolean' ? (col.default ?? false) : null;
+      continue;
+    }
     // varchar/char/text columns: coerce numbers to strings
     if (/^(varchar|char|text)/i.test(col.type) && typeof val === 'number') {
       row[col.name] = String(val);
@@ -844,12 +854,15 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
   // Transform every row up front so both preview and commit see the same
   // post-coercion shape. Carry `_rowNum` + the row's intended archive state
   // alongside the merged row so we can attribute errors and detect archive
-  // transitions later.
+  // transitions later. NB: `deactivated_at` is NOT set in this loop — it's
+  // applied per-row at commit time, only when an actual archive transition
+  // is detected against the existing DB row. That preserves the original
+  // archive timestamp on a re-import of an already-archived row.
   const prepared = [];
   for (const raw of rows) {
     const { _rowNum, ...rest } = raw;
     let row = rest;
-    let archiveTarget; // undefined → leave deactivated_at alone
+    let archiveTarget; // undefined → no archive intent expressed in the file
     if (!hasStatusColumn) {
       const { status, ...withoutStatus } = row;
       row = withoutStatus;
@@ -863,8 +876,13 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     const merged = callbackFn ? await callbackFn(row) : row;
     delete merged.tenant_code;
     if (tenantId) merged.tenant_id = tenantId;
-    if (archiveTarget === true) merged.deactivated_at = new Date();
-    else if (archiveTarget === false) merged.deactivated_at = null;
+    // Drop the stale-on-update audit columns now so they never participate
+    // in the diff (and never land in the insert/update DTO either).
+    delete merged.created_at;
+    delete merged.updated_at;
+    delete merged.updated_by;
+    // `deactivated_at` is decided per-row at commit time.
+    delete merged.deactivated_at;
     prepared.push({ rowNum: _rowNum || null, merged, archiveTarget });
   }
 
@@ -913,12 +931,16 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     }
   }
 
-  // Intra-file duplicate natural-key detection. Two rows with the same
-  // natural-key value would both classify as inserts (or one insert + one
-  // update against the same DB row); commit would fire the first insert
-  // then 422 on the second with a unique-constraint error. Catch it here
-  // so preview surfaces the duplicate up front instead of green-lighting
-  // a commit that will partially fail.
+  // Intra-file duplicate detection — natural-key AND UUID. Two rows with
+  // the same key (either kind) are blocking errors: the commit would either
+  // 422 on a unique-constraint violation (natural-key duplicate going to
+  // insert) or silently apply two updates against the same DB row with the
+  // later row winning (UUID duplicate). Surfacing them in preview lets the
+  // user fix the workbook before any writes.
+  //
+  // Errors flow through `pushIssue` so a workbook with thousands of
+  // duplicates can't build an unbounded error array (cap at MAX_IMPORT_ISSUES
+  // with a single sentinel entry once exceeded).
   const validationErrors = [];
   if (naturalKey) {
     const seenAt = new Map(); // value -> first rowNum
@@ -926,7 +948,7 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
       const nkVal = p.merged[naturalKey];
       if (nkVal == null || nkVal === '') continue;
       if (seenAt.has(nkVal)) {
-        validationErrors.push({
+        pushIssue(validationErrors, {
           sheet: sheetName,
           row: p.rowNum,
           column: naturalKey,
@@ -938,11 +960,32 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
       }
     }
   }
+  {
+    const seenIdAt = new Map(); // UUID id -> first rowNum
+    for (const p of prepared) {
+      const idVal = p.merged.id;
+      if (!isUuid(idVal)) continue;
+      if (seenIdAt.has(idVal)) {
+        pushIssue(validationErrors, {
+          sheet: sheetName,
+          row: p.rowNum,
+          column: 'id',
+          value: idVal,
+          message: `Duplicate id '${idVal}' in file (also at row ${seenIdAt.get(idVal)})`,
+        });
+      } else {
+        seenIdAt.set(idVal, p.rowNum);
+      }
+    }
+  }
 
   // Classification pass. Two lookups per row: UUID first (authoritative when
   // present), then natural key as a fallback. Rows that match by natural key
   // have their merged.id rewritten to the existing UUID so the commit path
-  // uses updateWhere instead of insert.
+  // uses updateWhere instead of insert. We also capture `diff` and `existing`
+  // on each classified entry so commit can write only the changed columns
+  // (instead of every imported cell, which would clobber unrelated DB values
+  // with blanks).
   let inserts = 0;
   let updates = 0;
   let noops = 0;
@@ -959,7 +1002,7 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     }
     if (!existing) {
       inserts += 1;
-      classified.push({ ...p, action: 'insert' });
+      classified.push({ ...p, existing: null, diff: null, action: 'insert' });
       continue;
     }
     const wasArchived = !!existing.deactivated_at;
@@ -968,10 +1011,10 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     const diff = diffParent(p.merged, existing, { caseSensitive: true });
     if (Object.keys(diff).length > 0 || archiveChanged) {
       updates += 1;
-      classified.push({ ...p, action: 'update' });
+      classified.push({ ...p, existing, diff, action: 'update' });
     } else {
       noops += 1;
-      classified.push({ ...p, action: 'noop' });
+      classified.push({ ...p, existing, diff, action: 'noop' });
     }
   }
 
@@ -983,7 +1026,17 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
   // commit doesn't half-apply a workbook the preview already flagged.
   if (validationErrors.length) return { errors: validationErrors };
 
-  // Commit pass. Per-row try/catch so a single bad row doesn't abort the import.
+  // Commit pass. Per-row try/catch collects errors without aborting on the
+  // first failure, so a response can surface multiple issues in one pass.
+  //
+  // Atomicity caveat: pg-schemata's `insert` and `updateWhere` use
+  // `this.db.*` directly rather than honoring `this.tx`, so wrapping this
+  // loop in `db.tx` would be a no-op — writes from earlier rows would
+  // already be committed by the time a later row hits a constraint
+  // violation. Pre-validation (intra-file duplicate-key check above) is
+  // the primary atomicity guard for now. True atomic commit would require
+  // either patching pg-schemata or rewriting this pass against raw
+  // `t.result(...)` queries; tracked as a follow-up.
   const errors = [];
   let inserted = 0;
   let updated = 0;
@@ -991,35 +1044,33 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     if (c.action === 'noop') continue;
     try {
       if (c.action === 'update') {
-        // Strip immutable + audit-create columns so an import never overwrites
-        // a row's `created_by` / `created_at` (BaseController.importXls injects
-        // a fresh `created_by` on every row, and the exported workbook may
-        // carry the original audit fields too — neither should be re-written
-        // on an update). `updated_at` is left to pg-schemata's writer to
-        // manage; `updated_by` flows from the ALS audit resolver, not the row.
-        const {
-          id,
-          tenant_id: _tid,
-          created_by: _cb,
-          created_at: _ca,
-          updated_at: _ua,
-          updated_by: _ub,
-          ...changes
-        } = c.merged;
-        await model.updateWhere([{ id }], changes, { includeDeactivated: true });
+        // Write only the computed diff. Blank cells in the workbook that
+        // match the existing DB value never appear in the diff, so they
+        // can't clobber non-null DB columns the user didn't intend to
+        // touch. Apply the archive transition explicitly when the row's
+        // status flipped.
+        const changes = { ...c.diff };
+        const wasArchived = !!c.existing.deactivated_at;
+        const willBeArchived = c.archiveTarget === undefined ? wasArchived : !!c.archiveTarget;
+        if (willBeArchived !== wasArchived) {
+          changes.deactivated_at = willBeArchived ? new Date() : null;
+        }
+        if (Object.keys(changes).length === 0) continue; // safety: nothing to write
+        await model.updateWhere([{ id: c.existing.id }], changes, { includeDeactivated: true });
         updated++;
       } else {
         const insertRow = { ...c.merged };
         delete insertRow.id;
+        if (c.archiveTarget === true) insertRow.deactivated_at = new Date();
         await model.insert(insertRow);
         inserted++;
       }
     } catch (err) {
       const parsed = parseDbImportError(err);
       if (parsed) {
-        for (const e of parsed) errors.push({ ...e, sheet: sheetName, row: c.rowNum });
+        for (const e of parsed) pushIssue(errors, { ...e, sheet: sheetName, row: c.rowNum });
       } else {
-        errors.push({ sheet: sheetName, row: c.rowNum, column: null, value: null, message: err.message });
+        pushIssue(errors, { sheet: sheetName, row: c.rowNum, column: null, value: null, message: err.message });
       }
     }
   }
@@ -2817,7 +2868,11 @@ function _arrayEq(a, b) {
  * @private
  */
 function _diffParent(transformed, existing, { caseSensitive = false } = {}) {
-  const SKIP = new Set(['id', 'tenant_id', 'created_at', 'created_by', 'updated_at', 'updated_by']);
+  // `deactivated_at` is treated as audit metadata too: archive transitions
+  // are driven by the importer's explicit `status` parse, not by diffing
+  // the timestamp. Including it in the diff would refresh the original
+  // archive timestamp on every re-import of an already-archived row.
+  const SKIP = new Set(['id', 'tenant_id', 'created_at', 'created_by', 'updated_at', 'updated_by', 'deactivated_at']);
   const changes = {};
   const eq = caseSensitive ? _strictEq : _normEq;
   for (const [col, val] of Object.entries(transformed)) {

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -794,12 +794,22 @@ export async function exportSourceEntity(model, filePath, where, joinType, optio
  * Activities, Categories, Projects, ChangeOrders, etc.):
  *
  *   - Sheet 0 only; one row per record.
- *   - Rows with a valid UUID in `id` are looked up; rows with no id are inserted.
- *   - For UUID rows, the writer compares the transformed row against the
- *     existing DB row with `diffParent(..., { caseSensitive: true })`. No
- *     diff and no archive transition → noop (no write). Otherwise → update.
- *   - `status` column (string) parses to `deactivated_at`: 'archived' soft-
- *     deletes, 'active' restores, anything else is ignored.
+ *   - Row classification is a two-stage lookup: (1) UUID `id` matched against
+ *     the DB, then (2) the entity's single-column natural unique key (e.g.
+ *     `label` for PaymentTerms, `code` for ChartOfAccounts) as a fallback.
+ *     Either match resolves to an update path against the existing row;
+ *     rows that miss both lookups insert. So a workbook with non-UUID ids
+ *     (hand-edited, or ghost UUIDs from a different env) still round-trips
+ *     idempotently by natural key.
+ *   - For matched rows, the writer diffs the transformed row against the
+ *     existing DB row via `diffParent(..., { caseSensitive: true })`. No
+ *     diff and no archive transition → noop (no write). Otherwise → update,
+ *     writing only the diff (plus an explicit archive transition) so blank
+ *     cells can't clobber unrelated DB values.
+ *   - `status` column is the synthetic archive marker ONLY when the schema
+ *     doesn't already have its own `status` column. For entities like
+ *     JournalEntries / ApInvoices / Projects (real workflow status), the
+ *     spreadsheet value flows through to the DB unchanged.
  *   - `tenant_id` is resolved from the callback's `tenant_code` once per call
  *     (matches `PaymentTerms`'s pattern). `tenant_code` is stripped from the
  *     row before write.
@@ -851,6 +861,14 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
   // export-side archived/active marker.
   const hasStatusColumn = (model._schema?.columns || []).some((c) => c.name === 'status');
 
+  // Build a set of valid schema column names to filter `merged` against.
+  // Spreadsheet headers from newer exports, user-added notes columns,
+  // or columns from a different system would otherwise live in `merged`,
+  // get compared against `existing[unknownCol]=undefined`, classify
+  // unchanged rows as updates, and then get silently dropped by
+  // `sanitizeDto` at write time (preview/commit divergence).
+  const schemaColumns = new Set((model._schema?.columns || []).map((c) => c.name));
+
   // Transform every row up front so both preview and commit see the same
   // post-coercion shape. Carry `_rowNum` + the row's intended archive state
   // alongside the merged row so we can attribute errors and detect archive
@@ -883,6 +901,14 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     delete merged.updated_by;
     // `deactivated_at` is decided per-row at commit time.
     delete merged.deactivated_at;
+    // Drop any spreadsheet column the schema doesn't know about. Keeps
+    // preview classification aligned with what `sanitizeDto` will actually
+    // persist on commit.
+    if (schemaColumns.size) {
+      for (const k of Object.keys(merged)) {
+        if (!schemaColumns.has(k)) delete merged[k];
+      }
+    }
     prepared.push({ rowNum: _rowNum || null, merged, archiveTarget });
   }
 
@@ -1072,6 +1098,9 @@ export async function importSimpleTable(model, filePath, callbackFn, { previewOn
     }
     const safeUpdates = model.sanitizeDto(changes, { includeImmutable: false });
     if (Object.keys(safeUpdates).length === 0) continue;
+    // Mirror what every other update path does: bump `updated_at` so the
+    // audit timestamp stays accurate for imported edits.
+    if (model._auditEnabled?.()) safeUpdates.updated_at = new Date();
     const updateCs = new model.pgp.helpers.ColumnSet(Object.keys(safeUpdates), {
       table: { table: model._schema.table, schema: model._schema.dbSchema },
     });
@@ -2936,6 +2965,19 @@ function _strictEq(a, b) {
   const nb = b == null || b === '' ? null : typeof b === 'string' ? b.trim() : b;
   if (na === nb) return true;
   if (na === null || nb === null) return false;
+
+  // Date equivalence: pg returns date/timestamp columns as Date objects,
+  // tablsx may hand back a fresh Date for the same cell, and spreadsheet
+  // authors sometimes type ISO strings. Compare on epoch ms so any of
+  // those combinations round-trip cleanly without classifying as updates.
+  const aDate = na instanceof Date ? na : null;
+  const bDate = nb instanceof Date ? nb : null;
+  if (aDate || bDate) {
+    const at = aDate ? aDate.getTime() : (typeof na === 'string' ? new Date(na).getTime() : NaN);
+    const bt = bDate ? bDate.getTime() : (typeof nb === 'string' ? new Date(nb).getTime() : NaN);
+    if (!Number.isNaN(at) && !Number.isNaN(bt) && at === bt) return true;
+  }
+
   const aIsNum = typeof na === 'number';
   const bIsNum = typeof nb === 'number';
   if ((aIsNum && typeof nb === 'string') || (bIsNum && typeof na === 'string')) {

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -775,6 +775,202 @@ export async function exportSourceEntity(model, filePath, where, joinType, optio
 }
 
 /**
+ * Import a single-sheet "simple" table (no children, no sources record, no
+ * slot-keyed reconciliation) with idempotent upsert-by-UUID semantics and
+ * optional preview classification.
+ *
+ * Behavior shared across every entity in the simple-table family
+ * (PaymentTerms, ChartOfAccounts, JournalEntries, CatalogSkus, ApInvoices,
+ * Activities, Categories, Projects, ChangeOrders, etc.):
+ *
+ *   - Sheet 0 only; one row per record.
+ *   - Rows with a valid UUID in `id` are looked up; rows with no id are inserted.
+ *   - For UUID rows, the writer compares the transformed row against the
+ *     existing DB row with `diffParent(..., { caseSensitive: true })`. No
+ *     diff and no archive transition → noop (no write). Otherwise → update.
+ *   - `status` column (string) parses to `deactivated_at`: 'archived' soft-
+ *     deletes, 'active' restores, anything else is ignored.
+ *   - `tenant_id` is resolved from the callback's `tenant_code` once per call
+ *     (matches `PaymentTerms`'s pattern). `tenant_code` is stripped from the
+ *     row before write.
+ *   - On `previewOnly`, no DB writes happen; returns classification counts
+ *     `{ preview, inserts, updates, noops, omitted: 0, errors }` shaped to
+ *     match the flat single-entity payload that `ImportDialog` already renders.
+ *   - On commit, returns `{ inserted, updated, errors? }`; per-row DB errors
+ *     are surfaced via `parseDbImportError` with sheet/row context.
+ *
+ * @param {Object}   model       pg-schemata TableModel instance (this).
+ * @param {string}   filePath    Input file path.
+ * @param {Function} callbackFn  Row transformer supplied by the controller
+ *                               (adds `tenant_code`, `created_by`, `updated_by`).
+ * @param {Object}   [opts]
+ * @param {boolean}  [opts.previewOnly=false]  Skip writes; return counts.
+ * @returns {Promise<Object>}    Preview or commit payload (see above).
+ */
+export async function importSimpleTable(model, filePath, callbackFn, { previewOnly = false } = {}) {
+  const { WorkbookReader } = await import('@nap-sft/tablsx');
+  const buffer = readFileSync(filePath);
+  const reader = WorkbookReader.fromBuffer(buffer);
+  const rows = parseSheet(reader, 0);
+  const sheetName = reader.sheetNames?.[0] || (model._schema?.table || 'Sheet1');
+
+  if (!rows.length) {
+    return previewOnly
+      ? { preview: true, inserts: 0, updates: 0, noops: 0, omitted: 0, errors: [] }
+      : { inserted: 0, updated: 0 };
+  }
+
+  // Resolve tenant_id from the callback's sample row (the controller injects
+  // tenant_code on every row). One DB lookup per import.
+  let tenantId = null;
+  const sampleRow = callbackFn ? await callbackFn({}) : {};
+  if (sampleRow.tenant_code) {
+    const tenantRec = await model.db.oneOrNone(
+      'SELECT id FROM admin.tenants WHERE tenant_code = $1 AND deactivated_at IS NULL',
+      [sampleRow.tenant_code.toUpperCase()],
+    );
+    tenantId = tenantRec?.id ?? null;
+  }
+
+  // Transform every row up front so both preview and commit see the same
+  // post-coercion shape. Carry `_rowNum` + the row's intended archive state
+  // alongside the merged row so we can attribute errors and detect archive
+  // transitions later.
+  const prepared = [];
+  for (const raw of rows) {
+    const { _rowNum, status, ...row } = raw;
+    coerceChildRow(row, model);
+    let archiveTarget; // undefined → leave deactivated_at alone
+    if (typeof status === 'string') {
+      const s = status.toLowerCase().trim();
+      if (s === 'archived') archiveTarget = true;
+      else if (s === 'active') archiveTarget = false;
+    }
+    const merged = callbackFn ? await callbackFn(row) : row;
+    delete merged.tenant_code;
+    if (tenantId) merged.tenant_id = tenantId;
+    if (archiveTarget === true) merged.deactivated_at = new Date();
+    else if (archiveTarget === false) merged.deactivated_at = null;
+    prepared.push({ rowNum: _rowNum || null, merged, archiveTarget });
+  }
+
+  const tName = model.pgp.as.name(model._schema?.table || sheetName);
+  const sName = model.pgp.as.name(model._schema?.dbSchema || 'public');
+
+  // Batch-load the existing DB rows for every UUID id in the file (avoid N+1).
+  const uuidIds = prepared.filter((p) => isUuid(p.merged.id)).map((p) => p.merged.id);
+  const existingById = new Map();
+  if (uuidIds.length) {
+    const existing = await model.db.any(
+      `SELECT * FROM ${sName}.${tName} WHERE id IN ($1:csv)`,
+      [uuidIds],
+    );
+    for (const row of existing) existingById.set(row.id, row);
+  }
+
+  // Natural-key fallback: when a row's `id` isn't a usable UUID (or doesn't
+  // resolve to a DB row), look it up by the entity's natural unique key
+  // before classifying as insert. This makes round-trip idempotent even
+  // when the file's `id` column carries non-UUID values (e.g. a workbook
+  // hand-edited with sequential 1/2/3 ids, or an export from a different
+  // system) — without this fallback the commit would hit the entity's
+  // (tenant_id, X) unique constraint and 422 with a cryptic error.
+  //
+  // The natural key is derived from the first unique constraint in the
+  // schema, minus `tenant_id` (which is implicit per-import). Only
+  // single-column natural keys are supported here; composite natural keys
+  // fall back to the UUID-only path.
+  const uniqueDef = model._schema?.constraints?.unique?.[0] || [];
+  const naturalKeyCols = uniqueDef.filter((c) => c !== 'tenant_id');
+  const naturalKey = naturalKeyCols.length === 1 ? naturalKeyCols[0] : null;
+  const existingByNatural = new Map();
+  if (naturalKey && tenantId) {
+    const valuesNeedingLookup = prepared
+      .filter((p) => !(isUuid(p.merged.id) && existingById.has(p.merged.id)))
+      .map((p) => p.merged[naturalKey])
+      .filter((v) => v != null && v !== '');
+    if (valuesNeedingLookup.length) {
+      const kCol = model.pgp.as.name(naturalKey);
+      const existing = await model.db.any(
+        `SELECT * FROM ${sName}.${tName} WHERE tenant_id = $1 AND ${kCol} IN ($2:csv)`,
+        [tenantId, valuesNeedingLookup],
+      );
+      for (const row of existing) existingByNatural.set(row[naturalKey], row);
+    }
+  }
+
+  // Classification pass. Two lookups per row: UUID first (authoritative when
+  // present), then natural key as a fallback. Rows that match by natural key
+  // have their merged.id rewritten to the existing UUID so the commit path
+  // uses updateWhere instead of insert.
+  let inserts = 0;
+  let updates = 0;
+  let noops = 0;
+  const classified = [];
+  for (const p of prepared) {
+    let existing = null;
+    if (isUuid(p.merged.id)) existing = existingById.get(p.merged.id);
+    if (!existing && naturalKey) {
+      const matched = existingByNatural.get(p.merged[naturalKey]);
+      if (matched) {
+        existing = matched;
+        p.merged.id = matched.id; // upgrade insert → update on the existing row
+      }
+    }
+    if (!existing) {
+      inserts += 1;
+      classified.push({ ...p, action: 'insert' });
+      continue;
+    }
+    const wasArchived = !!existing.deactivated_at;
+    const willBeArchived = p.archiveTarget === undefined ? wasArchived : !!p.archiveTarget;
+    const archiveChanged = wasArchived !== willBeArchived;
+    const diff = diffParent(p.merged, existing, { caseSensitive: true });
+    if (Object.keys(diff).length > 0 || archiveChanged) {
+      updates += 1;
+      classified.push({ ...p, action: 'update' });
+    } else {
+      noops += 1;
+      classified.push({ ...p, action: 'noop' });
+    }
+  }
+
+  if (previewOnly) {
+    return { preview: true, inserts, updates, noops, omitted: 0, errors: [] };
+  }
+
+  // Commit pass. Per-row try/catch so a single bad row doesn't abort the import.
+  const errors = [];
+  let inserted = 0;
+  let updated = 0;
+  for (const c of classified) {
+    if (c.action === 'noop') continue;
+    try {
+      if (c.action === 'update') {
+        const { id, ...changes } = c.merged;
+        await model.updateWhere([{ id }], changes, { includeDeactivated: true });
+        updated++;
+      } else {
+        const insertRow = { ...c.merged };
+        delete insertRow.id;
+        await model.insert(insertRow);
+        inserted++;
+      }
+    } catch (err) {
+      const parsed = parseDbImportError(err);
+      if (parsed) {
+        for (const e of parsed) errors.push({ ...e, sheet: sheetName, row: c.rowNum });
+      } else {
+        errors.push({ sheet: sheetName, row: c.rowNum, column: null, value: null, message: err.message });
+      }
+    }
+  }
+
+  if (errors.length) return { errors };
+  return { inserted, updated };
+}
+
+/**
  * Import a source entity from a multi-sheet workbook with upsert semantics.
  *
  * Sheet 0: Parent entity (required) — `id` determines insert vs update

--- a/apps/server/src/modules/accounting/models/ChartOfAccounts.js
+++ b/apps/server/src/modules/accounting/models/ChartOfAccounts.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import chartOfAccountsSchema from '../schemas/chartOfAccountsSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class ChartOfAccounts extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, chartOfAccountsSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/accounting/models/JournalEntries.js
+++ b/apps/server/src/modules/accounting/models/JournalEntries.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import journalEntriesSchema from '../schemas/journalEntriesSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class JournalEntries extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, journalEntriesSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/activities/models/Activities.js
+++ b/apps/server/src/modules/activities/models/Activities.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import activitiesSchema from '../schemas/activitiesSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class Activities extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, activitiesSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/activities/models/ActualCosts.js
+++ b/apps/server/src/modules/activities/models/ActualCosts.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import actualCostsSchema from '../schemas/actualCostsSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class ActualCosts extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, actualCostsSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/activities/models/Budgets.js
+++ b/apps/server/src/modules/activities/models/Budgets.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import budgetsSchema from '../schemas/budgetsSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class Budgets extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, budgetsSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/activities/models/Categories.js
+++ b/apps/server/src/modules/activities/models/Categories.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import categoriesSchema from '../schemas/categoriesSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class Categories extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, categoriesSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/activities/models/Deliverables.js
+++ b/apps/server/src/modules/activities/models/Deliverables.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import deliverablesSchema from '../schemas/deliverablesSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class Deliverables extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, deliverablesSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/ap/models/ApCreditMemos.js
+++ b/apps/server/src/modules/ap/models/ApCreditMemos.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import apCreditMemosSchema from '../schemas/apCreditMemosSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class ApCreditMemos extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, apCreditMemosSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/ap/models/ApInvoices.js
+++ b/apps/server/src/modules/ap/models/ApInvoices.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import apInvoicesSchema from '../schemas/apInvoicesSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class ApInvoices extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, apInvoicesSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/ap/models/Payments.js
+++ b/apps/server/src/modules/ap/models/Payments.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import paymentsSchema from '../schemas/paymentsSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class Payments extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, paymentsSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/ar/models/ArInvoices.js
+++ b/apps/server/src/modules/ar/models/ArInvoices.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import arInvoicesSchema from '../schemas/arInvoicesSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class ArInvoices extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, arInvoicesSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/ar/models/Receipts.js
+++ b/apps/server/src/modules/ar/models/Receipts.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import receiptsSchema from '../schemas/receiptsSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class Receipts extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, receiptsSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/bom/models/CatalogSkus.js
+++ b/apps/server/src/modules/bom/models/CatalogSkus.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import catalogSkusSchema from '../schemas/catalogSkusSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class CatalogSkus extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, catalogSkusSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/projects/models/ChangeOrders.js
+++ b/apps/server/src/modules/projects/models/ChangeOrders.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import changeOrdersSchema from '../schemas/changeOrdersSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class ChangeOrders extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, changeOrdersSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/modules/projects/models/Projects.js
+++ b/apps/server/src/modules/projects/models/Projects.js
@@ -7,9 +7,14 @@
 
 import { TableModel } from 'pg-schemata';
 import projectsSchema from '../schemas/projectsSchema.js';
+import { importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 export default class Projects extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, projectsSchema, logger);
+  }
+
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/system/core/models/PaymentTerms.js
+++ b/apps/server/src/system/core/models/PaymentTerms.js
@@ -5,10 +5,10 @@
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { TableModel } from 'pg-schemata';
 import paymentTermsSchema from '../schemas/paymentTermsSchema.js';
-import { curateRows, parseSheet, coerceChildRow, isUuid, parseDbImportError } from '../../../lib/spreadsheetHelpers.js';
+import { curateRows, importSimpleTable } from '../../../lib/spreadsheetHelpers.js';
 
 const SHEET_NAME = 'Payment Terms';
 const EXPORT_HEADERS = ['id', 'label', 'term', 'units', 'is_active', 'status'];
@@ -44,75 +44,12 @@ export default class PaymentTerms extends TableModel {
   }
 
   /**
-   * Import payment terms from an XLSX spreadsheet.
-   * Rows with a valid UUID `id` are updated; others are inserted.
+   * Import payment terms from an XLSX spreadsheet via the shared
+   * simple-table shim: rows with a valid UUID `id` upsert, others insert,
+   * `status` ('archived' / 'active') maps to `deactivated_at`, and the
+   * `previewOnly` option from `BaseController.importXls` is honored.
    */
-  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null) {
-    const { WorkbookReader } = await import('@nap-sft/tablsx');
-    const buffer = readFileSync(filePath);
-    const reader = WorkbookReader.fromBuffer(buffer);
-    const rows = parseSheet(reader, 0);
-    if (!rows.length) return { inserted: 0, updated: 0 };
-
-    // Resolve tenant_id from tenant_code provided by callbackFn
-    let tenantId;
-    const sampleRow = callbackFn ? await callbackFn({}) : {};
-    if (sampleRow.tenant_code) {
-      const tenantRec = await this.db.oneOrNone(
-        'SELECT id FROM admin.tenants WHERE tenant_code = $1 AND deactivated_at IS NULL',
-        [sampleRow.tenant_code.toUpperCase()],
-      );
-      tenantId = tenantRec?.id;
-    }
-
-    const errors = [];
-    let inserted = 0;
-    let updated = 0;
-
-    for (const raw of rows) {
-      // Strip non-schema columns
-      const { _rowNum, status, ...row } = raw;
-
-      // Coerce types (boolean is_active, enum units)
-      coerceChildRow(row, this);
-
-      // Derive deactivated_at from status column
-      if (typeof status === 'string') {
-        const s = status.toLowerCase().trim();
-        if (s === 'archived') row.deactivated_at = new Date();
-        else if (s === 'active') row.deactivated_at = null;
-      }
-
-      // Merge caller-provided fields (tenant_code, created_by)
-      const merged = callbackFn ? await callbackFn(row) : row;
-
-      // Replace tenant_code with resolved tenant_id
-      delete merged.tenant_code;
-      if (tenantId) merged.tenant_id = tenantId;
-
-      try {
-        if (isUuid(merged.id)) {
-          const { id, ...updates } = merged;
-          await this.updateWhere([{ id }], updates, { includeDeactivated: true });
-          updated++;
-        } else {
-          delete merged.id;
-          await this.insert(merged);
-          inserted++;
-        }
-      } catch (err) {
-        const parsed = parseDbImportError(err);
-        if (parsed) {
-          for (const e of parsed) {
-            errors.push({ ...e, sheet: SHEET_NAME, row: _rowNum || null });
-          }
-        } else {
-          errors.push({ sheet: SHEET_NAME, row: _rowNum || null, column: null, value: null, message: err.message });
-        }
-      }
-    }
-
-    if (errors.length) return { errors };
-    return { inserted, updated };
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {
+    return importSimpleTable(this, filePath, callbackFn, options);
   }
 }

--- a/apps/server/src/system/core/models/PaymentTerms.js
+++ b/apps/server/src/system/core/models/PaymentTerms.js
@@ -45,8 +45,12 @@ export default class PaymentTerms extends TableModel {
 
   /**
    * Import payment terms from an XLSX spreadsheet via the shared
-   * simple-table shim: rows with a valid UUID `id` upsert, others insert,
-   * `status` ('archived' / 'active') maps to `deactivated_at`, and the
+   * simple-table shim. Rows resolve to an existing row via UUID `id` first;
+   * if that misses, the shim falls back to the natural unique key (`label`)
+   * so round-trips remain idempotent even when the file's `id` cells aren't
+   * UUIDs (hand-edited workbook, or an export whose UUIDs no longer exist
+   * in the target DB). Rows that miss both lookups insert. The `status`
+   * column maps to `deactivated_at` ('archived' / 'active'), and the
    * `previewOnly` option from `BaseController.importXls` is honored.
    */
   async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, options = {}) {

--- a/apps/server/tests/contract/paymentTermsImport.test.js
+++ b/apps/server/tests/contract/paymentTermsImport.test.js
@@ -340,6 +340,79 @@ describe('PaymentTerms import — simple-table shim', () => {
     expect(after.n).toBe(0);
   });
 
+  test('re-importing an already-archived row preserves the original deactivated_at', async () => {
+    // Seed: archive 'Net 60' via import.
+    const net60Before = await db.one(`SELECT id FROM ptimp.payment_terms WHERE label = 'Net 60'`);
+    await postImport(
+      await buildWorkbook([
+        blank({ id: net60Before.id, label: 'Net 60', term: 60, units: 'days', is_active: true, status: 'archived' }),
+      ]),
+      cookies,
+      'archive-seed',
+    );
+    const archivedAt = await db.one(
+      `SELECT deactivated_at FROM ptimp.payment_terms WHERE id = $1`,
+      [net60Before.id],
+    );
+    expect(archivedAt.deactivated_at).not.toBeNull();
+    const originalDeactivatedAt = archivedAt.deactivated_at;
+
+    // Re-import same archived row → must NOT refresh the archive timestamp.
+    const buf = await buildWorkbook([
+      blank({ id: net60Before.id, label: 'Net 60', term: 60, units: 'days', is_active: true, status: 'archived' }),
+    ]);
+
+    const preview = await postImport(buf, cookies, 'archive-noop-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body).toMatchObject({ inserts: 0, updates: 0, noops: 1 });
+
+    const commit = await postImport(buf, cookies, 'archive-noop-commit');
+    expect(commit.status).toBe(201);
+    expect(commit.body).toMatchObject({ inserted: 0, updated: 0 });
+
+    const after = await db.one(
+      `SELECT deactivated_at FROM ptimp.payment_terms WHERE id = $1`,
+      [net60Before.id],
+    );
+    expect(after.deactivated_at.toISOString()).toBe(originalDeactivatedAt.toISOString());
+
+    // Restore for downstream tests.
+    await postImport(
+      await buildWorkbook([
+        blank({ id: net60Before.id, label: 'Net 60', term: 60, units: 'days', is_active: true, status: 'active' }),
+      ]),
+      cookies,
+      'archive-restore',
+    );
+  });
+
+  test('duplicate UUID id within the file is surfaced as a preview error and blocks commit', async () => {
+    const net60 = await db.one(`SELECT id FROM ptimp.payment_terms WHERE label = 'Net 60'`);
+
+    // Two rows with the same id pointing at Net 60, but different labels.
+    // Without the duplicate-id check both would classify as updates against
+    // the same DB row and apply silently (last-write-wins). Should now error.
+    const buf = await buildWorkbook([
+      blank({ id: net60.id, label: 'Net 60 First Write', term: 60, units: 'days', is_active: true, status: 'active' }),
+      blank({ id: net60.id, label: 'Net 60 Second Write', term: 60, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    const preview = await postImport(buf, cookies, 'dup-id-preview', { preview: true });
+    expect(preview.status).toBe(422);
+    expect(preview.body.errors.length).toBeGreaterThanOrEqual(1);
+    expect(preview.body.errors.some((e) => e.column === 'id' && /Duplicate id/.test(e.message))).toBe(true);
+
+    const commit = await postImport(buf, cookies, 'dup-id-commit');
+    expect(commit.status).toBe(422);
+
+    // Neither write landed.
+    const after = await db.one(
+      `SELECT label FROM ptimp.payment_terms WHERE id = $1`,
+      [net60.id],
+    );
+    expect(after.label).toBe('Net 60');
+  });
+
   test('case-only edit on a parent varchar field counts as a real change', async () => {
     const net30 = await db.one(`SELECT id, label FROM ptimp.payment_terms WHERE label = 'Net 30'`);
     const recased = net30.label.toUpperCase();

--- a/apps/server/tests/contract/paymentTermsImport.test.js
+++ b/apps/server/tests/contract/paymentTermsImport.test.js
@@ -273,6 +273,73 @@ describe('PaymentTerms import — simple-table shim', () => {
     expect(ghostsAfter).toHaveLength(0);
   });
 
+  test('update does not overwrite created_by — audit-create columns are stripped from the changes', async () => {
+    // BaseController.importXls injects the importing user's id into every
+    // row's `created_by`. Without stripping it from the update DTO, every
+    // commit-side update would silently re-write the row's `created_by`
+    // to the importer, losing the original creator's audit trail. Verify
+    // a real update (term bump) leaves `created_by` and `created_at`
+    // untouched. We bump `term` (not `label`) so subsequent tests in the
+    // describe block can still find rows by their original labels.
+    const net30 = await db.one(
+      `SELECT id, label, term, created_by, created_at FROM ptimp.payment_terms WHERE label = 'Net 30'`,
+    );
+    const originalCreatedBy = net30.created_by;
+    const originalCreatedAt = net30.created_at;
+    const bumpedTerm = net30.term + 1;
+
+    const buf = await buildWorkbook([
+      blank({ id: net30.id, label: 'Net 30', term: bumpedTerm, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    const commit = await postImport(buf, cookies, 'audit-preserve');
+    expect(commit.status).toBe(201);
+    expect(commit.body.updated).toBe(1);
+
+    const after = await db.one(
+      `SELECT label, term, created_by, created_at FROM ptimp.payment_terms WHERE id = $1`,
+      [net30.id],
+    );
+    expect(after.label).toBe('Net 30');
+    expect(after.term).toBe(bumpedTerm);
+    expect(after.created_by).toEqual(originalCreatedBy);
+    expect(after.created_at.toISOString()).toBe(originalCreatedAt.toISOString());
+  });
+
+  test('duplicate label within the file is surfaced as a preview error and blocks commit', async () => {
+    // The shim's intra-file duplicate-key detector catches two rows with
+    // the same natural key (label) up front, instead of letting the commit
+    // half-succeed and 422 on the unique constraint mid-way through.
+    const buf = await buildWorkbook([
+      blank({ label: 'Net 90', term: 90, units: 'days', is_active: true, status: 'active' }),
+      blank({ label: 'Net 90', term: 90, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    // BaseController.importXls maps `result.errors.length > 0` to a 422
+    // (matches the flat single-entity preview-with-errors behavior).
+    const preview = await postImport(buf, cookies, 'dup-preview', { preview: true });
+    expect(preview.status).toBe(422);
+    expect(preview.body.preview).toBe(true);
+    expect(preview.body.errors.length).toBe(1);
+    expect(preview.body.errors[0]).toMatchObject({
+      column: 'label',
+      value: 'Net 90',
+      message: expect.stringContaining("Duplicate label 'Net 90'"),
+    });
+
+    const commit = await postImport(buf, cookies, 'dup-commit');
+    expect(commit.status).toBe(422);
+    expect(commit.body.errors.length).toBe(1);
+    expect(commit.body.errors[0].column).toBe('label');
+
+    // Neither duplicate landed in the DB — the validation gate fired before
+    // any writes.
+    const after = await db.one(
+      `SELECT count(*)::int AS n FROM ptimp.payment_terms WHERE label = 'Net 90'`,
+    );
+    expect(after.n).toBe(0);
+  });
+
   test('case-only edit on a parent varchar field counts as a real change', async () => {
     const net30 = await db.one(`SELECT id, label FROM ptimp.payment_terms WHERE label = 'Net 30'`);
     const recased = net30.label.toUpperCase();

--- a/apps/server/tests/contract/paymentTermsImport.test.js
+++ b/apps/server/tests/contract/paymentTermsImport.test.js
@@ -413,6 +413,32 @@ describe('PaymentTerms import — simple-table shim', () => {
     expect(after.label).toBe('Net 60');
   });
 
+  test('atomic commit — a row that fails a check constraint rolls back the whole import', async () => {
+    // Row 1 is a valid new term ('Atomic A'). Row 2 violates the schema's
+    // CHECK (units IN ('days', 'months')) constraint. With bulkInsert wrapped
+    // in db.tx, the whole batch fails and rolls back — neither row should
+    // exist in the DB after the import returns 422.
+    const beforeCount = await db.one(`SELECT count(*)::int AS n FROM ptimp.payment_terms`);
+
+    const buf = await buildWorkbook([
+      blank({ label: 'Atomic A', term: 30, units: 'days', is_active: true, status: 'active' }),
+      blank({ label: 'Atomic B', term: 30, units: 'weeks', is_active: true, status: 'active' }),
+    ]);
+
+    const commit = await postImport(buf, cookies, 'atomic-rollback');
+    expect(commit.status).toBe(422);
+    expect(commit.body.errors.length).toBeGreaterThanOrEqual(1);
+
+    const afterCount = await db.one(`SELECT count(*)::int AS n FROM ptimp.payment_terms`);
+    expect(afterCount.n).toBe(beforeCount.n);
+
+    // Specifically: 'Atomic A' didn't leak through ahead of the failure.
+    const atomicA = await db.oneOrNone(
+      `SELECT id FROM ptimp.payment_terms WHERE label = 'Atomic A'`,
+    );
+    expect(atomicA).toBeNull();
+  });
+
   test('case-only edit on a parent varchar field counts as a real change', async () => {
     const net30 = await db.one(`SELECT id, label FROM ptimp.payment_terms WHERE label = 'Net 30'`);
     const recased = net30.label.toUpperCase();

--- a/apps/server/tests/contract/paymentTermsImport.test.js
+++ b/apps/server/tests/contract/paymentTermsImport.test.js
@@ -1,0 +1,297 @@
+/**
+ * @file Contract tests for the PaymentTerms import via the simple-table shim
+ * @module tests/contract/paymentTermsImport
+ *
+ * Behavior locked in:
+ *   - `?preview=1` returns counts (`inserts`, `updates`, `noops`, `omitted=0`)
+ *     without any DB writes.
+ *   - Commit writes the expected inserted/updated counts.
+ *   - Re-import of the same workbook is classified as noops (preview + commit).
+ *   - `status='archived'` sets `deactivated_at`; `status='active'` clears it.
+ *   - Case-only edits on a varchar parent field are classified as updates and
+ *     persist (the shim opts into `diffParent({ caseSensitive: true })`).
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(cookies, code) {
+  await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', cookies)
+    .send({
+      tenant_code: code,
+      company: `${code} Payment Terms Corp`,
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'Test',
+      admin_last_name: 'Admin',
+      admin_email: `admin@${code.toLowerCase()}.com`,
+      admin_password: 'PtImportPass123!',
+      billing_address: { address_line_1: '1 PT St', country_code: 'US' },
+    });
+}
+
+const HEADERS = ['id', 'label', 'term', 'units', 'is_active', 'status'];
+function blank(extras = {}) {
+  return Object.fromEntries(HEADERS.map((h) => [h, extras[h] ?? '']));
+}
+
+async function buildWorkbook(rows) {
+  const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+  const wb = WorkbookBuilder.create();
+  wb.sheet('Payment Terms').setHeaders(HEADERS).addObjects(rows);
+  return writeXlsx(wb.build());
+}
+
+async function postImport(buf, cookies, label, { preview = false } = {}) {
+  const tmpPath = join(tmpdir(), `pt-${label}-${Date.now()}.xlsx`);
+  writeFileSync(tmpPath, buf);
+  const url = `/api/core/v1/payment-terms/import-xls${preview ? '?preview=1' : ''}`;
+  try {
+    return await request(app).post(url).set('Cookie', cookies).attach('file', tmpPath);
+  } finally {
+    unlinkSync(tmpPath);
+  }
+}
+
+describe('PaymentTerms import — simple-table shim', () => {
+  let cookies;
+
+  beforeAll(async () => {
+    const rootCookies = await loginRoot();
+    await provisionTenant(rootCookies, 'PTIMP');
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@ptimp.com', password: 'PtImportPass123!' });
+    cookies = loginRes.headers['set-cookie'];
+  }, 30000);
+
+  test('preview returns counts and writes nothing', async () => {
+    const before = await db.one('SELECT count(*)::int AS n FROM ptimp.payment_terms');
+
+    const buf = await buildWorkbook([
+      blank({ label: 'Net 30', term: 30, units: 'days', is_active: true, status: 'active' }),
+      blank({ label: 'Net 60', term: 60, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    const res = await postImport(buf, cookies, 'preview1', { preview: true });
+    expect(res.status).toBe(200);
+    expect(res.body.preview).toBe(true);
+    expect(res.body.errors).toEqual([]);
+    expect(res.body.inserts).toBe(2);
+    expect(res.body.updates).toBe(0);
+    expect(res.body.noops).toBe(0);
+    expect(res.body.omitted).toBe(0);
+
+    const after = await db.one('SELECT count(*)::int AS n FROM ptimp.payment_terms');
+    expect(after.n).toBe(before.n);
+  });
+
+  test('commit writes inserts; re-commit using the same rows shows up as noops in preview', async () => {
+    const buf = await buildWorkbook([
+      blank({ label: 'Net 30', term: 30, units: 'days', is_active: true, status: 'active' }),
+      blank({ label: 'Net 60', term: 60, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    const commit = await postImport(buf, cookies, 'commit1');
+    if (commit.status !== 201) {
+      throw new Error(`commit returned ${commit.status}: ${JSON.stringify(commit.body)}`);
+    }
+    expect(commit.body.inserted).toBe(2);
+    expect(commit.body.updated || 0).toBe(0);
+
+    // Round-trip with explicit ids → preview must classify both as noops.
+    const persisted = await db.any(
+      `SELECT id, label FROM ptimp.payment_terms WHERE label IN ('Net 30', 'Net 60') ORDER BY label`,
+    );
+    expect(persisted).toHaveLength(2);
+    const net30 = persisted.find((r) => r.label === 'Net 30');
+    const net60 = persisted.find((r) => r.label === 'Net 60');
+
+    const round = await buildWorkbook([
+      blank({ id: net30.id, label: 'Net 30', term: 30, units: 'days', is_active: true, status: 'active' }),
+      blank({ id: net60.id, label: 'Net 60', term: 60, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    const previewRes = await postImport(round, cookies, 'roundpreview', { preview: true });
+    expect(previewRes.status).toBe(200);
+    expect(previewRes.body).toMatchObject({ preview: true, inserts: 0, updates: 0, noops: 2, omitted: 0 });
+
+    const commitRes = await postImport(round, cookies, 'roundcommit');
+    expect(commitRes.status).toBe(201);
+    expect(commitRes.body).toMatchObject({ inserted: 0, updated: 0 });
+  });
+
+  test('status=archived sets deactivated_at and updates the counter', async () => {
+    const net30 = await db.one(`SELECT id, deactivated_at FROM ptimp.payment_terms WHERE label = 'Net 30'`);
+    expect(net30.deactivated_at).toBeNull();
+
+    const buf = await buildWorkbook([
+      blank({ id: net30.id, label: 'Net 30', term: 30, units: 'days', is_active: true, status: 'archived' }),
+    ]);
+
+    const preview = await postImport(buf, cookies, 'archive-preview', { preview: true });
+    expect(preview.body.updates).toBe(1);
+    expect(preview.body.noops).toBe(0);
+
+    const commit = await postImport(buf, cookies, 'archive-commit');
+    expect(commit.status).toBe(201);
+    expect(commit.body.updated).toBe(1);
+
+    const after = await db.one(`SELECT deactivated_at FROM ptimp.payment_terms WHERE id = $1`, [net30.id]);
+    expect(after.deactivated_at).not.toBeNull();
+  });
+
+  test('status=active restores a soft-deleted row', async () => {
+    const net30 = await db.one(`SELECT id FROM ptimp.payment_terms WHERE label = 'Net 30'`);
+    const before = await db.one(`SELECT deactivated_at FROM ptimp.payment_terms WHERE id = $1`, [net30.id]);
+    expect(before.deactivated_at).not.toBeNull();
+
+    const buf = await buildWorkbook([
+      blank({ id: net30.id, label: 'Net 30', term: 30, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    const commit = await postImport(buf, cookies, 'restore-commit');
+    expect(commit.status).toBe(201);
+    expect(commit.body.updated).toBe(1);
+
+    const after = await db.one(`SELECT deactivated_at FROM ptimp.payment_terms WHERE id = $1`, [net30.id]);
+    expect(after.deactivated_at).toBeNull();
+  });
+
+  test('non-UUID id falls back to natural key (label) — round-trip is idempotent', async () => {
+    // Mirrors a real-world scenario: a workbook whose `id` column was
+    // hand-edited (or carried over from a non-axerra source) with sequential
+    // numeric ids instead of UUIDs. Without the natural-key fallback, the
+    // shim would classify both as inserts, the commit would hit the unique
+    // (tenant_id, label) constraint and 422 with a cryptic duplicate error.
+    // With the fallback, they upsert by `label` and round-trip as noops.
+    const existing = await db.any(
+      `SELECT label FROM ptimp.payment_terms WHERE deactivated_at IS NULL ORDER BY label`,
+    );
+    expect(existing.length).toBeGreaterThanOrEqual(2);
+    const [a, b] = existing;
+
+    const buf = await buildWorkbook([
+      blank({ id: 1, label: a.label, term: 30, units: 'days', is_active: true, status: 'active' }),
+      blank({ id: 2, label: b.label, term: 60, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    // First do a baseline commit to align the DB rows with the workbook's
+    // (term, units, is_active) values, so the round-trip check below
+    // measures only the id-vs-natural-key behavior — not unrelated field drift.
+    const baseline = await postImport(buf, cookies, 'naturalKey-baseline');
+    expect(baseline.status).toBe(201);
+
+    const preview = await postImport(buf, cookies, 'naturalKey-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body).toMatchObject({ preview: true, inserts: 0, updates: 0, noops: 2 });
+
+    const commit = await postImport(buf, cookies, 'naturalKey-commit');
+    expect(commit.status).toBe(201);
+    expect(commit.body).toMatchObject({ inserted: 0, updated: 0 });
+
+    // And the row count didn't grow.
+    const after = await db.one(
+      `SELECT count(*)::int AS n FROM ptimp.payment_terms WHERE label IN ($1, $2)`,
+      [a.label, b.label],
+    );
+    expect(after.n).toBe(2);
+  });
+
+  test('UUID in file but not in DB falls back to natural key (label) — no spurious inserts', async () => {
+    // Mirrors the real-world scenario where a user exports payment terms,
+    // resets/migrates the DB (so the old UUIDs are gone), then re-imports
+    // the same workbook. Without the natural-key fallback the shim would
+    // classify both rows as inserts and the commit would 422 on the unique
+    // (tenant_id, label) constraint. With the fallback they upsert by label.
+    const existing = await db.any(
+      `SELECT label FROM ptimp.payment_terms WHERE deactivated_at IS NULL ORDER BY label`,
+    );
+    expect(existing.length).toBeGreaterThanOrEqual(2);
+    const [a, b] = existing;
+
+    // Use UUIDs that look real but aren't in the DB (random v4-shaped).
+    const ghost1 = 'd1869bd7-6191-4e49-9670-62c180a761fa';
+    const ghost2 = '8e402252-97ba-4d6a-b357-fa4f1c7b7431';
+    const present = await db.oneOrNone(
+      `SELECT id FROM ptimp.payment_terms WHERE id IN ($1, $2)`,
+      [ghost1, ghost2],
+    );
+    expect(present).toBeNull();
+
+    const buf = await buildWorkbook([
+      blank({ id: ghost1, label: a.label, term: 30, units: 'days', is_active: true, status: 'active' }),
+      blank({ id: ghost2, label: b.label, term: 60, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    // Baseline commit so the rows match the workbook before measuring noop parity.
+    const baseline = await postImport(buf, cookies, 'ghostUuid-baseline');
+    expect(baseline.status).toBe(201);
+
+    const preview = await postImport(buf, cookies, 'ghostUuid-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body).toMatchObject({ preview: true, inserts: 0, updates: 0, noops: 2 });
+
+    const commit = await postImport(buf, cookies, 'ghostUuid-commit');
+    expect(commit.status).toBe(201);
+    expect(commit.body).toMatchObject({ inserted: 0, updated: 0 });
+
+    // And neither ghost UUID landed in the DB — the upsert used the existing
+    // rows' real UUIDs.
+    const ghostsAfter = await db.any(
+      `SELECT id FROM ptimp.payment_terms WHERE id IN ($1, $2)`,
+      [ghost1, ghost2],
+    );
+    expect(ghostsAfter).toHaveLength(0);
+  });
+
+  test('case-only edit on a parent varchar field counts as a real change', async () => {
+    const net30 = await db.one(`SELECT id, label FROM ptimp.payment_terms WHERE label = 'Net 30'`);
+    const recased = net30.label.toUpperCase();
+    expect(recased).not.toBe(net30.label);
+
+    const buf = await buildWorkbook([
+      blank({ id: net30.id, label: recased, term: 30, units: 'days', is_active: true, status: 'active' }),
+    ]);
+
+    const preview = await postImport(buf, cookies, 'caseEdit-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body.updates).toBe(1);
+    expect(preview.body.noops).toBe(0);
+
+    const commit = await postImport(buf, cookies, 'caseEdit-commit');
+    expect(commit.status).toBe(201);
+    expect(commit.body.updated).toBe(1);
+
+    const after = await db.one(`SELECT label FROM ptimp.payment_terms WHERE id = $1`, [net30.id]);
+    expect(after.label).toBe(recased);
+  });
+});

--- a/apps/server/tests/contract/simpleTableImportShim.test.js
+++ b/apps/server/tests/contract/simpleTableImportShim.test.js
@@ -196,6 +196,92 @@ describe('Simple-table shim — ChartOfAccounts', () => {
     expect(row.deactivated_at).toBeNull();
   });
 
+  test('sparse update via partial-headers workbook — only the listed columns are touched', async () => {
+    // Seed an account with bank metadata populated.
+    const SEED_HEADERS = ['id', 'code', 'name', 'type', 'is_active', 'cash_basis', 'bank_account_number', 'routing_number', 'bank_name', 'status'];
+    const seedBlank = (extras = {}) => Object.fromEntries(SEED_HEADERS.map((h) => [h, extras[h] ?? '']));
+    const seedBuf = await (async () => {
+      const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+      const wb = WorkbookBuilder.create();
+      wb.sheet('Chart of Accounts').setHeaders(SEED_HEADERS).addObjects([
+        seedBlank({ code: '1500', name: 'Operating Bank', type: 'asset', is_active: true, cash_basis: true, bank_name: 'Big Bank', routing_number: '123456789', status: 'active' }),
+      ]);
+      return writeXlsx(wb.build());
+    })();
+    expect((await postImport(seedBuf, cookies, 'sparse-seed')).status).toBe(201);
+
+    const seeded = await db.one(
+      `SELECT id, name, bank_name, routing_number FROM coashm.chart_of_accounts WHERE code = '1500'`,
+    );
+
+    // Re-import with a NARROW header list — only id + name. The other
+    // columns aren't in the workbook at all, so they never enter `merged`
+    // and can't appear in the diff. Diff-as-DTO update touches only `name`.
+    // (Blank-cell-vs-null is a separate concern; this test proves the
+    // headers-omitted protection.)
+    const PARTIAL_HEADERS = ['id', 'name'];
+    const partialBuf = await (async () => {
+      const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+      const wb = WorkbookBuilder.create();
+      wb.sheet('Chart of Accounts').setHeaders(PARTIAL_HEADERS).addObjects([
+        { id: seeded.id, name: 'Operating Bank Account' },
+      ]);
+      return writeXlsx(wb.build());
+    })();
+
+    const commit = await postImport(partialBuf, cookies, 'sparse-commit');
+    if (commit.status !== 201) throw new Error(`sparse commit ${commit.status}: ${JSON.stringify(commit.body)}`);
+    expect(commit.body.updated).toBe(1);
+
+    const after = await db.one(
+      `SELECT name, bank_name, routing_number, type, is_active, cash_basis FROM coashm.chart_of_accounts WHERE id = $1`,
+      [seeded.id],
+    );
+    expect(after.name).toBe('Operating Bank Account');
+    expect(after.bank_name).toBe('Big Bank');         // ← preserved (col not in headers)
+    expect(after.routing_number).toBe('123456789');   // ← preserved
+    expect(after.type).toBe('asset');                 // ← preserved
+    expect(after.is_active).toBe(true);               // ← preserved
+    expect(after.cash_basis).toBe(true);              // ← preserved
+  });
+
+  test('blank cell in a nullable non-text column coerces to null on insert (deliverables date)', async () => {
+    // Deliverables has nullable `start_date` / `end_date` columns. A blank
+    // spreadsheet cell arrives as `''` from tablsx; without coerceChildRow
+    // mapping '' → null for non-text types, Postgres would reject `''` as
+    // an invalid date literal at insert time.
+    const HEADERS_D = ['id', 'name', 'description', 'status', 'start_date', 'end_date'];
+    const blankD = (extras = {}) => Object.fromEntries(HEADERS_D.map((h) => [h, extras[h] ?? '']));
+    const buf = await (async () => {
+      const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+      const wb = WorkbookBuilder.create();
+      wb.sheet('Deliverables').setHeaders(HEADERS_D).addObjects([
+        blankD({ name: 'Blank Date Insert', status: 'pending' }),
+      ]);
+      return writeXlsx(wb.build());
+    })();
+
+    const postD = async (b, label) => {
+      const tmpPath = join(tmpdir(), `dblank-${label}-${Date.now()}.xlsx`);
+      writeFileSync(tmpPath, b);
+      try {
+        return await request(app).post('/api/activities/v1/deliverables/import-xls').set('Cookie', cookies).attach('file', tmpPath);
+      } finally {
+        unlinkSync(tmpPath);
+      }
+    };
+
+    const commit = await postD(buf, 'blank-date');
+    if (commit.status !== 201) throw new Error(`blank-date commit ${commit.status}: ${JSON.stringify(commit.body)}`);
+    expect(commit.body.inserted).toBe(1);
+
+    const row = await db.one(
+      `SELECT name, start_date, end_date FROM coashm.deliverables WHERE name = 'Blank Date Insert'`,
+    );
+    expect(row.start_date).toBeNull();
+    expect(row.end_date).toBeNull();
+  });
+
   test('rename via the same id classifies as update + persists the new name', async () => {
     const cash = await db.one(`SELECT id, name FROM coashm.chart_of_accounts WHERE code = '1000'`);
     expect(cash.name).toBe('Cash');

--- a/apps/server/tests/contract/simpleTableImportShim.test.js
+++ b/apps/server/tests/contract/simpleTableImportShim.test.js
@@ -149,6 +149,53 @@ describe('Simple-table shim — ChartOfAccounts', () => {
     expect(commitRes.body).toMatchObject({ inserted: 0, updated: 0 });
   });
 
+  test('status column on entities that have a real status column flows through (deliverables)', async () => {
+    // Deliverables has a real workflow status column
+    // (pending -> released -> finished -> canceled). The shim must NOT treat
+    // the spreadsheet's `status` cell as synthetic archive metadata for
+    // these entities — it must let the value flow through to the DB.
+    // Without the schema-aware check the import would silently drop the
+    // 'released' value and use the column default 'pending'.
+    // Only include required + non-date columns. Empty-string date cells
+    // would fail Postgres DTO validation on the date type.
+    const HEADERS_D = ['id', 'name', 'description', 'status'];
+    const blankD = (extras = {}) => Object.fromEntries(HEADERS_D.map((h) => [h, extras[h] ?? '']));
+    const buildD = async (rows) => {
+      const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+      const wb = WorkbookBuilder.create();
+      wb.sheet('Deliverables').setHeaders(HEADERS_D).addObjects(rows);
+      return writeXlsx(wb.build());
+    };
+    const postD = async (buf, label, opts = {}) => {
+      const tmpPath = join(tmpdir(), `del-${label}-${Date.now()}.xlsx`);
+      writeFileSync(tmpPath, buf);
+      const url = `/api/activities/v1/deliverables/import-xls${opts.preview ? '?preview=1' : ''}`;
+      try {
+        return await request(app).post(url).set('Cookie', cookies).attach('file', tmpPath);
+      } finally {
+        unlinkSync(tmpPath);
+      }
+    };
+
+    const buf = await buildD([
+      blankD({ name: 'Foundation Pour', description: 'Pad ready', status: 'released' }),
+    ]);
+
+    const commit = await postD(buf, 'status-passthrough');
+    if (commit.status !== 201) {
+      throw new Error(`deliverables commit returned ${commit.status}: ${JSON.stringify(commit.body)}`);
+    }
+    expect(commit.body.inserted).toBe(1);
+
+    const row = await db.one(
+      `SELECT name, status, deactivated_at FROM coashm.deliverables WHERE name = 'Foundation Pour'`,
+    );
+    expect(row.status).toBe('released');
+    // And the row was NOT archived — `released` is not 'archived', so the
+    // synthetic archive parser must not have fired.
+    expect(row.deactivated_at).toBeNull();
+  });
+
   test('rename via the same id classifies as update + persists the new name', async () => {
     const cash = await db.one(`SELECT id, name FROM coashm.chart_of_accounts WHERE code = '1000'`);
     expect(cash.name).toBe('Cash');

--- a/apps/server/tests/contract/simpleTableImportShim.test.js
+++ b/apps/server/tests/contract/simpleTableImportShim.test.js
@@ -1,0 +1,169 @@
+/**
+ * @file Contract tests for the generic simple-table import shim against an
+ *       entity that previously had no override (`ChartOfAccounts`).
+ * @module tests/contract/simpleTableImportShim
+ *
+ * PaymentTerms had its own bespoke `importFromSpreadsheet`. Every other
+ * simple-table model used pg-schemata's default `bulkInsert`-only path, which
+ * meant re-importing an exported workbook would PK-conflict. This file proves
+ * the shared `importSimpleTable` helper works for a brand-new adopter:
+ *   - `?preview=1` classifies inserts/updates/noops without writing.
+ *   - Commit writes the expected counts.
+ *   - Round-trip with explicit ids preserves rows (no PK conflict; reports noops).
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(cookies, code) {
+  await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', cookies)
+    .send({
+      tenant_code: code,
+      company: `${code} CoA Shim Corp`,
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'Test',
+      admin_last_name: 'Admin',
+      admin_email: `admin@${code.toLowerCase()}.com`,
+      admin_password: 'CoaShimPass123!',
+      billing_address: { address_line_1: '1 Shim St', country_code: 'US' },
+    });
+}
+
+const HEADERS = ['id', 'code', 'name', 'type', 'is_active', 'cash_basis', 'status'];
+function blank(extras = {}) {
+  return Object.fromEntries(HEADERS.map((h) => [h, extras[h] ?? '']));
+}
+
+async function buildWorkbook(rows) {
+  const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+  const wb = WorkbookBuilder.create();
+  wb.sheet('Chart of Accounts').setHeaders(HEADERS).addObjects(rows);
+  return writeXlsx(wb.build());
+}
+
+async function postImport(buf, cookies, label, { preview = false } = {}) {
+  const tmpPath = join(tmpdir(), `coa-${label}-${Date.now()}.xlsx`);
+  writeFileSync(tmpPath, buf);
+  const url = `/api/accounting/v1/chart-of-accounts/import-xls${preview ? '?preview=1' : ''}`;
+  try {
+    return await request(app).post(url).set('Cookie', cookies).attach('file', tmpPath);
+  } finally {
+    unlinkSync(tmpPath);
+  }
+}
+
+describe('Simple-table shim — ChartOfAccounts', () => {
+  let cookies;
+
+  beforeAll(async () => {
+    const rootCookies = await loginRoot();
+    await provisionTenant(rootCookies, 'COASHM');
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@coashm.com', password: 'CoaShimPass123!' });
+    cookies = loginRes.headers['set-cookie'];
+  }, 30000);
+
+  test('preview returns counts and writes nothing', async () => {
+    const before = await db.one('SELECT count(*)::int AS n FROM coashm.chart_of_accounts');
+
+    const buf = await buildWorkbook([
+      blank({ code: '1000', name: 'Cash', type: 'asset', is_active: true, cash_basis: true, status: 'active' }),
+      blank({ code: '4000', name: 'Sales Revenue', type: 'revenue', is_active: true, cash_basis: false, status: 'active' }),
+    ]);
+
+    const res = await postImport(buf, cookies, 'preview1', { preview: true });
+    expect(res.status).toBe(200);
+    expect(res.body.preview).toBe(true);
+    expect(res.body.errors).toEqual([]);
+    expect(res.body.inserts).toBe(2);
+    expect(res.body.updates).toBe(0);
+    expect(res.body.noops).toBe(0);
+
+    const after = await db.one('SELECT count(*)::int AS n FROM coashm.chart_of_accounts');
+    expect(after.n).toBe(before.n);
+  });
+
+  test('commit writes inserts; round-trip via UUIDs reports noops (no PK conflict)', async () => {
+    const buf = await buildWorkbook([
+      blank({ code: '1000', name: 'Cash', type: 'asset', is_active: true, cash_basis: true, status: 'active' }),
+      blank({ code: '4000', name: 'Sales Revenue', type: 'revenue', is_active: true, cash_basis: false, status: 'active' }),
+    ]);
+
+    const commit = await postImport(buf, cookies, 'commit1');
+    if (commit.status !== 201) {
+      throw new Error(`commit returned ${commit.status}: ${JSON.stringify(commit.body)}`);
+    }
+    expect(commit.body.inserted).toBe(2);
+
+    // Re-import with explicit ids — the pg-schemata default (bulkInsert-only)
+    // would PK-conflict here. The shim's id-aware upsert path should classify
+    // both as noops since nothing changed.
+    const persisted = await db.any(
+      `SELECT id, code FROM coashm.chart_of_accounts WHERE code IN ('1000', '4000') ORDER BY code`,
+    );
+    expect(persisted).toHaveLength(2);
+    const cash = persisted.find((r) => r.code === '1000');
+    const sales = persisted.find((r) => r.code === '4000');
+
+    const round = await buildWorkbook([
+      blank({ id: cash.id, code: '1000', name: 'Cash', type: 'asset', is_active: true, cash_basis: true, status: 'active' }),
+      blank({ id: sales.id, code: '4000', name: 'Sales Revenue', type: 'revenue', is_active: true, cash_basis: false, status: 'active' }),
+    ]);
+
+    const previewRes = await postImport(round, cookies, 'roundpreview', { preview: true });
+    expect(previewRes.status).toBe(200);
+    expect(previewRes.body).toMatchObject({ preview: true, inserts: 0, updates: 0, noops: 2, omitted: 0 });
+
+    const commitRes = await postImport(round, cookies, 'roundcommit');
+    expect(commitRes.status).toBe(201);
+    expect(commitRes.body).toMatchObject({ inserted: 0, updated: 0 });
+  });
+
+  test('rename via the same id classifies as update + persists the new name', async () => {
+    const cash = await db.one(`SELECT id, name FROM coashm.chart_of_accounts WHERE code = '1000'`);
+    expect(cash.name).toBe('Cash');
+
+    const buf = await buildWorkbook([
+      blank({ id: cash.id, code: '1000', name: 'Operating Cash', type: 'asset', is_active: true, cash_basis: true, status: 'active' }),
+    ]);
+
+    const preview = await postImport(buf, cookies, 'rename-preview', { preview: true });
+    expect(preview.body.updates).toBe(1);
+
+    const commit = await postImport(buf, cookies, 'rename-commit');
+    expect(commit.body.updated).toBe(1);
+
+    const after = await db.one(`SELECT name FROM coashm.chart_of_accounts WHERE id = $1`, [cash.id]);
+    expect(after.name).toBe('Operating Cash');
+  });
+});

--- a/apps/server/tests/unit/spreadsheetHelpers.test.js
+++ b/apps/server/tests/unit/spreadsheetHelpers.test.js
@@ -437,14 +437,38 @@ describe('diffParent { caseSensitive: true } numeric equivalence', () => {
   });
 
   it('does not coerce a non-numeric string to match a number', () => {
-    const transformed = { code: '1000' };
+    // Exercises the number-vs-string branch: one side must be a number
+    // for the coercion path to fire at all.
+    const transformed = { code: 1000 };
     const existing = { code: 'abc' };
-    expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({ code: '1000' });
+    expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({ code: 1000 });
   });
 
   it('preserves case-sensitive string comparison alongside the numeric fix', () => {
     const transformed = { label: 'Acme' };
     const existing = { label: 'ACME' };
     expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({ label: 'Acme' });
+  });
+});
+
+describe('diffParent { caseSensitive: true } date equivalence', () => {
+  it('treats two Date instances with the same epoch as no diff', () => {
+    const t = Date.UTC(2026, 4, 15);
+    const transformed = { invoice_date: new Date(t) };
+    const existing = { invoice_date: new Date(t) };
+    expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({});
+  });
+
+  it('treats a Date instance equal to its ISO string form as no diff', () => {
+    const iso = '2026-05-15T00:00:00.000Z';
+    const transformed = { invoice_date: iso };
+    const existing = { invoice_date: new Date(iso) };
+    expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({});
+  });
+
+  it('still reports a real date change as a diff', () => {
+    const transformed = { invoice_date: new Date('2026-05-15T00:00:00Z') };
+    const existing = { invoice_date: new Date('2026-05-16T00:00:00Z') };
+    expect(Object.keys(diffParent(transformed, existing, { caseSensitive: true }))).toEqual(['invoice_date']);
   });
 });

--- a/apps/server/tests/unit/spreadsheetHelpers.test.js
+++ b/apps/server/tests/unit/spreadsheetHelpers.test.js
@@ -21,6 +21,7 @@ const {
   parseSheet,
   validateImportGroups,
   checkPortalUserEmailCollisions,
+  diffParent,
 } = await import('../../src/lib/spreadsheetHelpers.js');
 
 describe('getEnumColumns', () => {
@@ -408,5 +409,42 @@ describe('checkPortalUserEmailCollisions', () => {
     const errs = await checkPortalUserEmailCollisions(groups, { sheetName: 'X', entityType: 'client' });
     expect(errs).toEqual([]);
     expect(dbMock.manyOrNone).not.toHaveBeenCalled();
+  });
+});
+
+describe('diffParent { caseSensitive: true } numeric equivalence', () => {
+  // pg-promise returns `numeric(p,s)` and `bigint` columns as strings, but
+  // spreadsheet cells deserialise as JS numbers. Without numeric-aware
+  // equality the simple-table importer would classify every round-trip of
+  // a row with a numeric column (total_amount, contract_amount, etc.) as
+  // an update, even when the value is unchanged.
+  it('treats a JS number equal to its pg numeric-string form as no diff', () => {
+    const transformed = { total_amount: 100.5, label: 'Acme' };
+    const existing = { total_amount: '100.50', label: 'Acme' };
+    expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({});
+  });
+
+  it('treats integer-as-string from pg as equal to JS number', () => {
+    const transformed = { term: 30 };
+    const existing = { term: '30' };
+    expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({});
+  });
+
+  it('still reports a real numeric change as a diff', () => {
+    const transformed = { total_amount: 100.5 };
+    const existing = { total_amount: '99.99' };
+    expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({ total_amount: 100.5 });
+  });
+
+  it('does not coerce a non-numeric string to match a number', () => {
+    const transformed = { code: '1000' };
+    const existing = { code: 'abc' };
+    expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({ code: '1000' });
+  });
+
+  it('preserves case-sensitive string comparison alongside the numeric fix', () => {
+    const transformed = { label: 'Acme' };
+    const existing = { label: 'ACME' };
+    expect(diffParent(transformed, existing, { caseSensitive: true })).toEqual({ label: 'Acme' });
   });
 });


### PR DESCRIPTION
## Summary

- New `importSimpleTable` helper in `spreadsheetHelpers.js`: parses sheet 0, resolves `tenant_id` once, transforms rows via `coerceChildRow` + the controller callback, derives `deactivated_at` from a `status` column, batches UUID lookup, then falls back to a single-column natural unique key (`label` for PaymentTerms, `code` for ChartOfAccounts, etc.) when the UUID lookup misses. That makes re-importing an exported workbook idempotent even when the file's `id` cells are non-UUID (hand-edited) or the UUIDs no longer exist in the target DB (env reset between export and import). Returns `{ preview, inserts, updates, noops, omitted: 0, errors }` for `previewOnly`, `{ inserted, updated }` for commit.
- `PaymentTerms.importFromSpreadsheet` body collapses to a one-line delegation. 15 other user-importable simple-table models (ChartOfAccounts, JournalEntries, CatalogSkus, ApInvoices/CreditMemos/Payments, ArInvoices/Receipts, Activities/Categories/Deliverables/Budgets/ActualCosts, Projects/ChangeOrders) each get the same four-line override and gain idempotent upsert-by-id-or-natural-key for the first time — they used to inherit pg-schemata's `bulkInsert`-only default and would PK-conflict on round-trip.
- 16 entity pages: API client methods accept `{ preview }`, `ImportDialog` mounts get `onPreview`, success toast unified with the VendorsPage pattern (`"<Entity>: X new, Y updated"` or `"Import complete — no changes"`).

## Test plan

- [x] \`npm run lint\`
- [x] \`npm -w apps/server test\` — 690/690 passing across 70 files
- [x] 7 new contract tests in \`tests/contract/paymentTermsImport.test.js\` covering preview, commit, round-trip noop, status archive/restore, case-only edit, non-UUID id natural-key fallback, ghost-UUID natural-key fallback
- [x] 3 new contract tests in \`tests/contract/simpleTableImportShim.test.js\` proving the shim generalises to ChartOfAccounts (no prior override; previously bulkInsert-only)
- [ ] Manual UI smoke on PaymentTermsPage + ChartOfAccountsPage: export → re-import → preview reports noops → commit returns \`{inserted: 0, updated: 0}\` → toast says "Import complete — no changes"
- [ ] CI: Lint + Architecture Check + test-fast + test-integration + Copilot review