### PR TITLE
feat(tenants): import preview + diff-as-DTO updates

### DIFF
--- a/apps/client/src/pages/Tenant/ManageTenantsPage.jsx
+++ b/apps/client/src/pages/Tenant/ManageTenantsPage.jsx
@@ -238,19 +238,18 @@ export default function ManageTenantsPage() {
     setImportErrors(null);
     try {
       const result = await importMut.mutateAsync(formData);
-      const parts = [];
-      if (result.inserted) parts.push(`${result.inserted} created`);
-      if (result.updated) parts.push(`${result.updated} updated`);
-      toast(parts.join(', ') || 'Import complete');
+      const ins = result?.inserted ?? 0;
+      const upd = result?.updated ?? 0;
+      toast(ins + upd === 0 ? 'Import complete — no changes' : `Tenants: ${ins} new, ${upd} updated`);
       importDialog.close();
     } catch (err) {
       const validationErrors = err.payload?.errors;
       if (validationErrors?.length) {
         setImportErrors(validationErrors.map((e) => ({
-          sheet: e.sheet || 'tenants',
-          row: e.row,
-          column: e.tenant_code ? 'tenant_code' : '',
-          value: e.tenant_code || '',
+          sheet: e.sheet || 'Tenants',
+          row: e.row ?? null,
+          column: e.column || '',
+          value: e.value ?? '',
           message: e.message,
         })));
       } else {
@@ -526,6 +525,7 @@ export default function ManageTenantsPage() {
         title="Import Tenants"
         loading={importMut.isPending}
         errors={importErrors}
+        onPreview={(fd) => tenantApi.importXls(fd, { preview: true })}
         onSubmit={handleImport}
         onCancel={() => { importDialog.close(); setImportErrors(null); }}
       />

--- a/apps/client/src/services/tenantApi.js
+++ b/apps/client/src/services/tenantApi.js
@@ -46,8 +46,9 @@ export const tenantApi = {
   /** POST /export-xls — export tenants to flat spreadsheet. */
   exportXls: (body = {}) => client.post(`${BASE}/export-xls`, body, { responseType: 'blob' }),
 
-  /** POST /import-xls — import tenants from flat spreadsheet. */
-  importXls: (formData) => client.post(`${BASE}/import-xls`, formData),
+  /** POST /import-xls — import tenants from flat spreadsheet. Pass `{ preview: true }` for a dry-run. */
+  importXls: (formData, { preview = false } = {}) =>
+    client.post(`${BASE}/import-xls${preview ? '?preview=1' : ''}`, formData),
 };
 
 export default tenantApi;

--- a/apps/server/src/system/auth/models/Tenants.js
+++ b/apps/server/src/system/auth/models/Tenants.js
@@ -53,6 +53,13 @@ function _validatePasswordStrength(pw) {
   return PW_RULES.filter((r) => !r.test(pw)).map((r) => r.msg);
 }
 
+// Postgres error codes: 3F000 = invalid_schema_name, 42P01 = undefined_table.
+// Used to scope the diff-helper try/catch to "tenant schema not provisioned
+// yet" cases — any other DB error must surface.
+function _isSchemaMissing(err) {
+  return err && (err.code === '3F000' || err.code === '42P01');
+}
+
 export default class Tenants extends TableModel {
   constructor(db, pgp, logger = null) {
     super(db, pgp, tenantsSchema, logger);
@@ -412,6 +419,27 @@ export default class Tenants extends TableModel {
       for (const t of tenants) existingById.set(t.id, t);
     }
 
+    // ROOT_TENANT archive protection for UPDATE rows: also resolve by the
+    // persisted tenant_code, since the spreadsheet may identify the row by
+    // `id` alone (with a blank/different tenant_code in the row).
+    for (const c of updateCandidates) {
+      const willArchive = String(c.row.status || '').toLowerCase().trim() === 'archived';
+      if (!willArchive) continue;
+      const existing = existingById.get(c.row.id);
+      if (existing && existing.tenant_code?.toUpperCase() === rootTenantCode) {
+        // Only push if we didn't already record a code-based hit for this row.
+        const already = errors.some(
+          (e) => e.row === c.rowNum && e.column === 'tenant_code' && /Cannot archive the root tenant/.test(e.message),
+        );
+        if (!already) {
+          pushIssue(errors, {
+            sheet: sheetName, row: c.rowNum, column: 'tenant_code', value: existing.tenant_code,
+            message: `Cannot archive the root tenant '${rootTenantCode}'.`,
+          });
+        }
+      }
+    }
+
     // Classification pass. A row is `error` if any error in `errors` references
     // its rowNum. Otherwise: insert / update / noop.
     const errorRows = new Set(errors.map((e) => e.row).filter((r) => r != null));
@@ -439,9 +467,15 @@ export default class Tenants extends TableModel {
       const addressDiff = await this._billingAddressDiff(c.row, existing);
       const taxDiff = await this._taxIdentifierDiff(c.row, existing);
       const phoneDiff = await this._adminPhoneDiff(c.row, existing);
-      const willArchive = String(c.row.status || '').toLowerCase().trim() === 'archived';
+      // Archive transitions only fire when status is *explicitly present and
+      // recognized*. A row that omits `status` leaves archive state untouched —
+      // re-importing a workbook without a status column must not silently
+      // restore archived tenants.
+      const normalizedStatus = c.row.status ? String(c.row.status).toLowerCase().trim() : null;
+      const statusRecognized = normalizedStatus === 'archived' || VALID_STATUSES.has(normalizedStatus);
+      const willArchive = normalizedStatus === 'archived';
       const wasArchived = !!existing.deactivated_at;
-      const archiveChanged = willArchive !== wasArchived;
+      const archiveChanged = statusRecognized && willArchive !== wasArchived;
       const hasAnyChange = Object.keys(tenantDiff).length > 0
         || addressDiff != null
         || taxDiff != null
@@ -499,8 +533,9 @@ export default class Tenants extends TableModel {
         `SELECT source_id FROM ${sch}.companies WHERE code = $1 AND deactivated_at IS NULL LIMIT 1`,
         [existing.tenant_code],
       );
-    } catch {
-      return null; // schema may not exist (failed provision)
+    } catch (err) {
+      if (_isSchemaMissing(err)) return null; // tenant schema not provisioned
+      throw err;
     }
     if (!company?.source_id) return null;
 
@@ -540,8 +575,9 @@ export default class Tenants extends TableModel {
         `SELECT source_id FROM ${sch}.companies WHERE code = $1 AND deactivated_at IS NULL LIMIT 1`,
         [existing.tenant_code],
       );
-    } catch {
-      return null;
+    } catch (err) {
+      if (_isSchemaMissing(err)) return null;
+      throw err;
     }
     if (!company?.source_id) return null;
 
@@ -580,8 +616,9 @@ export default class Tenants extends TableModel {
          WHERE e.is_primary_contact = true AND e.deactivated_at IS NULL
          ORDER BY e.created_at LIMIT 1`,
       );
-    } catch {
-      return null;
+    } catch (err) {
+      if (_isSchemaMissing(err)) return null;
+      throw err;
     }
     if (!adminEmp?.source_id) return null;
 

--- a/apps/server/src/system/auth/models/Tenants.js
+++ b/apps/server/src/system/auth/models/Tenants.js
@@ -3,8 +3,14 @@
  * @module auth/models/Tenants
  *
  * Export flattens each tenant's billing address and primary tax identifier into
- * a single row. Import supports both update (rows with id) and create (rows
- * without id trigger full provisioning via provisionNewTenant).
+ * a single row. Import supports update (rows with id), create (rows without id
+ * trigger full provisioning via provisionNewTenant), and `previewOnly`
+ * classification with full upfront validation:
+ *   - per-row required-field / format / password-strength checks for inserts
+ *   - intra-file duplicate detection (tenant_code, admin_email)
+ *   - cross-table uniqueness checks (admin.tenants + admin.portal_users)
+ *   - ROOT_TENANT archive protection
+ *   - diff-as-DTO updates so round-trip re-imports are true noops
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
@@ -12,7 +18,7 @@
 import { writeFileSync, readFileSync } from 'node:fs';
 import { TableModel } from 'pg-schemata';
 import tenantsSchema from '../schemas/tenantsSchema.js';
-import { parseSheet, isUuid } from '../../../lib/spreadsheetHelpers.js';
+import { parseSheet, isUuid, pushIssue } from '../../../lib/spreadsheetHelpers.js';
 import { provisionNewTenant } from '../../../services/tenantSetup.js';
 
 // ── Column layout for the flat "Tenants" sheet ──────────────────────────────
@@ -23,6 +29,29 @@ const HEADERS = [
   'tax_country_code', 'tax_type', 'tax_value',
   'admin_first_name', 'admin_last_name', 'admin_email', 'admin_password', 'admin_phone',
 ];
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const PW_RULES = [
+  { test: (p) => p.length >= 8, msg: 'at least 8 characters' },
+  { test: (p) => /[A-Z]/.test(p), msg: 'an uppercase letter' },
+  { test: (p) => /[a-z]/.test(p), msg: 'a lowercase letter' },
+  { test: (p) => /[0-9]/.test(p), msg: 'a digit' },
+  { test: (p) => /[^A-Za-z0-9]/.test(p), msg: 'a special character' },
+];
+
+const VALID_STATUSES = new Set(['active', 'trial', 'suspended', 'pending']);
+
+/** Null / undefined / empty-string conflation for change detection. */
+function _eq(a, b) {
+  const na = a == null || a === '' ? null : a;
+  const nb = b == null || b === '' ? null : b;
+  return na === nb;
+}
+
+function _validatePasswordStrength(pw) {
+  return PW_RULES.filter((r) => !r.test(pw)).map((r) => r.msg);
+}
 
 export default class Tenants extends TableModel {
   constructor(db, pgp, logger = null) {
@@ -141,166 +170,520 @@ export default class Tenants extends TableModel {
   /**
    * Import tenants from a flat single-sheet spreadsheet.
    *
-   * Rows with a valid UUID `id` → update tenant metadata + billing address + tax identifier.
+   * Rows with a valid UUID `id` → update tenant metadata + billing address + tax identifier + admin phone.
    * Rows without `id` → full provisioning (requires admin_* columns).
+   *
+   * Pass `{ previewOnly: true }` to receive a classification + validation payload
+   * without any DB writes: `{ preview: true, inserts, updates, noops, omitted: 0, errors }`.
    */
-  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null) {
+  async importFromSpreadsheet(filePath, _sheetIndex = 0, callbackFn = null, _returning = null, { previewOnly = false } = {}) {
     const { WorkbookReader } = await import('@nap-sft/tablsx');
     const buffer = readFileSync(filePath);
     const reader = WorkbookReader.fromBuffer(buffer);
-    const sheetName = reader.sheetNames?.[0] || 'tenants';
+    const sheetName = reader.sheetNames?.[0] || 'Tenants';
     const rows = parseSheet(reader, 0);
-    if (!rows.length) return { inserted: 0, updated: 0 };
+
+    if (!rows.length) {
+      return previewOnly
+        ? { preview: true, inserts: 0, updates: 0, noops: 0, omitted: 0, errors: [] }
+        : { inserted: 0, updated: 0 };
+    }
 
     const actorId = callbackFn ? (await callbackFn({})).created_by || null : null;
 
+    const { classified, errors } = await this._classifyAndValidateRows(rows, sheetName);
+
+    let inserts = 0;
+    let updates = 0;
+    let noops = 0;
+    for (const c of classified) {
+      if (c.action === 'insert') inserts++;
+      else if (c.action === 'update') updates++;
+      else if (c.action === 'noop') noops++;
+    }
+
+    if (previewOnly) {
+      return { preview: true, inserts, updates, noops, omitted: 0, errors };
+    }
+
+    // Errors are blocking — surface them before any provisioning writes.
+    if (errors.length) return { errors };
+
+    // Commit pass: per-row create or update. Errors here are surfaced per row
+    // but earlier rows that succeeded remain provisioned (no cross-row tx —
+    // pg schema creation is DDL that can't roll back cleanly).
     let inserted = 0;
     let updated = 0;
-    const errors = [];
-
-    for (let i = 0; i < rows.length; i++) {
-      const row = rows[i];
+    const commitErrors = [];
+    for (const c of classified) {
+      if (c.action !== 'insert' && c.action !== 'update') continue;
       try {
-        if (isUuid(row.id)) {
-          await this._updateTenantRow(row, actorId);
-          updated++;
-        } else {
-          await this._createTenantRow(row, actorId);
+        if (c.action === 'insert') {
+          await this._createTenantRow(c.row, actorId);
           inserted++;
+        } else {
+          await this._updateTenantRow(c.row, actorId, c.existing, c.diffs);
+          updated++;
         }
       } catch (err) {
-        errors.push({ sheet: sheetName, row: row._rowNum || i + 2, tenant_code: row.tenant_code || '', message: err.message });
+        pushIssue(commitErrors, {
+          sheet: sheetName,
+          row: c.rowNum,
+          column: null,
+          value: c.row.tenant_code || '',
+          message: err.message,
+        });
       }
     }
 
-    return { inserted, updated, ...(errors.length ? { errors } : {}) };
+    if (commitErrors.length) return { errors: commitErrors };
+    return { inserted, updated };
   }
 
-  // ── Private helpers ────────────────────────────────────────────────────────
+  // ── Phase 1: classify + validate ───────────────────────────────────────────
 
   /**
-   * Update an existing tenant's metadata, billing address, and tax identifier.
+   * Per-row validation, intra-file duplicate detection, batched cross-table
+   * uniqueness checks, and noop classification (with cross-schema diffs).
+   * Pure read; no writes. Returns `{ classified, errors }`.
    */
-  async _updateTenantRow(row, actorId) {
-    const tenant = await this.findById(row.id);
-    if (!tenant) throw new Error(`Tenant id ${row.id} not found`);
+  async _classifyAndValidateRows(rows, sheetName) {
+    const rootTenantCode = (process.env.ROOT_TENANT_CODE || 'AXERRA').toUpperCase();
+    const errors = [];
 
-    // Update tenant metadata
-    const VALID_STATUSES = new Set(['active', 'trial', 'suspended', 'pending', 'archived']);
-    const normalizedStatus = row.status ? String(row.status).toLowerCase().trim() : null;
+    // Intra-file dup tracking (case-insensitive).
+    const seenTenantCodeAt = new Map();
+    const seenEmailAt = new Map();
+
+    // First pass: per-row validation + dup detection. Capture context so the
+    // batched DB lookups + classification have everything they need.
+    const candidates = [];
+    for (const row of rows) {
+      const rowNum = row._rowNum || null;
+      const isInsert = !isUuid(row.id);
+      const tcRaw = (row.tenant_code || '').toString().trim();
+      const tcUpper = tcRaw.toUpperCase();
+      const emailRaw = (row.admin_email || '').toString().trim().toLowerCase();
+
+      // ROOT_TENANT archive protection (applies to insert AND update).
+      const willArchive = String(row.status || '').toLowerCase().trim() === 'archived';
+      if (willArchive && tcUpper === rootTenantCode) {
+        pushIssue(errors, {
+          sheet: sheetName, row: rowNum, column: 'tenant_code', value: tcRaw,
+          message: `Cannot archive the root tenant '${rootTenantCode}'.`,
+        });
+      }
+
+      // Intra-file dups (case-insensitive).
+      if (tcUpper) {
+        if (seenTenantCodeAt.has(tcUpper)) {
+          pushIssue(errors, {
+            sheet: sheetName, row: rowNum, column: 'tenant_code', value: tcRaw,
+            message: `Duplicate tenant_code '${tcRaw}' in file (also at row ${seenTenantCodeAt.get(tcUpper)})`,
+          });
+        } else {
+          seenTenantCodeAt.set(tcUpper, rowNum);
+        }
+      }
+      if (emailRaw) {
+        if (seenEmailAt.has(emailRaw)) {
+          pushIssue(errors, {
+            sheet: sheetName, row: rowNum, column: 'admin_email', value: row.admin_email,
+            message: `Duplicate admin_email '${row.admin_email}' in file (also at row ${seenEmailAt.get(emailRaw)})`,
+          });
+        } else {
+          seenEmailAt.set(emailRaw, rowNum);
+        }
+      }
+
+      // Insert-specific validation.
+      if (isInsert) {
+        const required = [
+          ['tenant_code', tcRaw],
+          ['company', row.company],
+          ['admin_first_name', row.admin_first_name],
+          ['admin_last_name', row.admin_last_name],
+          ['admin_email', row.admin_email],
+          ['admin_password', row.admin_password],
+          ['address_line_1', row.address_line_1],
+          ['country_code', row.country_code],
+        ];
+        for (const [col, val] of required) {
+          if (!val) {
+            pushIssue(errors, {
+              sheet: sheetName, row: rowNum, column: col, value: '',
+              message: `${col} is required for new tenants`,
+            });
+          }
+        }
+        if (tcRaw && tcRaw.length > 6) {
+          pushIssue(errors, {
+            sheet: sheetName, row: rowNum, column: 'tenant_code', value: tcRaw,
+            message: 'tenant_code must be 6 characters or fewer',
+          });
+        }
+        if (row.admin_email && !EMAIL_RE.test(row.admin_email)) {
+          pushIssue(errors, {
+            sheet: sheetName, row: rowNum, column: 'admin_email', value: row.admin_email,
+            message: 'admin_email is not a valid email address',
+          });
+        }
+        if (row.admin_password) {
+          const failures = _validatePasswordStrength(String(row.admin_password));
+          if (failures.length) {
+            pushIssue(errors, {
+              sheet: sheetName, row: rowNum, column: 'admin_password', value: '',
+              message: `admin_password must contain ${failures.join(', ')}`,
+            });
+          }
+        }
+      }
+
+      candidates.push({ rowNum, row, isInsert, tcUpper, emailRaw });
+    }
+
+    // Batched cross-table uniqueness checks for inserts.
+    const inserts = candidates.filter((c) => c.isInsert);
+    if (inserts.length) {
+      const tcs = [...new Set(inserts.map((c) => c.tcUpper).filter(Boolean))];
+      const companies = [...new Set(inserts.map((c) => c.row.company).filter(Boolean))];
+      const schemaNames = [...new Set(tcs.map((tc) => tc.toLowerCase()))];
+      const emails = [...new Set(inserts.map((c) => c.emailRaw).filter(Boolean))];
+
+      const existingTRows = (tcs.length || companies.length || schemaNames.length)
+        ? await this.db.any(
+            `SELECT tenant_code, company, schema_name FROM admin.tenants
+             WHERE UPPER(tenant_code) = ANY($1::text[])
+                OR company = ANY($2::text[])
+                OR schema_name = ANY($3::text[])`,
+            [tcs, companies, schemaNames],
+          )
+        : [];
+      const existingTcSet = new Set(existingTRows.map((r) => r.tenant_code.toUpperCase()));
+      const existingCoSet = new Set(existingTRows.map((r) => r.company));
+      const existingSnSet = new Set(existingTRows.map((r) => r.schema_name));
+
+      const existingEmailRows = emails.length
+        ? await this.db.any(
+            `SELECT email FROM admin.portal_users WHERE LOWER(email) = ANY($1::text[])`,
+            [emails],
+          )
+        : [];
+      const existingEmailSet = new Set(existingEmailRows.map((r) => r.email.toLowerCase()));
+
+      for (const c of inserts) {
+        if (c.tcUpper && existingTcSet.has(c.tcUpper)) {
+          pushIssue(errors, {
+            sheet: sheetName, row: c.rowNum, column: 'tenant_code', value: c.row.tenant_code,
+            message: `tenant_code '${c.row.tenant_code}' already exists`,
+          });
+        }
+        if (c.row.company && existingCoSet.has(c.row.company)) {
+          pushIssue(errors, {
+            sheet: sheetName, row: c.rowNum, column: 'company', value: c.row.company,
+            message: `company '${c.row.company}' already exists`,
+          });
+        }
+        const derivedSn = c.tcUpper ? c.tcUpper.toLowerCase() : null;
+        if (derivedSn && existingSnSet.has(derivedSn)) {
+          pushIssue(errors, {
+            sheet: sheetName, row: c.rowNum, column: 'tenant_code', value: c.row.tenant_code,
+            message: `schema_name '${derivedSn}' already exists (derived from tenant_code)`,
+          });
+        }
+        if (c.emailRaw && existingEmailSet.has(c.emailRaw)) {
+          pushIssue(errors, {
+            sheet: sheetName, row: c.rowNum, column: 'admin_email', value: c.row.admin_email,
+            message: `admin_email '${c.row.admin_email}' already exists in admin.portal_users`,
+          });
+        }
+      }
+    }
+
+    // Pre-load existing tenant rows for the UPDATE candidates.
+    const updateCandidates = candidates.filter((c) => !c.isInsert);
+    const existingById = new Map();
+    if (updateCandidates.length) {
+      const ids = updateCandidates.map((c) => c.row.id);
+      const tenants = await this.db.any(
+        `SELECT * FROM admin.tenants WHERE id = ANY($1::uuid[])`,
+        [ids],
+      );
+      for (const t of tenants) existingById.set(t.id, t);
+    }
+
+    // Classification pass. A row is `error` if any error in `errors` references
+    // its rowNum. Otherwise: insert / update / noop.
+    const errorRows = new Set(errors.map((e) => e.row).filter((r) => r != null));
+    const classified = [];
+    for (const c of candidates) {
+      if (errorRows.has(c.rowNum)) {
+        classified.push({ rowNum: c.rowNum, row: c.row, action: 'error' });
+        continue;
+      }
+      if (c.isInsert) {
+        classified.push({ rowNum: c.rowNum, row: c.row, action: 'insert' });
+        continue;
+      }
+      const existing = existingById.get(c.row.id);
+      if (!existing) {
+        pushIssue(errors, {
+          sheet: sheetName, row: c.rowNum, column: 'id', value: c.row.id,
+          message: `Tenant id '${c.row.id}' not found`,
+        });
+        classified.push({ rowNum: c.rowNum, row: c.row, action: 'error' });
+        continue;
+      }
+      // Compute diffs across the four data surfaces for noop classification.
+      const tenantDiff = this._tenantMetadataDiff(c.row, existing);
+      const addressDiff = await this._billingAddressDiff(c.row, existing);
+      const taxDiff = await this._taxIdentifierDiff(c.row, existing);
+      const phoneDiff = await this._adminPhoneDiff(c.row, existing);
+      const willArchive = String(c.row.status || '').toLowerCase().trim() === 'archived';
+      const wasArchived = !!existing.deactivated_at;
+      const archiveChanged = willArchive !== wasArchived;
+      const hasAnyChange = Object.keys(tenantDiff).length > 0
+        || addressDiff != null
+        || taxDiff != null
+        || phoneDiff != null
+        || archiveChanged;
+      classified.push({
+        rowNum: c.rowNum,
+        row: c.row,
+        existing,
+        diffs: { tenantDiff, addressDiff, taxDiff, phoneDiff, archiveChanged, willArchive },
+        action: hasAnyChange ? 'update' : 'noop',
+      });
+    }
+
+    return { classified, errors };
+  }
+
+  // ── Diff helpers (used for noop classification AND diff-as-DTO writes) ────
+
+  /** Compare row-provided tenant metadata fields against the existing row. */
+  _tenantMetadataDiff(row, existing) {
     const changes = {};
-    if (row.company) changes.company = row.company;
-    if (normalizedStatus && VALID_STATUSES.has(normalizedStatus) && normalizedStatus !== 'archived') changes.status = normalizedStatus;
-    if (row.tier) changes.tier = row.tier;
-    if ('region' in row) changes.region = row.region || null;
-    if (row.max_users != null) {
+    if (row.company && !_eq(row.company, existing.company)) changes.company = row.company;
+    const normalizedStatus = row.status ? String(row.status).toLowerCase().trim() : null;
+    if (
+      normalizedStatus
+      && VALID_STATUSES.has(normalizedStatus)
+      && !_eq(normalizedStatus, existing.status)
+    ) {
+      changes.status = normalizedStatus;
+    }
+    if (row.tier && !_eq(row.tier, existing.tier)) changes.tier = row.tier;
+    if ('region' in row && !_eq(row.region || null, existing.region)) changes.region = row.region || null;
+    if (row.max_users != null && row.max_users !== '') {
       const parsed = parseInt(row.max_users, 10);
-      if (Number.isFinite(parsed)) changes.max_users = parsed;
+      if (Number.isFinite(parsed) && parsed !== existing.max_users) changes.max_users = parsed;
     }
-    if ('notes' in row) changes.notes = row.notes || null;
-    if (actorId) changes.updated_by = actorId;
+    if ('notes' in row && !_eq(row.notes || null, existing.notes)) changes.notes = row.notes || null;
+    return changes;
+  }
 
-    if (Object.keys(changes).length) {
-      await this.updateWhere([{ id: row.id }], changes, { includeDeactivated: true });
+  /**
+   * Diff the row's billing address against the existing one. Returns:
+   *   - null if the row doesn't intend to write an address (no address_line_1) OR matches the existing.
+   *   - { action: 'insert', sourceId, fields } if there's no current address.
+   *   - { action: 'update', id, changes } if some fields differ.
+   *   - null if the company source doesn't exist yet (can't address it).
+   */
+  async _billingAddressDiff(row, existing) {
+    if (!row.address_line_1) return null;
+    const sch = this.pgp.as.name(existing.schema_name);
+    let company;
+    try {
+      company = await this.db.oneOrNone(
+        `SELECT source_id FROM ${sch}.companies WHERE code = $1 AND deactivated_at IS NULL LIMIT 1`,
+        [existing.tenant_code],
+      );
+    } catch {
+      return null; // schema may not exist (failed provision)
     }
+    if (!company?.source_id) return null;
 
-    // Handle archive/restore via status column
-    if (normalizedStatus === 'archived' && !tenant.deactivated_at) {
-      await this.db.none('UPDATE admin.tenants SET deactivated_at = NOW() WHERE id = $1', [row.id]);
-    } else if (normalizedStatus && normalizedStatus !== 'archived' && tenant.deactivated_at) {
-      await this.db.none('UPDATE admin.tenants SET deactivated_at = NULL WHERE id = $1', [row.id]);
-    }
-
-    // Cross-schema upsert billing address + tax identifier
-    const sch = this.pgp.as.name(tenant.schema_name);
-    const company = await this.db.oneOrNone(
-      `SELECT source_id FROM ${sch}.companies WHERE code = $1 AND deactivated_at IS NULL LIMIT 1`,
-      [tenant.tenant_code],
+    const current = await this.db.oneOrNone(
+      `SELECT id, address_line_1, address_line_2, address_line_3, city, state_province, postal_code, country_code
+       FROM ${sch}.addresses WHERE source_id = $1 AND label = 'billing' AND deactivated_at IS NULL LIMIT 1`,
+      [company.source_id],
     );
-    if (!company?.source_id) return;
-    const sourceId = company.source_id;
 
-    // Upsert billing address
-    if (row.address_line_1) {
-      const existing = await this.db.oneOrNone(
-        `SELECT id FROM ${sch}.addresses WHERE source_id = $1 AND label = 'billing' AND deactivated_at IS NULL LIMIT 1`,
-        [sourceId],
-      );
-      const addrFields = {
-        address_line_1: row.address_line_1,
-        address_line_2: row.address_line_2 || null,
-        address_line_3: row.address_line_3 || null,
-        city: row.city || null,
-        state_province: row.state_province || null,
-        postal_code: row.postal_code || null,
-        country_code: row.country_code || null,
-        updated_by: actorId,
-      };
-      if (existing) {
-        await this.db.none(
-          `UPDATE ${sch}.addresses SET address_line_1=$1, address_line_2=$2, address_line_3=$3,
-           city=$4, state_province=$5, postal_code=$6, country_code=$7, updated_by=$8
-           WHERE id = $9`,
-          [...Object.values(addrFields), existing.id],
-        );
-      } else {
-        await this.db.none(
-          `INSERT INTO ${sch}.addresses (tenant_id, source_id, label, address_line_1, address_line_2, address_line_3,
-           city, state_province, postal_code, country_code, created_by)
-           VALUES ((SELECT id FROM admin.tenants WHERE schema_name = $1), $2, 'billing', $3, $4, $5, $6, $7, $8, $9, $10)`,
-          [tenant.schema_name, sourceId, row.address_line_1, row.address_line_2 || null, row.address_line_3 || null,
-            row.city || null, row.state_province || null, row.postal_code || null, row.country_code || null, actorId],
-        );
-      }
+    const desired = {
+      address_line_1: row.address_line_1,
+      address_line_2: row.address_line_2 || null,
+      address_line_3: row.address_line_3 || null,
+      city: row.city || null,
+      state_province: row.state_province || null,
+      postal_code: row.postal_code || null,
+      country_code: row.country_code || null,
+    };
+
+    if (!current) return { action: 'insert', sourceId: company.source_id, fields: desired };
+
+    const changes = {};
+    for (const [k, v] of Object.entries(desired)) {
+      if (!_eq(v, current[k])) changes[k] = v;
     }
+    if (Object.keys(changes).length === 0) return null;
+    return { action: 'update', id: current.id, changes };
+  }
 
-    // Upsert tax identifier
-    if (row.tax_type && row.tax_value) {
-      const existing = await this.db.oneOrNone(
-        `SELECT id FROM ${sch}.tax_identifiers WHERE source_id = $1 AND deactivated_at IS NULL LIMIT 1`,
-        [sourceId],
+  /** Same shape as the address diff, against the primary tax identifier. */
+  async _taxIdentifierDiff(row, existing) {
+    if (!row.tax_type || !row.tax_value) return null;
+    const sch = this.pgp.as.name(existing.schema_name);
+    let company;
+    try {
+      company = await this.db.oneOrNone(
+        `SELECT source_id FROM ${sch}.companies WHERE code = $1 AND deactivated_at IS NULL LIMIT 1`,
+        [existing.tenant_code],
       );
-      if (existing) {
-        await this.db.none(
-          `UPDATE ${sch}.tax_identifiers SET country_code=$1, tax_type=$2, tax_value=$3, updated_by=$4 WHERE id = $5`,
-          [row.tax_country_code || row.country_code || null, row.tax_type, row.tax_value, actorId, existing.id],
-        );
-      } else {
-        await this.db.none(
-          `INSERT INTO ${sch}.tax_identifiers (tenant_id, source_id, country_code, tax_type, tax_value, created_by)
-           VALUES ((SELECT id FROM admin.tenants WHERE schema_name = $1), $2, $3, $4, $5, $6)`,
-          [tenant.schema_name, sourceId, row.tax_country_code || row.country_code || null, row.tax_type, row.tax_value, actorId],
-        );
-      }
+    } catch {
+      return null;
     }
+    if (!company?.source_id) return null;
 
-    // Upsert admin phone number
-    if (row.admin_phone) {
-      const adminEmp = await this.db.oneOrNone(
+    const current = await this.db.oneOrNone(
+      `SELECT id, country_code, tax_type, tax_value FROM ${sch}.tax_identifiers
+       WHERE source_id = $1 AND deactivated_at IS NULL LIMIT 1`,
+      [company.source_id],
+    );
+
+    const desired = {
+      country_code: row.tax_country_code || row.country_code || null,
+      tax_type: row.tax_type,
+      tax_value: row.tax_value,
+    };
+
+    if (!current) return { action: 'insert', sourceId: company.source_id, fields: desired };
+
+    const changes = {};
+    for (const [k, v] of Object.entries(desired)) {
+      if (!_eq(v, current[k])) changes[k] = v;
+    }
+    if (Object.keys(changes).length === 0) return null;
+    return { action: 'update', id: current.id, changes };
+  }
+
+  /** Diff the row's `admin_phone` against the primary contact's primary phone. */
+  async _adminPhoneDiff(row, existing) {
+    if (!row.admin_phone) return null;
+    const sch = this.pgp.as.name(existing.schema_name);
+    let adminEmp;
+    try {
+      adminEmp = await this.db.oneOrNone(
         `SELECT s.id AS source_id
          FROM ${sch}.employees e
          JOIN ${sch}.sources s ON s.table_id = e.id AND s.source_type = 'employee' AND s.deactivated_at IS NULL
          WHERE e.is_primary_contact = true AND e.deactivated_at IS NULL
          ORDER BY e.created_at LIMIT 1`,
       );
-      if (adminEmp?.source_id) {
-        const existingPhone = await this.db.oneOrNone(
-          `SELECT id FROM ${sch}.phone_numbers WHERE source_id = $1 AND deactivated_at IS NULL
-           ORDER BY is_primary DESC, created_at LIMIT 1`,
-          [adminEmp.source_id],
+    } catch {
+      return null;
+    }
+    if (!adminEmp?.source_id) return null;
+
+    const current = await this.db.oneOrNone(
+      `SELECT id, phone_number FROM ${sch}.phone_numbers
+       WHERE source_id = $1 AND deactivated_at IS NULL
+       ORDER BY is_primary DESC, created_at LIMIT 1`,
+      [adminEmp.source_id],
+    );
+
+    if (!current) return { action: 'insert', sourceId: adminEmp.source_id, phone_number: row.admin_phone };
+    if (_eq(row.admin_phone, current.phone_number)) return null;
+    return { action: 'update', id: current.id, phone_number: row.admin_phone };
+  }
+
+  // ── Phase 2: commit ────────────────────────────────────────────────────────
+
+  /**
+   * Apply the precomputed diffs to an existing tenant. Writes only the fields
+   * that changed (diff-as-DTO) plus an explicit archive transition when
+   * required. No-op if every diff is empty (won't be called in that case —
+   * classification already routes those rows to `noop`).
+   */
+  async _updateTenantRow(row, actorId, tenant, diffs) {
+    const { tenantDiff, addressDiff, taxDiff, phoneDiff, archiveChanged, willArchive } = diffs;
+
+    // Tenant-metadata UPDATE (only when fields actually differ).
+    if (Object.keys(tenantDiff).length) {
+      const changes = { ...tenantDiff };
+      if (actorId) changes.updated_by = actorId;
+      await this.updateWhere([{ id: row.id }], changes, { includeDeactivated: true });
+    } else if (actorId) {
+      // Pure address/tax/phone change. Still bump updated_by so the audit
+      // trail reflects who touched the tenant via this import.
+      await this.updateWhere([{ id: row.id }], { updated_by: actorId }, { includeDeactivated: true });
+    }
+
+    // Archive transition via direct SQL (mirrors the original handler's pattern).
+    if (archiveChanged) {
+      if (willArchive) {
+        await this.db.none('UPDATE admin.tenants SET deactivated_at = NOW() WHERE id = $1', [row.id]);
+      } else {
+        await this.db.none('UPDATE admin.tenants SET deactivated_at = NULL WHERE id = $1', [row.id]);
+      }
+    }
+
+    const sch = this.pgp.as.name(tenant.schema_name);
+
+    if (addressDiff) {
+      if (addressDiff.action === 'update') {
+        const cols = Object.keys(addressDiff.changes);
+        const setClause = cols.map((c, i) => `${c} = $${i + 1}`).join(', ');
+        const values = cols.map((c) => addressDiff.changes[c]);
+        values.push(actorId, addressDiff.id);
+        await this.db.none(
+          `UPDATE ${sch}.addresses SET ${setClause}, updated_by = $${values.length - 1} WHERE id = $${values.length}`,
+          values,
         );
-        if (existingPhone) {
-          await this.db.none(
-            `UPDATE ${sch}.phone_numbers SET phone_number = $1, updated_by = $2 WHERE id = $3`,
-            [row.admin_phone, actorId, existingPhone.id],
-          );
-        } else {
-          await this.db.none(
-            `INSERT INTO ${sch}.phone_numbers (tenant_id, source_id, phone_number, phone_type, is_primary, created_by)
-             VALUES ($1, $2, $3, 'work', true, $4)`,
-            [tenant.id, adminEmp.source_id, row.admin_phone, actorId],
-          );
-        }
+      } else {
+        const f = addressDiff.fields;
+        await this.db.none(
+          `INSERT INTO ${sch}.addresses (tenant_id, source_id, label, address_line_1, address_line_2, address_line_3,
+           city, state_province, postal_code, country_code, created_by)
+           VALUES ((SELECT id FROM admin.tenants WHERE schema_name = $1), $2, 'billing', $3, $4, $5, $6, $7, $8, $9, $10)`,
+          [tenant.schema_name, addressDiff.sourceId, f.address_line_1, f.address_line_2, f.address_line_3,
+           f.city, f.state_province, f.postal_code, f.country_code, actorId],
+        );
+      }
+    }
+
+    if (taxDiff) {
+      if (taxDiff.action === 'update') {
+        const cols = Object.keys(taxDiff.changes);
+        const setClause = cols.map((c, i) => `${c} = $${i + 1}`).join(', ');
+        const values = cols.map((c) => taxDiff.changes[c]);
+        values.push(actorId, taxDiff.id);
+        await this.db.none(
+          `UPDATE ${sch}.tax_identifiers SET ${setClause}, updated_by = $${values.length - 1} WHERE id = $${values.length}`,
+          values,
+        );
+      } else {
+        const f = taxDiff.fields;
+        await this.db.none(
+          `INSERT INTO ${sch}.tax_identifiers (tenant_id, source_id, country_code, tax_type, tax_value, created_by)
+           VALUES ((SELECT id FROM admin.tenants WHERE schema_name = $1), $2, $3, $4, $5, $6)`,
+          [tenant.schema_name, taxDiff.sourceId, f.country_code, f.tax_type, f.tax_value, actorId],
+        );
+      }
+    }
+
+    if (phoneDiff) {
+      if (phoneDiff.action === 'update') {
+        await this.db.none(
+          `UPDATE ${sch}.phone_numbers SET phone_number = $1, updated_by = $2 WHERE id = $3`,
+          [phoneDiff.phone_number, actorId, phoneDiff.id],
+        );
+      } else {
+        await this.db.none(
+          `INSERT INTO ${sch}.phone_numbers (tenant_id, source_id, phone_number, phone_type, is_primary, created_by)
+           VALUES ($1, $2, $3, 'work', true, $4)`,
+          [tenant.id, phoneDiff.sourceId, phoneDiff.phone_number, actorId],
+        );
       }
     }
   }
@@ -309,13 +692,6 @@ export default class Tenants extends TableModel {
    * Create a new tenant from a flat row via full provisioning.
    */
   async _createTenantRow(row, actorId) {
-    if (!row.admin_first_name || !row.admin_last_name) {
-      throw new Error('admin_first_name and admin_last_name are required for new tenants');
-    }
-    if (!row.admin_email || !row.admin_password) {
-      throw new Error('admin_email and admin_password are required for new tenants');
-    }
-
     const billingAddress = {
       address_line_1: row.address_line_1,
       address_line_2: row.address_line_2 || null,

--- a/apps/server/src/system/tenants/controllers/tenantsController.js
+++ b/apps/server/src/system/tenants/controllers/tenantsController.js
@@ -54,16 +54,26 @@ class TenantsController extends BaseController {
    *
    * Overrides BaseController.importXls to pass only created_by in the callback
    * (each row carries its own tenant_code, unlike tenant-scoped entities).
+   *
+   * Pass `?preview=1` to receive a classification + validation payload without
+   * any DB writes.
    */
   async importXls(req, res) {
     const file = req.file;
     if (!file) return res.status(400).json({ error: 'No file uploaded' });
 
+    const previewOnly = req.query.preview === '1' || req.query.preview === 'true';
+
     try {
       const result = await this.model('admin').importFromSpreadsheet(
-        file.path, 0, (row) => ({ ...row, created_by: req.user?.id }),
+        file.path,
+        0,
+        (row) => ({ ...row, created_by: req.user?.id }),
+        null,
+        { previewOnly },
       );
       if (result.errors?.length) return res.status(422).json(result);
+      if (result.preview) return res.status(200).json(result);
       res.status(201).json(result);
     } catch (err) {
       this.handleError(err, res, 'importing', this.errorLabel);

--- a/apps/server/tests/contract/tenantsImport.test.js
+++ b/apps/server/tests/contract/tenantsImport.test.js
@@ -1,0 +1,227 @@
+/**
+ * @file Contract tests for tenants import preview + commit (item 7)
+ * @module tests/contract/tenantsImport
+ *
+ * Behavior locked in:
+ *   - `?preview=1` returns counts + accumulated errors without any DB writes.
+ *   - Preview surfaces: missing required fields, malformed admin_email,
+ *     weak admin_password, intra-file dup tenant_code / admin_email,
+ *     existing tenant_code in admin.tenants, existing admin_email in
+ *     admin.portal_users, ROOT_TENANT archive attempt.
+ *   - Commit on a clean workbook actually provisions the tenant (schema
+ *     created, admin portal_user binding exists). A round-trip re-import
+ *     then classifies as all noops with no DB churn.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+const ROOT_TENANT_CODE = (process.env.ROOT_TENANT_CODE || 'AXERRA').toUpperCase();
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+const HEADERS = [
+  'id', 'tenant_code', 'company', 'status', 'tier', 'region', 'max_users', 'notes',
+  'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code',
+  'tax_country_code', 'tax_type', 'tax_value',
+  'admin_first_name', 'admin_last_name', 'admin_email', 'admin_password', 'admin_phone',
+];
+
+function blank(extras = {}) {
+  return Object.fromEntries(HEADERS.map((h) => [h, extras[h] ?? '']));
+}
+
+function goodInsertRow(overrides = {}) {
+  return blank({
+    tenant_code: 'TIMP01',
+    company: 'Tenant Import 01 LLC',
+    status: 'active',
+    tier: 'starter',
+    address_line_1: '1 Import St',
+    country_code: 'US',
+    admin_first_name: 'Imp',
+    admin_last_name: 'Admin',
+    admin_email: 'admin@timp01.test',
+    admin_password: 'StrongPw123!',
+    ...overrides,
+  });
+}
+
+async function buildWorkbook(rows) {
+  const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+  const wb = WorkbookBuilder.create();
+  wb.sheet('Tenants').setHeaders(HEADERS).addObjects(rows);
+  return writeXlsx(wb.build());
+}
+
+async function postImport(buf, cookies, label, { preview = false } = {}) {
+  const tmpPath = join(tmpdir(), `tenants-${label}-${Date.now()}.xlsx`);
+  writeFileSync(tmpPath, buf);
+  const url = `/api/tenants/v1/tenants/import-xls${preview ? '?preview=1' : ''}`;
+  try {
+    return await request(app).post(url).set('Cookie', cookies).attach('file', tmpPath);
+  } finally {
+    unlinkSync(tmpPath);
+  }
+}
+
+describe('Tenants import — preview + commit (item 7)', () => {
+  let cookies;
+
+  beforeAll(async () => {
+    cookies = await loginRoot();
+  }, 30000);
+
+  test('preview returns counts without writing anything to admin.tenants', async () => {
+    const before = await db.one(`SELECT count(*)::int AS n FROM admin.tenants`);
+
+    const buf = await buildWorkbook([goodInsertRow()]);
+
+    const res = await postImport(buf, cookies, 'preview-clean', { preview: true });
+    expect(res.status).toBe(200);
+    expect(res.body.preview).toBe(true);
+    expect(res.body.errors).toEqual([]);
+    expect(res.body.inserts).toBe(1);
+    expect(res.body.updates).toBe(0);
+    expect(res.body.noops).toBe(0);
+
+    const after = await db.one(`SELECT count(*)::int AS n FROM admin.tenants`);
+    expect(after.n).toBe(before.n);
+  });
+
+  test('preview surfaces missing required fields, bad email, weak password', async () => {
+    const buf = await buildWorkbook([
+      blank({ tenant_code: 'TIMP02' }), // missing company, admin_*, address_line_1, country_code
+      goodInsertRow({ tenant_code: 'TIMP03', admin_email: 'not-an-email' }),
+      goodInsertRow({ tenant_code: 'TIMP04', admin_email: 'admin@timp04.test', admin_password: 'weak' }),
+    ]);
+
+    const res = await postImport(buf, cookies, 'preview-bad', { preview: true });
+    expect(res.status).toBe(422);
+    expect(res.body.preview).toBe(true);
+    const cols = res.body.errors.map((e) => e.column);
+    expect(cols).toEqual(expect.arrayContaining(['company', 'admin_first_name', 'admin_email', 'admin_password', 'address_line_1', 'country_code']));
+    expect(res.body.errors.some((e) => e.column === 'admin_email' && /not a valid email/.test(e.message))).toBe(true);
+    expect(res.body.errors.some((e) => e.column === 'admin_password' && /at least 8 characters/.test(e.message))).toBe(true);
+  });
+
+  test('preview catches intra-file duplicate tenant_code and admin_email', async () => {
+    const buf = await buildWorkbook([
+      goodInsertRow({ tenant_code: 'TIMPDP', admin_email: 'dup@timpdp.test' }),
+      goodInsertRow({ tenant_code: 'TIMPDP', company: 'Other Co LLC', admin_email: 'other@timpdp.test' }),
+      goodInsertRow({ tenant_code: 'TIMPDQ', company: 'Third Co LLC', admin_email: 'dup@timpdp.test' }),
+    ]);
+
+    const res = await postImport(buf, cookies, 'preview-dup', { preview: true });
+    expect(res.status).toBe(422);
+    expect(res.body.errors.some((e) => e.column === 'tenant_code' && /Duplicate tenant_code/.test(e.message))).toBe(true);
+    expect(res.body.errors.some((e) => e.column === 'admin_email' && /Duplicate admin_email/.test(e.message))).toBe(true);
+  });
+
+  test('preview catches a tenant_code that already exists in admin.tenants', async () => {
+    const buf = await buildWorkbook([
+      goodInsertRow({ tenant_code: ROOT_TENANT_CODE, company: 'Should Collide', admin_email: 'collide@root.test' }),
+    ]);
+
+    const res = await postImport(buf, cookies, 'preview-existing-tc', { preview: true });
+    expect(res.status).toBe(422);
+    expect(res.body.errors.some((e) => e.column === 'tenant_code' && /already exists/.test(e.message))).toBe(true);
+  });
+
+  test('preview blocks an attempt to archive the root tenant', async () => {
+    const rootRow = await db.one(`SELECT id FROM admin.tenants WHERE tenant_code = $1`, [ROOT_TENANT_CODE]);
+    const buf = await buildWorkbook([
+      blank({ id: rootRow.id, tenant_code: ROOT_TENANT_CODE, company: 'Axerra, LLC', status: 'archived', tier: 'enterprise' }),
+    ]);
+
+    const res = await postImport(buf, cookies, 'preview-root-archive', { preview: true });
+    expect(res.status).toBe(422);
+    expect(res.body.errors.some((e) => /Cannot archive the root tenant/.test(e.message))).toBe(true);
+  });
+
+  test('commit provisions a new tenant; re-import is reported as all noops with no DB churn', async () => {
+    const insertRow = goodInsertRow({
+      tenant_code: 'TIMPRT',
+      company: 'Tenant Import Round-Trip LLC',
+      admin_email: 'admin@timprt.test',
+    });
+    const buf = await buildWorkbook([insertRow]);
+
+    const commit = await postImport(buf, cookies, 'rt-commit');
+    if (commit.status !== 201) {
+      throw new Error(`commit returned ${commit.status}: ${JSON.stringify(commit.body)}`);
+    }
+    expect(commit.body.inserted).toBe(1);
+    expect(commit.body.updated || 0).toBe(0);
+
+    const persisted = await db.one(`SELECT id, schema_name FROM admin.tenants WHERE tenant_code = 'TIMPRT'`);
+    expect(persisted.schema_name).toBe('timprt');
+
+    // Tenant schema exists.
+    const schemaRow = await db.oneOrNone(`SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1`, ['timprt']);
+    expect(schemaRow).not.toBeNull();
+
+    // Admin portal_user binding exists.
+    const binding = await db.oneOrNone(
+      `SELECT pu.email, put.status, put.entity_type
+       FROM admin.portal_users pu
+       JOIN admin.portal_user_tenants put ON put.portal_user_id = pu.id
+       WHERE put.tenant_id = $1`,
+      [persisted.id],
+    );
+    expect(binding).not.toBeNull();
+    expect(binding.email).toBe('admin@timprt.test');
+    expect(binding.entity_type).toBe('employee');
+
+    // Snapshot updated_at so we can prove the round-trip doesn't churn it.
+    const before = await db.one(`SELECT updated_at FROM admin.tenants WHERE id = $1`, [persisted.id]);
+
+    // Round-trip preview using the persisted id + same field values.
+    const roundRow = blank({
+      id: persisted.id,
+      tenant_code: 'TIMPRT',
+      company: 'Tenant Import Round-Trip LLC',
+      status: 'active',
+      tier: 'starter',
+      max_users: 5,
+      address_line_1: '1 Import St',
+      country_code: 'US',
+      admin_phone: '',
+    });
+    const roundBuf = await buildWorkbook([roundRow]);
+
+    const preview = await postImport(roundBuf, cookies, 'rt-preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body).toMatchObject({ preview: true, inserts: 0, updates: 0, noops: 1, omitted: 0, errors: [] });
+
+    const recommit = await postImport(roundBuf, cookies, 'rt-recommit');
+    expect(recommit.status).toBe(201);
+    expect(recommit.body).toMatchObject({ inserted: 0, updated: 0 });
+
+    const after = await db.one(`SELECT updated_at FROM admin.tenants WHERE id = $1`, [persisted.id]);
+    expect(after.updated_at.toISOString()).toBe(before.updated_at.toISOString());
+  });
+});


### PR DESCRIPTION
## Summary

- Two-phase `Tenants.importFromSpreadsheet`: classify+validate against `admin.tenants` and `admin.portal_users` (required fields, email/password rules, intra-file dups, ROOT_TENANT archive block) before any writes.
- Diff-as-DTO update path across tenant metadata, billing address, tax identifier, and admin phone so round-trip re-imports classify as noops with no `updated_at` churn.
- Controller passes `?preview=1` through; client wires `onPreview` on `ImportDialog` and unifies the toast wording with the other importers.

## Test plan

- [x] `npm run lint`
- [x] `npm -w apps/server test` (712 ✓, including 6 new tenants contract tests)
- [ ] Manual smoke: export tenants → re-import unchanged → preview reports all noops → commit returns `{ inserted: 0, updated: 0 }`. Upload with one new tenant + one bad row (weak password) → preview surfaces the validation error and blocks commit.