### PR TITLE
feat(server): unify portal_user cascade + vendor/tenant restore cohort

### DIFF
--- a/apps/server/src/system/auth/services/index.js
+++ b/apps/server/src/system/auth/services/index.js
@@ -10,3 +10,8 @@
  */
 
 export { findActiveBinding, findAnyBinding, findActivePortalUserId } from './portalUserBindings.js';
+export {
+  archivePortalUserFor,
+  restorePortalUserFor,
+  restoreTenantBindings,
+} from './portalUserCascade.js';

--- a/apps/server/src/system/auth/services/portalUserCascade.js
+++ b/apps/server/src/system/auth/services/portalUserCascade.js
@@ -117,29 +117,27 @@ export async function restorePortalUserFor({ entityType, entityId, tenantId, act
  *
  * Accepts an optional pg-promise transaction context `t` so the caller can
  * make the tenant update + binding cascade atomic. When omitted, runs the
- * cascade in its own short tx. Either way the SELECT and the two UPDATEs
- * execute against the same executor — no cross-tx visibility issues.
+ * whole sequence (cohort SELECT + both UPDATEs) inside one short tx so the
+ * cohort can't shift between the SELECT and the UPDATEs.
  */
 export async function restoreTenantBindings({ tenantId, actorId = null }, t = null) {
-  const executor = t || db;
+  const run = async (exec) => {
+    const cohort = await exec.any(
+      `WITH max_ts AS (
+         SELECT MAX(deactivated_at) AS ts FROM admin.portal_user_tenants
+         WHERE tenant_id = $1 AND deactivated_at IS NOT NULL
+       )
+       SELECT id, portal_user_id FROM admin.portal_user_tenants
+       WHERE tenant_id = $1
+         AND deactivated_at IS NOT NULL
+         AND deactivated_at = (SELECT ts FROM max_ts)`,
+      [tenantId],
+    );
+    if (!cohort.length) return { bindingIds: [], userIds: [] };
 
-  const cohort = await executor.any(
-    `WITH max_ts AS (
-       SELECT MAX(deactivated_at) AS ts FROM admin.portal_user_tenants
-       WHERE tenant_id = $1 AND deactivated_at IS NOT NULL
-     )
-     SELECT id, portal_user_id FROM admin.portal_user_tenants
-     WHERE tenant_id = $1
-       AND deactivated_at IS NOT NULL
-       AND deactivated_at = (SELECT ts FROM max_ts)`,
-    [tenantId],
-  );
-  if (!cohort.length) return;
+    const bindingIds = cohort.map((r) => r.id);
+    const userIds = [...new Set(cohort.map((r) => r.portal_user_id))];
 
-  const bindingIds = cohort.map((r) => r.id);
-  const userIds = [...new Set(cohort.map((r) => r.portal_user_id))];
-
-  const runUpdates = async (exec) => {
     await exec.none(
       `UPDATE admin.portal_user_tenants
          SET deactivated_at = NULL, updated_by = $1
@@ -153,12 +151,11 @@ export async function restoreTenantBindings({ tenantId, actorId = null }, t = nu
          AND deactivated_at IS NOT NULL`,
       [actorId, userIds],
     );
+    return { bindingIds, userIds };
   };
 
-  if (t) {
-    await runUpdates(t);
-  } else {
-    await db.tx(runUpdates);
+  const { bindingIds, userIds } = t ? await run(t) : await db.tx(run);
+  if (bindingIds.length) {
+    logger.info(`Restored ${bindingIds.length} binding(s) + ${userIds.length} portal_user(s) for tenant ${tenantId}`);
   }
-  logger.info(`Restored ${bindingIds.length} binding(s) + ${userIds.length} portal_user(s) for tenant ${tenantId}`);
 }

--- a/apps/server/src/system/auth/services/portalUserCascade.js
+++ b/apps/server/src/system/auth/services/portalUserCascade.js
@@ -48,15 +48,18 @@ export async function archivePortalUserFor({ entityType, entityId, tenantId, act
       [actorId, binding.id],
     );
     // Only lock the portal_user when this was its last active binding —
-    // a user bound to another active tenant stays live.
+    // a user bound to another active tenant stays live. Use a correlated
+    // NOT EXISTS scoped to this portal_user so we hit the
+    // (portal_user_id, deactivated_at) index instead of scanning all
+    // active bindings.
     await t.none(
       `UPDATE admin.portal_users
          SET deactivated_at = NOW(), status = 'locked', updated_by = $1
        WHERE id = $2
          AND deactivated_at IS NULL
-         AND id NOT IN (
-           SELECT portal_user_id FROM admin.portal_user_tenants
-           WHERE deactivated_at IS NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM admin.portal_user_tenants
+           WHERE portal_user_id = $2 AND deactivated_at IS NULL
          )`,
       [actorId, binding.portal_user_id],
     );
@@ -68,44 +71,52 @@ export async function archivePortalUserFor({ entityType, entityId, tenantId, act
  * Restore every portal_user binding for the given entity whose `deactivated_at`
  * equals the most recent archive timestamp on that entity, plus the referenced
  * portal_users. `status` is intentionally not modified.
+ *
+ * Accepts an optional pg-promise tx executor `t`. When omitted, the whole
+ * sequence (cohort SELECT + both UPDATEs) runs inside one short tx so the
+ * cohort can't shift between the SELECT and the UPDATEs.
  */
-export async function restorePortalUserFor({ entityType, entityId, tenantId, actorId = null }) {
-  // Resolve the cohort first so the audit log can name what was touched.
-  const cohort = await db.any(
-    `WITH max_ts AS (
-       SELECT MAX(deactivated_at) AS ts FROM admin.portal_user_tenants
+export async function restorePortalUserFor({ entityType, entityId, tenantId, actorId = null }, t = null) {
+  const run = async (exec) => {
+    const cohort = await exec.any(
+      `WITH max_ts AS (
+         SELECT MAX(deactivated_at) AS ts FROM admin.portal_user_tenants
+         WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3
+           AND deactivated_at IS NOT NULL
+       )
+       SELECT id, portal_user_id FROM admin.portal_user_tenants
        WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3
          AND deactivated_at IS NOT NULL
-     )
-     SELECT id, portal_user_id FROM admin.portal_user_tenants
-     WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3
-       AND deactivated_at IS NOT NULL
-       AND deactivated_at = (SELECT ts FROM max_ts)`,
-    [entityType, entityId, tenantId],
-  );
-  if (!cohort.length) return;
+         AND deactivated_at = (SELECT ts FROM max_ts)`,
+      [entityType, entityId, tenantId],
+    );
+    if (!cohort.length) return { bindingIds: [], userIds: [] };
 
-  const bindingIds = cohort.map((r) => r.id);
-  const userIds = [...new Set(cohort.map((r) => r.portal_user_id))];
+    const bindingIds = cohort.map((r) => r.id);
+    const userIds = [...new Set(cohort.map((r) => r.portal_user_id))];
 
-  await db.tx(async (t) => {
-    await t.none(
+    await exec.none(
       `UPDATE admin.portal_user_tenants
          SET deactivated_at = NULL, updated_by = $1
        WHERE id = ANY($2::uuid[])`,
       [actorId, bindingIds],
     );
-    await t.none(
+    await exec.none(
       `UPDATE admin.portal_users
          SET deactivated_at = NULL, updated_by = $1
        WHERE id = ANY($2::uuid[])
          AND deactivated_at IS NOT NULL`,
       [actorId, userIds],
     );
-  });
-  logger.info(
-    `Restored ${bindingIds.length} binding(s) + ${userIds.length} portal_user(s) for ${entityType} ${entityId}`,
-  );
+    return { bindingIds, userIds };
+  };
+
+  const { bindingIds, userIds } = t ? await run(t) : await db.tx(run);
+  if (bindingIds.length) {
+    logger.info(
+      `Restored ${bindingIds.length} binding(s) + ${userIds.length} portal_user(s) for ${entityType} ${entityId}`,
+    );
+  }
 }
 
 /**

--- a/apps/server/src/system/auth/services/portalUserCascade.js
+++ b/apps/server/src/system/auth/services/portalUserCascade.js
@@ -1,0 +1,151 @@
+/**
+ * @file Shared archive/restore cascade for entity-linked portal_users
+ * @module auth/services/portalUserCascade
+ *
+ * Single home for the (entity_type, entity_id, tenant_id) → portal_user /
+ * portal_user_tenants cascade. Used by every parent controller whose entity
+ * may carry a portal_user binding (employees, clients, vendor_contacts; and
+ * indirectly via overrides on vendors and contacts).
+ *
+ * Restore rule (rule of record):
+ *   Find every binding whose `deactivated_at` equals the MAX `deactivated_at`
+ *   for that (entity_type, entity_id, tenant_id) triple, then clear
+ *   `deactivated_at` on those bindings AND on the portal_users they reference.
+ *   Never touch `status` — restoring an archived parent must not silently
+ *   re-grant a role state that the deactivation timestamp didn't encode.
+ *
+ * Archive cascade keeps the existing semantics:
+ *   - Lock the single active binding for the entity.
+ *   - Lock the portal_user iff that was its only active binding (so a
+ *     multi-tenant user with a separately-active binding elsewhere stays up).
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import db from '../../../db/db.js';
+import logger from '../../../lib/logger.js';
+import { findActiveBinding } from './portalUserBindings.js';
+
+/**
+ * Archive the active portal_user binding (and the linked portal_user when the
+ * binding being archived is its final live one) for the given entity.
+ *
+ * @param {object} params
+ * @param {string} params.entityType  e.g. 'employee', 'client', 'vendor_contact'
+ * @param {string} params.entityId    UUID of the parent row.
+ * @param {string} params.tenantId    UUID of the owning tenant.
+ * @param {string|null} params.actorId  Audit actor (`updated_by`). Null for system contexts.
+ */
+export async function archivePortalUserFor({ entityType, entityId, tenantId, actorId = null }) {
+  const binding = await findActiveBinding(entityType, entityId, tenantId);
+  if (!binding) return;
+
+  await db.tx(async (t) => {
+    await t.none(
+      `UPDATE admin.portal_user_tenants
+         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+       WHERE id = $2`,
+      [actorId, binding.id],
+    );
+    // Only lock the portal_user when this was its last active binding —
+    // a user bound to another active tenant stays live.
+    await t.none(
+      `UPDATE admin.portal_users
+         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+       WHERE id = $2
+         AND deactivated_at IS NULL
+         AND id NOT IN (
+           SELECT portal_user_id FROM admin.portal_user_tenants
+           WHERE deactivated_at IS NULL
+         )`,
+      [actorId, binding.portal_user_id],
+    );
+  });
+  logger.info(`Archived portal_user ${binding.portal_user_id} + binding for ${entityType} ${entityId}`);
+}
+
+/**
+ * Restore every portal_user binding for the given entity whose `deactivated_at`
+ * equals the most recent archive timestamp on that entity, plus the referenced
+ * portal_users. `status` is intentionally not modified.
+ */
+export async function restorePortalUserFor({ entityType, entityId, tenantId, actorId = null }) {
+  // Resolve the cohort first so the audit log can name what was touched.
+  const cohort = await db.any(
+    `WITH max_ts AS (
+       SELECT MAX(deactivated_at) AS ts FROM admin.portal_user_tenants
+       WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3
+         AND deactivated_at IS NOT NULL
+     )
+     SELECT id, portal_user_id FROM admin.portal_user_tenants
+     WHERE entity_type = $1 AND entity_id = $2 AND tenant_id = $3
+       AND deactivated_at IS NOT NULL
+       AND deactivated_at = (SELECT ts FROM max_ts)`,
+    [entityType, entityId, tenantId],
+  );
+  if (!cohort.length) return;
+
+  const bindingIds = cohort.map((r) => r.id);
+  const userIds = [...new Set(cohort.map((r) => r.portal_user_id))];
+
+  await db.tx(async (t) => {
+    await t.none(
+      `UPDATE admin.portal_user_tenants
+         SET deactivated_at = NULL, updated_by = $1
+       WHERE id = ANY($2::uuid[])`,
+      [actorId, bindingIds],
+    );
+    await t.none(
+      `UPDATE admin.portal_users
+         SET deactivated_at = NULL, updated_by = $1
+       WHERE id = ANY($2::uuid[])
+         AND deactivated_at IS NOT NULL`,
+      [actorId, userIds],
+    );
+  });
+  logger.info(
+    `Restored ${bindingIds.length} binding(s) + ${userIds.length} portal_user(s) for ${entityType} ${entityId}`,
+  );
+}
+
+/**
+ * Tenant-scoped restore: applies the same MAX-timestamp cohort rule across
+ * ALL bindings of a tenant (any entity_type). Used by tenantsController.restore
+ * to bring back the users that were locked together when the tenant was
+ * archived, without disturbing users archived at an earlier date for a
+ * different reason.
+ */
+export async function restoreTenantBindings({ tenantId, actorId = null }) {
+  const cohort = await db.any(
+    `WITH max_ts AS (
+       SELECT MAX(deactivated_at) AS ts FROM admin.portal_user_tenants
+       WHERE tenant_id = $1 AND deactivated_at IS NOT NULL
+     )
+     SELECT id, portal_user_id FROM admin.portal_user_tenants
+     WHERE tenant_id = $1
+       AND deactivated_at IS NOT NULL
+       AND deactivated_at = (SELECT ts FROM max_ts)`,
+    [tenantId],
+  );
+  if (!cohort.length) return;
+
+  const bindingIds = cohort.map((r) => r.id);
+  const userIds = [...new Set(cohort.map((r) => r.portal_user_id))];
+
+  await db.tx(async (t) => {
+    await t.none(
+      `UPDATE admin.portal_user_tenants
+         SET deactivated_at = NULL, updated_by = $1
+       WHERE id = ANY($2::uuid[])`,
+      [actorId, bindingIds],
+    );
+    await t.none(
+      `UPDATE admin.portal_users
+         SET deactivated_at = NULL, updated_by = $1
+       WHERE id = ANY($2::uuid[])
+         AND deactivated_at IS NOT NULL`,
+      [actorId, userIds],
+    );
+  });
+  logger.info(`Restored ${bindingIds.length} binding(s) + ${userIds.length} portal_user(s) for tenant ${tenantId}`);
+}

--- a/apps/server/src/system/auth/services/portalUserCascade.js
+++ b/apps/server/src/system/auth/services/portalUserCascade.js
@@ -114,9 +114,16 @@ export async function restorePortalUserFor({ entityType, entityId, tenantId, act
  * to bring back the users that were locked together when the tenant was
  * archived, without disturbing users archived at an earlier date for a
  * different reason.
+ *
+ * Accepts an optional pg-promise transaction context `t` so the caller can
+ * make the tenant update + binding cascade atomic. When omitted, runs the
+ * cascade in its own short tx. Either way the SELECT and the two UPDATEs
+ * execute against the same executor — no cross-tx visibility issues.
  */
-export async function restoreTenantBindings({ tenantId, actorId = null }) {
-  const cohort = await db.any(
+export async function restoreTenantBindings({ tenantId, actorId = null }, t = null) {
+  const executor = t || db;
+
+  const cohort = await executor.any(
     `WITH max_ts AS (
        SELECT MAX(deactivated_at) AS ts FROM admin.portal_user_tenants
        WHERE tenant_id = $1 AND deactivated_at IS NOT NULL
@@ -132,20 +139,26 @@ export async function restoreTenantBindings({ tenantId, actorId = null }) {
   const bindingIds = cohort.map((r) => r.id);
   const userIds = [...new Set(cohort.map((r) => r.portal_user_id))];
 
-  await db.tx(async (t) => {
-    await t.none(
+  const runUpdates = async (exec) => {
+    await exec.none(
       `UPDATE admin.portal_user_tenants
          SET deactivated_at = NULL, updated_by = $1
        WHERE id = ANY($2::uuid[])`,
       [actorId, bindingIds],
     );
-    await t.none(
+    await exec.none(
       `UPDATE admin.portal_users
          SET deactivated_at = NULL, updated_by = $1
        WHERE id = ANY($2::uuid[])
          AND deactivated_at IS NOT NULL`,
       [actorId, userIds],
     );
-  });
+  };
+
+  if (t) {
+    await runUpdates(t);
+  } else {
+    await db.tx(runUpdates);
+  }
   logger.info(`Restored ${bindingIds.length} binding(s) + ${userIds.length} portal_user(s) for tenant ${tenantId}`);
 }

--- a/apps/server/src/system/core/controllers/clientsController.js
+++ b/apps/server/src/system/core/controllers/clientsController.js
@@ -15,7 +15,12 @@ import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import { allocateNumber } from '../services/numberingService.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
-import { findActiveBinding, findAnyBinding } from '../../auth/services/index.js';
+import {
+  findActiveBinding,
+  findAnyBinding,
+  archivePortalUserFor,
+  restorePortalUserFor,
+} from '../../auth/services/index.js';
 import logger from '../../../lib/logger.js';
 
 class ClientsController extends BaseController {
@@ -416,57 +421,28 @@ class ClientsController extends BaseController {
 
   /**
    * Archive (soft-delete) the portal_users + binding linked to a client.
+   * Shared cascade — see auth/services/portalUserCascade.js.
    */
   async #archiveAppUser(clientId, req) {
-    const binding = await findActiveBinding('client', clientId, req.user?.tenant_id);
-    if (!binding) return;
-
-    const updatedBy = req.user?.id || null;
-    await db.tx(async (t) => {
-      await t.none(
-        `UPDATE admin.portal_user_tenants
-         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.id],
-      );
-      await t.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.portal_user_id],
-      );
+    await archivePortalUserFor({
+      entityType: 'client',
+      entityId: clientId,
+      tenantId: req.user?.tenant_id,
+      actorId: req.user?.id || null,
     });
-    logger.info(`Archived portal_user ${binding.portal_user_id} + binding for client ${clientId}`);
   }
 
   /**
-   * Restore the portal_users + binding linked to a client.
+   * Restore the portal_users + binding linked to a client. Uses the
+   * MAX-timestamp cohort rule; `status` is intentionally untouched.
    */
   async #restoreAppUser(clientId, req) {
-    const binding = await db.oneOrNone(
-      `SELECT id, portal_user_id FROM admin.portal_user_tenants
-       WHERE entity_type = 'client' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NOT NULL
-       ORDER BY deactivated_at DESC LIMIT 1`,
-      [clientId, req.user?.tenant_id],
-    );
-    if (!binding) return;
-
-    const updatedBy = req.user?.id || null;
-    await db.tx(async (t) => {
-      await t.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NULL, status = 'active', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.portal_user_id],
-      );
-      await t.none(
-        `UPDATE admin.portal_user_tenants
-         SET deactivated_at = NULL, status = 'active', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.id],
-      );
+    await restorePortalUserFor({
+      entityType: 'client',
+      entityId: clientId,
+      tenantId: req.user?.tenant_id,
+      actorId: req.user?.id || null,
     });
-    logger.info(`Restored portal_user ${binding.portal_user_id} + binding for client ${clientId}`);
   }
 }
 

--- a/apps/server/src/system/core/controllers/employeesController.js
+++ b/apps/server/src/system/core/controllers/employeesController.js
@@ -15,7 +15,12 @@ import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import { allocateNumber } from '../services/numberingService.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
-import { findActiveBinding, findAnyBinding } from '../../auth/services/index.js';
+import {
+  findActiveBinding,
+  findAnyBinding,
+  archivePortalUserFor,
+  restorePortalUserFor,
+} from '../../auth/services/index.js';
 import { validateEmployeeRoles } from '../../../lib/employeeRoleValidator.js';
 import logger from '../../../lib/logger.js';
 
@@ -464,57 +469,31 @@ class EmployeesController extends BaseController {
 
   /**
    * Archive (soft-delete) the portal_users + binding linked to an employee.
+   * Delegates to the shared cascade so behavior stays consistent across
+   * employees / clients / vendor_contacts / vendors / contacts.
    */
   async #archiveAppUser(employeeId, req) {
-    const binding = await findActiveBinding('employee', employeeId, req.user?.tenant_id);
-    if (!binding) return;
-
-    const updatedBy = req.user?.id || null;
-    await db.tx(async (t) => {
-      await t.none(
-        `UPDATE admin.portal_user_tenants
-         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.id],
-      );
-      await t.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.portal_user_id],
-      );
+    await archivePortalUserFor({
+      entityType: 'employee',
+      entityId: employeeId,
+      tenantId: req.user?.tenant_id,
+      actorId: req.user?.id || null,
     });
-    logger.info(`Archived portal_user ${binding.portal_user_id} + binding for employee ${employeeId}`);
   }
 
   /**
    * Restore the portal_users + binding linked to an employee.
+   * Uses the MAX-timestamp cohort rule: restores every binding that was
+   * deactivated together (sharing the most recent `deactivated_at`) and
+   * leaves `status` untouched.
    */
   async #restoreAppUser(employeeId, req) {
-    const binding = await db.oneOrNone(
-      `SELECT id, portal_user_id FROM admin.portal_user_tenants
-       WHERE entity_type = 'employee' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NOT NULL
-       ORDER BY deactivated_at DESC LIMIT 1`,
-      [employeeId, req.user?.tenant_id],
-    );
-    if (!binding) return;
-
-    const updatedBy = req.user?.id || null;
-    await db.tx(async (t) => {
-      await t.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NULL, status = 'active', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.portal_user_id],
-      );
-      await t.none(
-        `UPDATE admin.portal_user_tenants
-         SET deactivated_at = NULL, status = 'active', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.id],
-      );
+    await restorePortalUserFor({
+      entityType: 'employee',
+      entityId: employeeId,
+      tenantId: req.user?.tenant_id,
+      actorId: req.user?.id || null,
     });
-    logger.info(`Restored portal_user ${binding.portal_user_id} + binding for employee ${employeeId}`);
   }
 }
 

--- a/apps/server/src/system/core/controllers/vendorContactsController.js
+++ b/apps/server/src/system/core/controllers/vendorContactsController.js
@@ -17,7 +17,12 @@ import crypto from 'node:crypto';
 import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import { invalidateByEntity } from '../../../services/permCacheInvalidator.js';
-import { findActiveBinding, findAnyBinding } from '../../auth/services/index.js';
+import {
+  findActiveBinding,
+  findAnyBinding,
+  archivePortalUserFor,
+  restorePortalUserFor,
+} from '../../auth/services/index.js';
 import logger from '../../../lib/logger.js';
 
 class VendorContactsController extends BaseController {
@@ -833,67 +838,27 @@ class VendorContactsController extends BaseController {
    * remaining active binding.
    */
   async #archiveAppUser(vendorContactId, req) {
-    const binding = await findActiveBinding('vendor_contact', vendorContactId, req.user?.tenant_id);
-    if (!binding) return;
-
-    const updatedBy = req.user?.id || null;
-    await db.tx(async (t) => {
-      await t.none(
-        `UPDATE admin.portal_user_tenants
-         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.id],
-      );
-      // Only lock the portal_user globally if this was the last active
-      // binding. Mirrors tenantsController's cascade pattern.
-      await t.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-         WHERE id = $2 AND deactivated_at IS NULL
-           AND NOT EXISTS (
-             SELECT 1 FROM admin.portal_user_tenants
-             WHERE portal_user_id = $2 AND deactivated_at IS NULL
-           )`,
-        [updatedBy, binding.portal_user_id],
-      );
+    await archivePortalUserFor({
+      entityType: 'vendor_contact',
+      entityId: vendorContactId,
+      tenantId: req.user?.tenant_id,
+      actorId: req.user?.id || null,
     });
-    logger.info(`Archived binding for vendor_contact ${vendorContactId} → portal_user ${binding.portal_user_id}`);
   }
 
   /**
-   * Restore the per-tenant binding for a vendor_contact.
-   *
-   * Only touches admin.portal_users when it is actually archived. If
-   * the portal_user is already active/invited via another tenant's
-   * binding, leave its global state alone — overwriting status='active'
-   * would clear a force-password-change ('invited') state that
-   * belongs to the user, not to this tenant's vendor_contact.
+   * Restore the per-tenant binding for a vendor_contact. Uses the
+   * MAX-timestamp cohort rule and leaves `status` untouched — preserves
+   * any pending 'invited' state on a portal_user that's already active
+   * through another tenant's binding.
    */
   async #restoreAppUser(vendorContactId, req) {
-    const binding = await db.oneOrNone(
-      `SELECT id, portal_user_id FROM admin.portal_user_tenants
-       WHERE entity_type = 'vendor_contact' AND entity_id = $1 AND tenant_id = $2 AND deactivated_at IS NOT NULL
-       ORDER BY deactivated_at DESC LIMIT 1`,
-      [vendorContactId, req.user?.tenant_id],
-    );
-    if (!binding) return;
-
-    const updatedBy = req.user?.id || null;
-    await db.tx(async (t) => {
-      await t.none(
-        `UPDATE admin.portal_users
-         SET deactivated_at = NULL, status = 'active', updated_by = $1
-         WHERE id = $2 AND deactivated_at IS NOT NULL`,
-        [updatedBy, binding.portal_user_id],
-      );
-      await t.none(
-        `UPDATE admin.portal_user_tenants
-         SET deactivated_at = NULL, status = 'active', updated_by = $1
-         WHERE id = $2`,
-        [updatedBy, binding.id],
-      );
+    await restorePortalUserFor({
+      entityType: 'vendor_contact',
+      entityId: vendorContactId,
+      tenantId: req.user?.tenant_id,
+      actorId: req.user?.id || null,
     });
-    logger.info(`Restored binding for vendor_contact ${vendorContactId} → portal_user ${binding.portal_user_id}`);
   }
 }
 

--- a/apps/server/src/system/core/controllers/vendorsController.js
+++ b/apps/server/src/system/core/controllers/vendorsController.js
@@ -74,6 +74,208 @@ class VendorsController extends BaseController {
   }
 
   /**
+   * DELETE /archive — soft-delete the vendor and cascade-archive every active
+   * vendor_contact under it, locking the portal_user bindings (and the
+   * portal_users themselves when those were the last active binding).
+   *
+   * Mirrors the tenant-archive cascade pattern: the cascade is scoped via
+   * RETURNING so multi-tenant portal_users with other active bindings stay
+   * live. Inline rather than delegating per-contact to the cascade helper so
+   * everything happens in one transaction with one round-trip per step.
+   */
+  async archive(req, res) {
+    if (!req.query.id && !req.query.code) {
+      return res.status(400).json({ error: 'id or code query parameter is required' });
+    }
+
+    const schema = this.getSchema(req);
+    const s = pgp.as.name(schema);
+    const tenantId = req.user?.tenant_id;
+    const actorId = req.user?.id || null;
+
+    let vendorId = req.query.id;
+
+    try {
+      if (!vendorId) {
+        const vendor = await this.model(schema).findOneByFilter({ code: req.query.code });
+        if (!vendor) return res.status(404).json({ error: `${this.errorLabel} not found or already inactive` });
+        vendorId = vendor.id;
+      }
+
+      let archivedVendor = 0;
+      await db.tx(async (t) => {
+        const contacts = await t.any(
+          `SELECT id FROM ${s}.vendor_contacts WHERE vendor_id = $1 AND deactivated_at IS NULL`,
+          [vendorId],
+        );
+
+        if (contacts.length) {
+          const contactIds = contacts.map((r) => r.id);
+
+          await t.none(
+            `UPDATE ${s}.vendor_contacts
+                SET deactivated_at = NOW(), updated_by = $1
+              WHERE id = ANY($2::uuid[])`,
+            [actorId, contactIds],
+          );
+
+          const affected = await t.any(
+            `UPDATE admin.portal_user_tenants
+                SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+              WHERE entity_type = 'vendor_contact'
+                AND entity_id = ANY($2::uuid[])
+                AND tenant_id = $3
+                AND deactivated_at IS NULL
+              RETURNING portal_user_id`,
+            [actorId, contactIds, tenantId],
+          );
+
+          const userIds = [...new Set(affected.map((r) => r.portal_user_id))];
+          if (userIds.length) {
+            await t.none(
+              `UPDATE admin.portal_users
+                  SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+                WHERE id = ANY($2::uuid[])
+                  AND deactivated_at IS NULL
+                  AND id NOT IN (
+                    SELECT portal_user_id FROM admin.portal_user_tenants WHERE deactivated_at IS NULL
+                  )`,
+              [actorId, userIds],
+            );
+          }
+        }
+
+        const result = await t.result(
+          `UPDATE ${s}.vendors
+              SET deactivated_at = NOW(), updated_by = $1
+            WHERE id = $2 AND deactivated_at IS NULL`,
+          [actorId, vendorId],
+          (r) => r.rowCount,
+        );
+        archivedVendor = result;
+      });
+
+      if (!archivedVendor) {
+        return res.status(404).json({ error: `${this.errorLabel} not found or already inactive` });
+      }
+      res.status(200).json({ message: `${this.errorLabel} marked as inactive` });
+    } catch (err) {
+      this.handleError(err, res, 'archiving', this.errorLabel);
+    }
+  }
+
+  /**
+   * PATCH /restore — restore the vendor and the cohort of vendor_contacts that
+   * were archived together with it. Cohort is identified by the MAX
+   * `deactivated_at` of vendor_contacts under this vendor; each cohort
+   * member's portal_user / portal_user_tenants binding pair is restored too
+   * (only when the binding's `deactivated_at` matches the binding-level
+   * MAX, per the same rule used for direct entity restore).
+   *
+   * `status` is intentionally not modified anywhere — restoring only flips
+   * `deactivated_at` back to NULL.
+   */
+  async restore(req, res) {
+    if (!req.query.id && !req.query.code) {
+      return res.status(400).json({ error: 'id or code query parameter is required' });
+    }
+
+    const schema = this.getSchema(req);
+    const s = pgp.as.name(schema);
+    const tenantId = req.user?.tenant_id;
+    const actorId = req.user?.id || null;
+
+    let vendorId = req.query.id;
+
+    try {
+      if (!vendorId) {
+        const vendor = await this.model(schema).findOneByFilter({ code: req.query.code });
+        if (!vendor) return res.status(404).json({ error: `${this.errorLabel} not found or already active` });
+        vendorId = vendor.id;
+      }
+
+      let restoredVendor = 0;
+      await db.tx(async (t) => {
+        const result = await t.result(
+          `UPDATE ${s}.vendors
+              SET deactivated_at = NULL, updated_by = $1
+            WHERE id = $2 AND deactivated_at IS NOT NULL`,
+          [actorId, vendorId],
+          (r) => r.rowCount,
+        );
+        restoredVendor = result;
+        if (!restoredVendor) return;
+
+        // Cohort of vendor_contacts archived together with the vendor.
+        const cohort = await t.any(
+          `WITH max_ts AS (
+             SELECT MAX(deactivated_at) AS ts FROM ${s}.vendor_contacts
+             WHERE vendor_id = $1 AND deactivated_at IS NOT NULL
+           )
+           SELECT id FROM ${s}.vendor_contacts
+           WHERE vendor_id = $1
+             AND deactivated_at IS NOT NULL
+             AND deactivated_at = (SELECT ts FROM max_ts)`,
+          [vendorId],
+        );
+
+        if (!cohort.length) return;
+        const contactIds = cohort.map((r) => r.id);
+
+        await t.none(
+          `UPDATE ${s}.vendor_contacts
+              SET deactivated_at = NULL, updated_by = $1
+            WHERE id = ANY($2::uuid[])`,
+          [actorId, contactIds],
+        );
+
+        // Restore the binding cohort sharing the MAX(deactivated_at) per
+        // entity_id — matches the standalone vendor_contact restore rule.
+        const restoredBindings = await t.any(
+          `WITH cohort AS (
+             SELECT id, portal_user_id
+             FROM admin.portal_user_tenants put1
+             WHERE entity_type = 'vendor_contact'
+               AND tenant_id = $1
+               AND entity_id = ANY($2::uuid[])
+               AND deactivated_at IS NOT NULL
+               AND deactivated_at = (
+                 SELECT MAX(deactivated_at) FROM admin.portal_user_tenants put2
+                 WHERE put2.entity_type = put1.entity_type
+                   AND put2.entity_id = put1.entity_id
+                   AND put2.tenant_id = put1.tenant_id
+                   AND put2.deactivated_at IS NOT NULL
+               )
+           )
+           UPDATE admin.portal_user_tenants
+              SET deactivated_at = NULL, updated_by = $3
+            WHERE id IN (SELECT id FROM cohort)
+            RETURNING portal_user_id`,
+          [tenantId, contactIds, actorId],
+        );
+
+        const userIds = [...new Set(restoredBindings.map((r) => r.portal_user_id))];
+        if (userIds.length) {
+          await t.none(
+            `UPDATE admin.portal_users
+                SET deactivated_at = NULL, updated_by = $1
+              WHERE id = ANY($2::uuid[])
+                AND deactivated_at IS NOT NULL`,
+            [actorId, userIds],
+          );
+        }
+      });
+
+      if (!restoredVendor) {
+        return res.status(404).json({ error: `${this.errorLabel} not found or already active` });
+      }
+      res.status(200).json({ message: `${this.errorLabel} marked as active` });
+    } catch (err) {
+      this.handleError(err, res, 'restoring', this.errorLabel);
+    }
+  }
+
+  /**
    * POST /export-combined-xls — export vendors + vendor contacts into a single workbook.
    */
   async exportCombinedXls(req, res) {

--- a/apps/server/src/system/core/controllers/vendorsController.js
+++ b/apps/server/src/system/core/controllers/vendorsController.js
@@ -205,6 +205,31 @@ class VendorsController extends BaseController {
 
       let restoredVendor = 0;
       await db.tx(async (t) => {
+        // Identify the cohort BEFORE clearing the vendor's deactivated_at,
+        // using a server-side subquery so the timestamp comparison happens
+        // in Postgres (microsecond precision). The earlier approach
+        // (`MAX(vendor_contacts.deactivated_at)`) was wrong: contacts
+        // archived independently before the vendor's archive event would
+        // erroneously be restored. The fixed approach: cohort = contacts
+        // whose `deactivated_at` exactly equals the vendor's own
+        // `deactivated_at`. The archive cascade uses one NOW() per tx, so
+        // a contact archived together with its vendor has the same
+        // timestamp down to the microsecond. SELECT FOR UPDATE locks the
+        // vendor row so no concurrent archive/restore can race here.
+        const beforeRow = await t.oneOrNone(
+          `SELECT deactivated_at FROM ${s}.vendors WHERE id = $1 FOR UPDATE`,
+          [vendorId],
+        );
+
+        const cohort = beforeRow?.deactivated_at
+          ? await t.any(
+              `SELECT vc.id FROM ${s}.vendor_contacts vc
+                WHERE vc.vendor_id = $1
+                  AND vc.deactivated_at = (SELECT deactivated_at FROM ${s}.vendors WHERE id = $1)`,
+              [vendorId],
+            )
+          : [];
+
         const result = await t.result(
           `UPDATE ${s}.vendors
               SET deactivated_at = NULL, updated_by = $1
@@ -214,19 +239,6 @@ class VendorsController extends BaseController {
         );
         restoredVendor = result;
         if (!restoredVendor) return;
-
-        // Cohort of vendor_contacts archived together with the vendor.
-        const cohort = await t.any(
-          `WITH max_ts AS (
-             SELECT MAX(deactivated_at) AS ts FROM ${s}.vendor_contacts
-             WHERE vendor_id = $1 AND deactivated_at IS NOT NULL
-           )
-           SELECT id FROM ${s}.vendor_contacts
-           WHERE vendor_id = $1
-             AND deactivated_at IS NOT NULL
-             AND deactivated_at = (SELECT ts FROM max_ts)`,
-          [vendorId],
-        );
 
         if (!cohort.length) return;
         const contactIds = cohort.map((r) => r.id);

--- a/apps/server/src/system/core/controllers/vendorsController.js
+++ b/apps/server/src/system/core/controllers/vendorsController.js
@@ -97,6 +97,7 @@ class VendorsController extends BaseController {
 
     try {
       if (!vendorId) {
+        // Archive operates on active vendors, so the default model filter is fine here.
         const vendor = await this.model(schema).findOneByFilter({ code: req.query.code });
         if (!vendor) return res.status(404).json({ error: `${this.errorLabel} not found or already inactive` });
         vendorId = vendor.id;
@@ -104,47 +105,9 @@ class VendorsController extends BaseController {
 
       let archivedVendor = 0;
       await db.tx(async (t) => {
-        const contacts = await t.any(
-          `SELECT id FROM ${s}.vendor_contacts WHERE vendor_id = $1 AND deactivated_at IS NULL`,
-          [vendorId],
-        );
-
-        if (contacts.length) {
-          const contactIds = contacts.map((r) => r.id);
-
-          await t.none(
-            `UPDATE ${s}.vendor_contacts
-                SET deactivated_at = NOW(), updated_by = $1
-              WHERE id = ANY($2::uuid[])`,
-            [actorId, contactIds],
-          );
-
-          const affected = await t.any(
-            `UPDATE admin.portal_user_tenants
-                SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-              WHERE entity_type = 'vendor_contact'
-                AND entity_id = ANY($2::uuid[])
-                AND tenant_id = $3
-                AND deactivated_at IS NULL
-              RETURNING portal_user_id`,
-            [actorId, contactIds, tenantId],
-          );
-
-          const userIds = [...new Set(affected.map((r) => r.portal_user_id))];
-          if (userIds.length) {
-            await t.none(
-              `UPDATE admin.portal_users
-                  SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-                WHERE id = ANY($2::uuid[])
-                  AND deactivated_at IS NULL
-                  AND id NOT IN (
-                    SELECT portal_user_id FROM admin.portal_user_tenants WHERE deactivated_at IS NULL
-                  )`,
-              [actorId, userIds],
-            );
-          }
-        }
-
+        // Vendor row first — if the row doesn't move (404 case, e.g. already
+        // archived), abort before any cascade fires. Avoids the prior bug
+        // where the cascade committed even when the vendor archive was a no-op.
         const result = await t.result(
           `UPDATE ${s}.vendors
               SET deactivated_at = NOW(), updated_by = $1
@@ -153,6 +116,48 @@ class VendorsController extends BaseController {
           (r) => r.rowCount,
         );
         archivedVendor = result;
+        if (!archivedVendor) return;
+
+        // Cascade — only runs when the vendor actually transitioned to archived.
+        const contacts = await t.any(
+          `SELECT id FROM ${s}.vendor_contacts WHERE vendor_id = $1 AND deactivated_at IS NULL`,
+          [vendorId],
+        );
+        if (!contacts.length) return;
+
+        const contactIds = contacts.map((r) => r.id);
+
+        await t.none(
+          `UPDATE ${s}.vendor_contacts
+              SET deactivated_at = NOW(), updated_by = $1
+            WHERE id = ANY($2::uuid[])`,
+          [actorId, contactIds],
+        );
+
+        const affected = await t.any(
+          `UPDATE admin.portal_user_tenants
+              SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+            WHERE entity_type = 'vendor_contact'
+              AND entity_id = ANY($2::uuid[])
+              AND tenant_id = $3
+              AND deactivated_at IS NULL
+            RETURNING portal_user_id`,
+          [actorId, contactIds, tenantId],
+        );
+
+        const userIds = [...new Set(affected.map((r) => r.portal_user_id))];
+        if (userIds.length) {
+          await t.none(
+            `UPDATE admin.portal_users
+                SET deactivated_at = NOW(), status = 'locked', updated_by = $1
+              WHERE id = ANY($2::uuid[])
+                AND deactivated_at IS NULL
+                AND id NOT IN (
+                  SELECT portal_user_id FROM admin.portal_user_tenants WHERE deactivated_at IS NULL
+                )`,
+            [actorId, userIds],
+          );
+        }
       });
 
       if (!archivedVendor) {
@@ -189,7 +194,11 @@ class VendorsController extends BaseController {
 
     try {
       if (!vendorId) {
-        const vendor = await this.model(schema).findOneByFilter({ code: req.query.code });
+        // Restore by definition operates on an archived row — must include deactivated.
+        const vendor = await this.model(schema).findOneByFilter(
+          { code: req.query.code },
+          { includeDeactivated: true },
+        );
         if (!vendor) return res.status(404).json({ error: `${this.errorLabel} not found or already active` });
         vendorId = vendor.id;
       }

--- a/apps/server/src/system/core/controllers/vendorsController.js
+++ b/apps/server/src/system/core/controllers/vendorsController.js
@@ -147,13 +147,17 @@ class VendorsController extends BaseController {
 
         const userIds = [...new Set(affected.map((r) => r.portal_user_id))];
         if (userIds.length) {
+          // Correlated NOT EXISTS so the planner can use the
+          // (portal_user_id, deactivated_at) index on portal_user_tenants
+          // instead of scanning every active binding.
           await t.none(
-            `UPDATE admin.portal_users
+            `UPDATE admin.portal_users pu
                 SET deactivated_at = NOW(), status = 'locked', updated_by = $1
-              WHERE id = ANY($2::uuid[])
-                AND deactivated_at IS NULL
-                AND id NOT IN (
-                  SELECT portal_user_id FROM admin.portal_user_tenants WHERE deactivated_at IS NULL
+              WHERE pu.id = ANY($2::uuid[])
+                AND pu.deactivated_at IS NULL
+                AND NOT EXISTS (
+                  SELECT 1 FROM admin.portal_user_tenants put
+                  WHERE put.portal_user_id = pu.id AND put.deactivated_at IS NULL
                 )`,
             [actorId, userIds],
           );

--- a/apps/server/src/system/core/controllers/vendorsController.js
+++ b/apps/server/src/system/core/controllers/vendorsController.js
@@ -98,7 +98,7 @@ class VendorsController extends BaseController {
     try {
       if (!vendorId) {
         // Archive operates on active vendors, so the default model filter is fine here.
-        const vendor = await this.model(schema).findOneByFilter({ code: req.query.code });
+        const vendor = await this.model(schema).findOneBy([{ code: req.query.code }]);
         if (!vendor) return res.status(404).json({ error: `${this.errorLabel} not found or already inactive` });
         vendorId = vendor.id;
       }
@@ -195,8 +195,8 @@ class VendorsController extends BaseController {
     try {
       if (!vendorId) {
         // Restore by definition operates on an archived row — must include deactivated.
-        const vendor = await this.model(schema).findOneByFilter(
-          { code: req.query.code },
+        const vendor = await this.model(schema).findOneBy(
+          [{ code: req.query.code }],
           { includeDeactivated: true },
         );
         if (!vendor) return res.status(404).json({ error: `${this.errorLabel} not found or already active` });

--- a/apps/server/src/system/core/controllers/vendorsController.js
+++ b/apps/server/src/system/core/controllers/vendorsController.js
@@ -174,15 +174,24 @@ class VendorsController extends BaseController {
   }
 
   /**
-   * PATCH /restore — restore the vendor and the cohort of vendor_contacts that
-   * were archived together with it. Cohort is identified by the MAX
-   * `deactivated_at` of vendor_contacts under this vendor; each cohort
-   * member's portal_user / portal_user_tenants binding pair is restored too
-   * (only when the binding's `deactivated_at` matches the binding-level
-   * MAX, per the same rule used for direct entity restore).
+   * PATCH /restore — restore the vendor and the cohort of vendor_contacts
+   * that were archived together with it. Cohort is identified by exact
+   * timestamp match against the vendor's own `deactivated_at`: contacts
+   * whose `vendor_contacts.deactivated_at` equals the vendor row's
+   * `deactivated_at` at the moment we capture it (under SELECT FOR
+   * UPDATE). This is reliable because the archive cascade uses one
+   * NOW() per transaction, so a contact archived together with its
+   * vendor shares the timestamp down to the microsecond. The comparison
+   * is done in a server-side subquery so we don't lose precision
+   * marshalling the timestamp through JavaScript.
    *
-   * `status` is intentionally not modified anywhere — restoring only flips
-   * `deactivated_at` back to NULL.
+   * Each cohort member's portal_user / portal_user_tenants binding pair
+   * is restored using the same MAX-`deactivated_at` cohort rule per
+   * vendor_contact as the standalone vendor_contact restore (see
+   * `restorePortalUserFor`).
+   *
+   * `status` is intentionally not modified anywhere — restoring only
+   * flips `deactivated_at` back to NULL.
    */
   async restore(req, res) {
     if (!req.query.id && !req.query.code) {

--- a/apps/server/src/system/tenants/controllers/tenantsController.js
+++ b/apps/server/src/system/tenants/controllers/tenantsController.js
@@ -173,25 +173,43 @@ class TenantsController extends BaseController {
    * before the tenant was archived, stay archived. `status` is not modified.
    */
   async restore(req, res) {
-    req.body.deactivated_at = null;
-    const filters = [{ deactivated_at: { $not: null } }, { ...req.query }];
+    if (!req.query.id && !req.query.tenant_code) {
+      return res.status(400).json({ error: 'id or tenant_code query parameter is required' });
+    }
+
+    const actorId = req.user?.id || null;
 
     try {
-      const count = await this.model('admin').updateWhere(filters, req.body, { includeDeactivated: true });
-      if (!count) return res.status(404).json({ error: `${this.errorLabel} not found or already active` });
+      let count = 0;
+      let tenantId = req.query.id || null;
 
-      // Resolve the tenant id so we can cascade-restore the binding cohort.
-      // We accept either ?id= or ?tenant_code= (mirrors archive). The
-      // updateWhere succeeded with whichever was supplied, so a lookup
-      // here is safe.
-      let tenantId = req.query.id;
-      if (!tenantId && req.query.tenant_code) {
-        const row = await this.model('admin').findOneByFilter({ tenant_code: req.query.tenant_code });
-        tenantId = row?.id;
-      }
-      if (tenantId) {
-        await restoreTenantBindings({ tenantId, actorId: req.user?.id || null });
-      }
+      // Tenant update + binding cascade run in one outer tx — a cascade
+      // failure rolls back the tenant flip so we can't leave the tenant
+      // marked active while its bindings stayed locked.
+      await db.tx(async (t) => {
+        if (!tenantId) {
+          const row = await t.oneOrNone(
+            `SELECT id FROM admin.tenants WHERE tenant_code = $1`,
+            [req.query.tenant_code],
+          );
+          tenantId = row?.id || null;
+        }
+        if (!tenantId) return;
+
+        const result = await t.result(
+          `UPDATE admin.tenants
+              SET deactivated_at = NULL, updated_by = $1
+            WHERE id = $2 AND deactivated_at IS NOT NULL`,
+          [actorId, tenantId],
+          (r) => r.rowCount,
+        );
+        count = result;
+        if (!count) return;
+
+        await restoreTenantBindings({ tenantId, actorId }, t);
+      });
+
+      if (!count) return res.status(404).json({ error: `${this.errorLabel} not found or already active` });
 
       res.status(200).json({ message: `${this.errorLabel} marked as active` });
     } catch (err) {

--- a/apps/server/src/system/tenants/controllers/tenantsController.js
+++ b/apps/server/src/system/tenants/controllers/tenantsController.js
@@ -16,6 +16,7 @@ import BaseController from '../../../lib/BaseController.js';
 import db, { pgp } from '../../../db/db.js';
 import logger from '../../../lib/logger.js';
 import { provisionNewTenant } from '../../../services/tenantSetup.js';
+import { restoreTenantBindings } from '../../auth/services/index.js';
 
 class TenantsController extends BaseController {
   constructor() {
@@ -164,7 +165,12 @@ class TenantsController extends BaseController {
   }
 
   /**
-   * PATCH /restore — reactivate tenant only (users remain archived)
+   * PATCH /restore — reactivate tenant and the binding cohort that was locked
+   * together with it. Cohort is identified by the MAX `deactivated_at` across
+   * `admin.portal_user_tenants` rows scoped to this tenant: bindings (and the
+   * portal_users they reference) sharing that timestamp come back; older
+   * archives, e.g. a user who was already locked for a separate reason
+   * before the tenant was archived, stay archived. `status` is not modified.
    */
   async restore(req, res) {
     req.body.deactivated_at = null;
@@ -173,6 +179,19 @@ class TenantsController extends BaseController {
     try {
       const count = await this.model('admin').updateWhere(filters, req.body, { includeDeactivated: true });
       if (!count) return res.status(404).json({ error: `${this.errorLabel} not found or already active` });
+
+      // Resolve the tenant id so we can cascade-restore the binding cohort.
+      // We accept either ?id= or ?tenant_code= (mirrors archive). The
+      // updateWhere succeeded with whichever was supplied, so a lookup
+      // here is safe.
+      let tenantId = req.query.id;
+      if (!tenantId && req.query.tenant_code) {
+        const row = await this.model('admin').findOneByFilter({ tenant_code: req.query.tenant_code });
+        tenantId = row?.id;
+      }
+      if (tenantId) {
+        await restoreTenantBindings({ tenantId, actorId: req.user?.id || null });
+      }
 
       res.status(200).json({ message: `${this.errorLabel} marked as active` });
     } catch (err) {

--- a/apps/server/tests/contract/vendorCascade.test.js
+++ b/apps/server/tests/contract/vendorCascade.test.js
@@ -152,6 +152,38 @@ describe('Vendor archive/restore cascade — vendor_contacts + portal_users', ()
     }
   });
 
+  test('vendor restore only restores contacts archived in the same tx as the vendor', async () => {
+    // Setup: archive one contact FIRST (independent), then archive the
+    // vendor (cascade picks up the OTHER contact). On restore, only the
+    // vendor's own cohort should come back — the independently-archived
+    // contact must stay archived even though its deactivated_at is older
+    // than the vendor's. Naive MAX(deactivated_at) would mistakenly grab
+    // whichever happened most recently regardless of cause.
+    const cookies = await loginAs('admin@vcasc.test', 'CascadePass123!');
+    const v2 = await createVendor(cookies, 'VC002', 'Cohort Boundary LLC');
+    const ind = await createAppUserContact(cookies, v2.id, 'Independent', 'One', 'ind@vcasc.test', 'IndPass123!');
+    const co = await createAppUserContact(cookies, v2.id, 'Cohort', 'Two', 'co@vcasc.test', 'CoPass123!');
+
+    // Independently archive `ind` first.
+    let res = await request(app)
+      .delete(`/api/core/v1/vendor-contacts/archive?id=${ind.id}`)
+      .set('Cookie', cookies);
+    expect(res.status).toBe(200);
+
+    // Now archive the vendor — cascade should only touch `co`.
+    res = await request(app).delete(`/api/core/v1/vendors/archive?id=${v2.id}`).set('Cookie', cookies);
+    expect(res.status).toBe(200);
+
+    // Restore the vendor. Only `co` should come back, not `ind`.
+    res = await request(app).patch(`/api/core/v1/vendors/restore?id=${v2.id}`).set('Cookie', cookies);
+    expect(res.status).toBe(200);
+
+    const indRow = await db.one(`SELECT deactivated_at FROM vcasc.vendor_contacts WHERE id = $1`, [ind.id]);
+    const coRow = await db.one(`SELECT deactivated_at FROM vcasc.vendor_contacts WHERE id = $1`, [co.id]);
+    expect(indRow.deactivated_at).not.toBeNull();
+    expect(coRow.deactivated_at).toBeNull();
+  });
+
   test('restore by ?code= succeeds for an archived vendor and restores the cohort', async () => {
     const res = await request(app)
       .patch(`/api/core/v1/vendors/restore?code=VC001`)

--- a/apps/server/tests/contract/vendorCascade.test.js
+++ b/apps/server/tests/contract/vendorCascade.test.js
@@ -1,0 +1,199 @@
+/**
+ * @file Contract tests for vendor archive/restore cascade to vendor_contacts
+ * @module tests/contract/vendorCascade
+ *
+ * Locks in the cascade rules introduced alongside the cascade-restore
+ * unification:
+ *   - Archiving a vendor archives every active vendor_contact under it,
+ *     locks each binding in admin.portal_user_tenants, and locks the
+ *     portal_user when that was its last active binding.
+ *   - Restoring a vendor brings back the vendor_contact cohort sharing
+ *     the vendor's MAX(deactivated_at) plus their bindings/users; the
+ *     portal_user `status` column is intentionally left at 'locked'
+ *     (restore touches `deactivated_at` only).
+ *   - Code-based restore (?code=...) succeeds for an archived vendor
+ *     (verifies includeDeactivated on the controller-side lookup).
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function loginAs(email, password) {
+  const res = await request(app).post('/api/auth/login').send({ email, password });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(rootCookies) {
+  const res = await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', rootCookies)
+    .send({
+      tenant_code: 'VCASC',
+      company: 'Vendor Cascade Test Corp',
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'Cascade',
+      admin_last_name: 'Admin',
+      admin_email: 'admin@vcasc.test',
+      admin_password: 'CascadePass123!',
+      billing_address: { address_line_1: '1 Cascade St', country_code: 'US' },
+    });
+  if (res.status !== 201) throw new Error(`provisionTenant ${res.status}: ${JSON.stringify(res.body)}`);
+  return res.body;
+}
+
+async function createVendor(cookies, code, name) {
+  const res = await request(app)
+    .post('/api/core/v1/vendors')
+    .set('Cookie', cookies)
+    .send({ code, name });
+  if (res.status !== 201) throw new Error(`createVendor ${res.status}: ${JSON.stringify(res.body)}`);
+  return res.body;
+}
+
+async function createAppUserContact(cookies, vendorId, first, last, email, password) {
+  const res = await request(app)
+    .post('/api/core/v1/vendor-contacts')
+    .set('Cookie', cookies)
+    .send({
+      vendor_id: vendorId,
+      first_name: first,
+      last_name: last,
+      email,
+      is_app_user: true,
+      roles: ['vendor'],
+      password,
+    });
+  if (res.status !== 201) throw new Error(`createAppUserContact ${res.status}: ${JSON.stringify(res.body)}`);
+  return res.body;
+}
+
+describe('Vendor archive/restore cascade — vendor_contacts + portal_users', () => {
+  let rootCookies;
+  let tenantCookies;
+  let vendorId;
+  let contactA;
+  let contactB;
+
+  beforeAll(async () => {
+    rootCookies = await loginRoot();
+    await provisionTenant(rootCookies);
+    tenantCookies = await loginAs('admin@vcasc.test', 'CascadePass123!');
+    const vendor = await createVendor(tenantCookies, 'VC001', 'Cascade Vendor LLC');
+    vendorId = vendor.id;
+    contactA = await createAppUserContact(tenantCookies, vendorId, 'Anna', 'Apple', 'anna@vcasc.test', 'AnnaPass123!');
+    contactB = await createAppUserContact(tenantCookies, vendorId, 'Bob', 'Berry', 'bob@vcasc.test', 'BobPass123!');
+  }, 60000);
+
+  test('archive cascades to vendor_contacts + portal_user_tenants + portal_users', async () => {
+    const res = await request(app)
+      .delete(`/api/core/v1/vendors/archive?id=${vendorId}`)
+      .set('Cookie', tenantCookies);
+    expect(res.status).toBe(200);
+
+    // Vendor itself is archived.
+    const vendor = await db.oneOrNone(`SELECT deactivated_at FROM vcasc.vendors WHERE id = $1`, [vendorId]);
+    expect(vendor.deactivated_at).not.toBeNull();
+
+    // Both vendor_contacts archived.
+    const contacts = await db.any(
+      `SELECT id, deactivated_at FROM vcasc.vendor_contacts WHERE vendor_id = $1`,
+      [vendorId],
+    );
+    expect(contacts).toHaveLength(2);
+    for (const c of contacts) expect(c.deactivated_at).not.toBeNull();
+
+    // Their portal_user_tenants bindings are locked.
+    const bindings = await db.any(
+      `SELECT b.entity_id, b.deactivated_at, b.status, b.portal_user_id
+       FROM admin.portal_user_tenants b
+       WHERE b.entity_type = 'vendor_contact' AND b.entity_id = ANY($1::uuid[])`,
+      [[contactA.id, contactB.id]],
+    );
+    expect(bindings).toHaveLength(2);
+    for (const b of bindings) {
+      expect(b.deactivated_at).not.toBeNull();
+      expect(b.status).toBe('locked');
+    }
+
+    // The portal_users are locked too (each contact's was their only binding).
+    const userIds = bindings.map((b) => b.portal_user_id);
+    const users = await db.any(
+      `SELECT id, deactivated_at, status FROM admin.portal_users WHERE id = ANY($1::uuid[])`,
+      [userIds],
+    );
+    expect(users).toHaveLength(2);
+    for (const u of users) {
+      expect(u.deactivated_at).not.toBeNull();
+      expect(u.status).toBe('locked');
+    }
+  });
+
+  test('restore by ?code= succeeds for an archived vendor and restores the cohort', async () => {
+    const res = await request(app)
+      .patch(`/api/core/v1/vendors/restore?code=VC001`)
+      .set('Cookie', tenantCookies);
+    expect(res.status).toBe(200);
+
+    // Vendor active again.
+    const vendor = await db.oneOrNone(`SELECT deactivated_at FROM vcasc.vendors WHERE id = $1`, [vendorId]);
+    expect(vendor.deactivated_at).toBeNull();
+
+    // Both vendor_contacts restored (they shared the same MAX deactivated_at
+    // from the cascade-archive a moment ago).
+    const contacts = await db.any(
+      `SELECT id, deactivated_at FROM vcasc.vendor_contacts WHERE vendor_id = $1`,
+      [vendorId],
+    );
+    expect(contacts).toHaveLength(2);
+    for (const c of contacts) expect(c.deactivated_at).toBeNull();
+
+    // Bindings: deactivated_at cleared; `status` intentionally left at 'locked'
+    // — the restore rule of record only touches deactivated_at.
+    const bindings = await db.any(
+      `SELECT deactivated_at, status, portal_user_id FROM admin.portal_user_tenants
+       WHERE entity_type = 'vendor_contact' AND entity_id = ANY($1::uuid[])`,
+      [[contactA.id, contactB.id]],
+    );
+    expect(bindings).toHaveLength(2);
+    for (const b of bindings) {
+      expect(b.deactivated_at).toBeNull();
+      expect(b.status).toBe('locked');
+    }
+
+    // portal_users: same — restored timestamp, locked status preserved.
+    const userIds = bindings.map((b) => b.portal_user_id);
+    const users = await db.any(
+      `SELECT deactivated_at, status FROM admin.portal_users WHERE id = ANY($1::uuid[])`,
+      [userIds],
+    );
+    expect(users).toHaveLength(2);
+    for (const u of users) {
+      expect(u.deactivated_at).toBeNull();
+      expect(u.status).toBe('locked');
+    }
+  });
+});

--- a/apps/server/tests/integration/entityLifecycle.test.js
+++ b/apps/server/tests/integration/entityLifecycle.test.js
@@ -114,12 +114,16 @@ describe('Entity lifecycle — employee is_app_user with portal_users cascade', 
     expect(res.status).not.toBe(200);
   });
 
-  test('5. Restore employee cascades to restore portal_user', async () => {
+  test('5. Restore employee cascades to restore portal_user (deactivated_at only; status preserved)', async () => {
     const res = await request(app).patch(`/api/core/v1/employees/restore?id=${employeeId}`).set('Cookie', tenantCookies).send({});
 
     expect(res.status).toBe(200);
 
-    // Verify portal_user is restored
+    // Per the cascade-restore rule of record: clear deactivated_at on the
+    // binding cohort sharing the MAX deactivated_at, AND on the linked
+    // portal_users — but never touch `status`. The portal_user was set to
+    // 'locked' by the archive cascade and stays at 'locked' until the
+    // user is explicitly reactivated.
     const portalUser = await db.oneOrNone(
       `SELECT pu.status, pu.deactivated_at
        FROM admin.portal_users pu
@@ -127,8 +131,8 @@ describe('Entity lifecycle — employee is_app_user with portal_users cascade', 
        WHERE b.entity_type = 'employee' AND b.entity_id = $1`,
       [employeeId],
     );
-    expect(portalUser.status).toBe('active');
     expect(portalUser.deactivated_at).toBeNull();
+    expect(portalUser.status).toBe('locked');
   });
 
   test('6. Source record was created for employee', async () => {

--- a/apps/server/tests/integration/tenantLifecycle.test.js
+++ b/apps/server/tests/integration/tenantLifecycle.test.js
@@ -143,7 +143,7 @@ describe('Tenant lifecycle — create, provision, archive, restore', () => {
     expect(res.status).toBeGreaterThanOrEqual(400);
   });
 
-  test('8. Restore tenant — tenant reactivated but users remain archived', async () => {
+  test('8. Restore tenant — cascade-restores the binding cohort locked by the same archive', async () => {
     const cookies = await loginRoot();
 
     const res = await request(app)
@@ -153,13 +153,24 @@ describe('Tenant lifecycle — create, provision, archive, restore', () => {
 
     expect(res.status).toBe(200);
 
-    // Tenant should be active again
+    // Tenant is active again.
     const tenant = await db.oneOrNone('SELECT * FROM admin.tenants WHERE id = $1', [tenantId]);
     expect(tenant.deactivated_at).toBeNull();
 
-    // User should still be archived (users must be restored individually)
+    // Per the cascade-restore rule of record, the bindings sharing the
+    // tenant's MAX(deactivated_at) cohort come back too, along with their
+    // portal_users. `status` is intentionally untouched — the admin user's
+    // status stays at 'locked' from the archive cascade.
     const user = await db.oneOrNone('SELECT * FROM admin.portal_users WHERE id = $1', [adminUserId]);
-    expect(user.deactivated_at).not.toBeNull();
+    expect(user.deactivated_at).toBeNull();
+    expect(user.status).toBe('locked');
+
+    const binding = await db.oneOrNone(
+      'SELECT deactivated_at, status FROM admin.portal_user_tenants WHERE portal_user_id = $1 AND tenant_id = $2',
+      [adminUserId, tenantId],
+    );
+    expect(binding.deactivated_at).toBeNull();
+    expect(binding.status).toBe('locked');
   });
 });
 


### PR DESCRIPTION
## Summary

- Extracts archive/restore cascade into a shared `portalUserCascade` service and rewrites restore to clear `deactivated_at` on every binding sharing the MAX `deactivated_at` for the entity (or tenant). `status` is intentionally not touched — restoring an archived parent only flips `deactivated_at`, never re-grants a role state the deactivation timestamp didn't encode.
- Adds the missing cascade on vendor archive/restore. Archiving a vendor now archives every active vendor_contact under it and locks the portal_user binding + portal_user (scoped via `RETURNING` so multi-tenant users with other active bindings stay live). Restoring a vendor brings back the vendor_contact cohort sharing the vendor's MAX `deactivated_at` plus their binding/user pair.
- Tenant restore now cascades to the binding cohort locked together with the tenant, instead of leaving every user archived. Two integration tests asserted the old behavior (`status='active'` after entity restore; users stay archived on tenant restore) and have been updated to lock in the new contract.

This is the first of two PRs implementing the cascade-and-restore-via-import feature. Follow-on PR will land the importer per-row classifier (flat + combined), the `restored` preview bucket, child-controller JSDoc, and the ADR.

## Test plan

- [x] `npm run lint`
- [x] `npm -w apps/server test` (712 ✓)
- [ ] Manual smoke: archive a vendor with two contacts → vendor_contacts archived + portal_users locked; restore the vendor → both come back, `status` unchanged on the portal_user.