### PR TITLE
feat: child restore via import (cascade-restore follow-on, phases 4–8)

### DIFF
--- a/apps/client/src/components/shared/ImportDialog.jsx
+++ b/apps/client/src/components/shared/ImportDialog.jsx
@@ -29,11 +29,19 @@ import FormDialog from './FormDialog.jsx';
 import SecondaryButton from './SecondaryButton.jsx';
 
 function PreviewBucket({ label, counts }) {
+  // `restores` is the per-row count of soft-deleted child rows that the
+  // importer would resurrect via natural-key match (see ADR-0026). Optional
+  // on the server response — render only when present and non-zero so older
+  // importers without the bucket don't show a redundant "Restored: 0".
+  const showRestored = typeof counts.restores === 'number' && counts.restores > 0;
   return (
     <Stack spacing={0.25}>
       <Typography variant="body2" sx={{ fontWeight: 600 }}>{label}</Typography>
       <Typography variant="body2">New rows: <strong>{counts.inserts}</strong></Typography>
       <Typography variant="body2">Updates in place: <strong>{counts.updates}</strong></Typography>
+      {showRestored && (
+        <Typography variant="body2">Restored from trash: <strong>{counts.restores}</strong></Typography>
+      )}
       <Typography variant="body2">Unchanged: <strong>{counts.noops}</strong></Typography>
       {typeof counts.omitted === 'number' && (
         <Typography variant="body2">Existing rows not in file (left unchanged): <strong>{counts.omitted}</strong></Typography>

--- a/apps/client/src/components/shared/ImportDialog.jsx
+++ b/apps/client/src/components/shared/ImportDialog.jsx
@@ -7,8 +7,11 @@
  *     is invoked with the FormData.
  *   - With `onPreview`: mandatory three-step flow — pick file → preview
  *     (counts or errors) → confirm. onPreview must resolve to the server's
- *     preview payload `{ preview: true, inserts, updates, noops, omitted, errors }`
- *     or throw with `err.payload.errors` if validation failed.
+ *     preview payload `{ preview: true, inserts, updates, restores, noops, omitted, errors }`
+ *     (single bucket) or `{ preview: true, vendors: {...}, contacts: {...}, errors }`
+ *     (combined Vendors+VendorContacts). `restores` and `omitted` are optional
+ *     per importer. onPreview should throw with `err.payload.errors` if
+ *     validation failed.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */

--- a/apps/client/src/components/shared/ImportDialog.jsx
+++ b/apps/client/src/components/shared/ImportDialog.jsx
@@ -39,7 +39,9 @@ function PreviewBucket({ label, counts }) {
   const showRestored = typeof counts.restores === 'number' && counts.restores > 0;
   return (
     <Stack spacing={0.25}>
-      <Typography variant="body2" sx={{ fontWeight: 600 }}>{label}</Typography>
+      {label && (
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>{label}</Typography>
+      )}
       <Typography variant="body2">New rows: <strong>{counts.inserts}</strong></Typography>
       <Typography variant="body2">Updates in place: <strong>{counts.updates}</strong></Typography>
       {showRestored && (
@@ -165,12 +167,12 @@ export default function ImportDialog({
               <PreviewBucket label="Vendor Contacts" counts={previewData.contacts} />
             </Stack>
           ) : (
-            <Stack spacing={0.5}>
-              <Typography variant="body2">New rows: <strong>{previewData.inserts}</strong></Typography>
-              <Typography variant="body2">Updates in place: <strong>{previewData.updates}</strong></Typography>
-              <Typography variant="body2">Unchanged: <strong>{previewData.noops}</strong></Typography>
-              <Typography variant="body2">Existing rows not in file (left unchanged): <strong>{previewData.omitted}</strong></Typography>
-            </Stack>
+            // Single-bucket render goes through PreviewBucket too so the
+            // conditional `restores` line surfaces for flat imports (not just
+            // the combined Vendors+Contacts shape rendered above). Label is
+            // omitted for the single-bucket case to keep the existing
+            // visual unchanged.
+            <PreviewBucket label="" counts={previewData} />
           )}
         </Alert>
       )}

--- a/apps/client/src/pages/Core/ClientsPage.jsx
+++ b/apps/client/src/pages/Core/ClientsPage.jsx
@@ -202,7 +202,16 @@ export default function ClientsPage() {
     setImportErrors(null);
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const inserted = result.inserted || 0;
+      const updated = result.updated || 0;
+      const restored = result.restored || 0;
+      if (inserted === 0 && updated === 0 && restored === 0) {
+        toast('Import complete — no changes');
+      } else {
+        const parts = [`${inserted} new`, `${updated} updated`];
+        if (restored > 0) parts.push(`${restored} restored`);
+        toast(`Clients: ${parts.join(', ')}`);
+      }
       importDialog.close();
     } catch (err) {
       const validationErrors = err.payload?.errors;

--- a/apps/client/src/pages/Core/ClientsPage.jsx
+++ b/apps/client/src/pages/Core/ClientsPage.jsx
@@ -205,7 +205,12 @@ export default function ClientsPage() {
       const inserted = result.inserted || 0;
       const updated = result.updated || 0;
       const restored = result.restored || 0;
-      if (inserted === 0 && updated === 0 && restored === 0) {
+      // Child-only edits leave parent counts at zero — see comment in
+      // EmployeesPage.handleImport for rationale.
+      const childInserted = result.childInserted || 0;
+      const childUpdated = result.childUpdated || 0;
+      const anyWrite = inserted || updated || restored || childInserted || childUpdated;
+      if (!anyWrite) {
         toast('Import complete — no changes');
       } else {
         const parts = [`${inserted} new`, `${updated} updated`];

--- a/apps/client/src/pages/Core/ClientsPage.jsx
+++ b/apps/client/src/pages/Core/ClientsPage.jsx
@@ -202,18 +202,16 @@ export default function ClientsPage() {
     setImportErrors(null);
     try {
       const result = await importMut.mutateAsync(formData);
-      const inserted = result.inserted || 0;
-      const updated = result.updated || 0;
+      // Roll parent + child counts into the displayed numbers — see the
+      // comment on EmployeesPage.handleImport.
+      const newTotal = (result.inserted || 0) + (result.childInserted || 0);
+      const updatedTotal = (result.updated || 0) + (result.childUpdated || 0);
       const restored = result.restored || 0;
-      // Child-only edits leave parent counts at zero — see comment in
-      // EmployeesPage.handleImport for rationale.
-      const childInserted = result.childInserted || 0;
-      const childUpdated = result.childUpdated || 0;
-      const anyWrite = inserted || updated || restored || childInserted || childUpdated;
+      const anyWrite = newTotal || updatedTotal || restored;
       if (!anyWrite) {
         toast('Import complete — no changes');
       } else {
-        const parts = [`${inserted} new`, `${updated} updated`];
+        const parts = [`${newTotal} new`, `${updatedTotal} updated`];
         if (restored > 0) parts.push(`${restored} restored`);
         toast(`Clients: ${parts.join(', ')}`);
       }

--- a/apps/client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/client/src/pages/Core/EmployeesPage.jsx
@@ -220,7 +220,16 @@ export default function EmployeesPage() {
     setImportErrors(null);
     try {
       const result = await importMut.mutateAsync(formData);
-      toast(`Imported ${result.inserted} records`);
+      const inserted = result.inserted || 0;
+      const updated = result.updated || 0;
+      const restored = result.restored || 0;
+      if (inserted === 0 && updated === 0 && restored === 0) {
+        toast('Import complete — no changes');
+      } else {
+        const parts = [`${inserted} new`, `${updated} updated`];
+        if (restored > 0) parts.push(`${restored} restored`);
+        toast(`Employees: ${parts.join(', ')}`);
+      }
       importDialog.close();
     } catch (err) {
       const validationErrors = err.payload?.errors;

--- a/apps/client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/client/src/pages/Core/EmployeesPage.jsx
@@ -223,7 +223,14 @@ export default function EmployeesPage() {
       const inserted = result.inserted || 0;
       const updated = result.updated || 0;
       const restored = result.restored || 0;
-      if (inserted === 0 && updated === 0 && restored === 0) {
+      // Child counts (child rows written via reconcile) are separate from
+      // parent counts — a child-only edit leaves parent inserted/updated at
+      // zero. Include them in the "any writes?" check so the toast doesn't
+      // claim "no changes" when a phone or address was actually written.
+      const childInserted = result.childInserted || 0;
+      const childUpdated = result.childUpdated || 0;
+      const anyWrite = inserted || updated || restored || childInserted || childUpdated;
+      if (!anyWrite) {
         toast('Import complete — no changes');
       } else {
         const parts = [`${inserted} new`, `${updated} updated`];

--- a/apps/client/src/pages/Core/EmployeesPage.jsx
+++ b/apps/client/src/pages/Core/EmployeesPage.jsx
@@ -220,20 +220,18 @@ export default function EmployeesPage() {
     setImportErrors(null);
     try {
       const result = await importMut.mutateAsync(formData);
-      const inserted = result.inserted || 0;
-      const updated = result.updated || 0;
+      // Roll parent + child counts into the displayed numbers — a child-only
+      // edit (phone, address, etc.) leaves parent inserted/updated at zero
+      // but is still a write the user should see reflected. The toast
+      // shows total rows written, mixed across parent and child.
+      const newTotal = (result.inserted || 0) + (result.childInserted || 0);
+      const updatedTotal = (result.updated || 0) + (result.childUpdated || 0);
       const restored = result.restored || 0;
-      // Child counts (child rows written via reconcile) are separate from
-      // parent counts — a child-only edit leaves parent inserted/updated at
-      // zero. Include them in the "any writes?" check so the toast doesn't
-      // claim "no changes" when a phone or address was actually written.
-      const childInserted = result.childInserted || 0;
-      const childUpdated = result.childUpdated || 0;
-      const anyWrite = inserted || updated || restored || childInserted || childUpdated;
+      const anyWrite = newTotal || updatedTotal || restored;
       if (!anyWrite) {
         toast('Import complete — no changes');
       } else {
-        const parts = [`${inserted} new`, `${updated} updated`];
+        const parts = [`${newTotal} new`, `${updatedTotal} updated`];
         if (restored > 0) parts.push(`${restored} restored`);
         toast(`Employees: ${parts.join(', ')}`);
       }

--- a/apps/client/src/pages/Core/VendorsPage.jsx
+++ b/apps/client/src/pages/Core/VendorsPage.jsx
@@ -267,12 +267,19 @@ export default function VendorsPage() {
       const result = await importMut.mutateAsync(formData);
       const vIns = result.inserted || 0;
       const vUpd = result.updated || 0;
+      const vRes = result.restored || 0;
       const cIns = result.contactsInserted || 0;
       const cUpd = result.contactsUpdated || 0;
-      const allZero = !vIns && !vUpd && !cIns && !cUpd;
+      const cRes = result.contactsRestored || 0;
+      const allZero = !vIns && !vUpd && !vRes && !cIns && !cUpd && !cRes;
+      const fmt = (i, u, r) => {
+        const parts = [`${i} new`, `${u} updated`];
+        if (r > 0) parts.push(`${r} restored`);
+        return parts.join(', ');
+      };
       const message = allZero
         ? 'Import complete — no changes'
-        : `Vendors: ${vIns} new, ${vUpd} updated • Contacts: ${cIns} new, ${cUpd} updated`;
+        : `Vendors: ${fmt(vIns, vUpd, vRes)} • Contacts: ${fmt(cIns, cUpd, cRes)}`;
       toast(message);
       importDialog.close();
     } catch (err) {

--- a/apps/client/src/pages/Core/VendorsPage.jsx
+++ b/apps/client/src/pages/Core/VendorsPage.jsx
@@ -265,19 +265,17 @@ export default function VendorsPage() {
     setImportErrors(null);
     try {
       const result = await importMut.mutateAsync(formData);
-      const vIns = result.inserted || 0;
-      const vUpd = result.updated || 0;
+      // Roll parent + child counts into the displayed numbers — a child-only
+      // edit (phone, address) leaves parent counters at zero but is still a
+      // write the user should see. Vendors and Contacts get their own
+      // totals so the message stays scoped per entity.
+      const vNew = (result.inserted || 0) + (result.childInserted || 0);
+      const vUpd = (result.updated || 0) + (result.childUpdated || 0);
       const vRes = result.restored || 0;
-      const cIns = result.contactsInserted || 0;
-      const cUpd = result.contactsUpdated || 0;
+      const cNew = (result.contactsInserted || 0) + (result.contactsChildInserted || 0);
+      const cUpd = (result.contactsUpdated || 0) + (result.contactsChildUpdated || 0);
       const cRes = result.contactsRestored || 0;
-      // Child counts (rows written via reconcile) are separate from parent
-      // counts — a child-only edit leaves the parent counters at zero.
-      // Include them in the "any writes?" check so the toast doesn't claim
-      // "no changes" when a phone or address was actually written.
-      const vChild = (result.childInserted || 0) + (result.childUpdated || 0);
-      const cChild = (result.contactsChildInserted || 0) + (result.contactsChildUpdated || 0);
-      const allZero = !vIns && !vUpd && !vRes && !vChild && !cIns && !cUpd && !cRes && !cChild;
+      const allZero = !vNew && !vUpd && !vRes && !cNew && !cUpd && !cRes;
       const fmt = (i, u, r) => {
         const parts = [`${i} new`, `${u} updated`];
         if (r > 0) parts.push(`${r} restored`);
@@ -285,7 +283,7 @@ export default function VendorsPage() {
       };
       const message = allZero
         ? 'Import complete — no changes'
-        : `Vendors: ${fmt(vIns, vUpd, vRes)} • Contacts: ${fmt(cIns, cUpd, cRes)}`;
+        : `Vendors: ${fmt(vNew, vUpd, vRes)} • Contacts: ${fmt(cNew, cUpd, cRes)}`;
       toast(message);
       importDialog.close();
     } catch (err) {

--- a/apps/client/src/pages/Core/VendorsPage.jsx
+++ b/apps/client/src/pages/Core/VendorsPage.jsx
@@ -271,7 +271,13 @@ export default function VendorsPage() {
       const cIns = result.contactsInserted || 0;
       const cUpd = result.contactsUpdated || 0;
       const cRes = result.contactsRestored || 0;
-      const allZero = !vIns && !vUpd && !vRes && !cIns && !cUpd && !cRes;
+      // Child counts (rows written via reconcile) are separate from parent
+      // counts — a child-only edit leaves the parent counters at zero.
+      // Include them in the "any writes?" check so the toast doesn't claim
+      // "no changes" when a phone or address was actually written.
+      const vChild = (result.childInserted || 0) + (result.childUpdated || 0);
+      const cChild = (result.contactsChildInserted || 0) + (result.contactsChildUpdated || 0);
+      const allZero = !vIns && !vUpd && !vRes && !vChild && !cIns && !cUpd && !cRes && !cChild;
       const fmt = (i, u, r) => {
         const parts = [`${i} new`, `${u} updated`];
         if (r > 0) parts.push(`${r} restored`);

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -2352,6 +2352,8 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
   let insertedCount = 0;
   let updatedCount = 0;
   let restoredCount = 0;
+  let childInsertedCount = 0;
+  let childUpdatedCount = 0;
   let appUserSkipped = 0;
 
   try {
@@ -2457,6 +2459,8 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
         if (sourceId) {
           const childCounts = await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, group.children, config.flat.children, callbackFn, tenantId);
           restoredCount += childCounts.restores;
+          childInsertedCount += childCounts.inserts;
+          childUpdatedCount += childCounts.updates;
         }
 
         // ── Login email portal_users sync (L1) ───────────────────────────
@@ -2621,6 +2625,8 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
           if (sourceId) {
             const childCounts = await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, toInsert[i].group.children, config.flat.children, callbackFn, tenantId);
             restoredCount += childCounts.restores;
+            childInsertedCount += childCounts.inserts;
+            childUpdatedCount += childCounts.updates;
           }
         }
 
@@ -2677,6 +2683,14 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
     inserted: insertedCount,
     updated: updatedCount,
     restored: restoredCount,
+    // Per-child writes bubble into the top-level response too. Without these
+    // the client toast can't tell whether a child-only edit produced writes
+    // (parent counts stay zero in that case) — without them, "Import
+    // complete — no changes" lies. Preview's counts already mix parent and
+    // child operations, so reporting both here keeps preview and commit
+    // aligned on what the user sees.
+    childInserted: childInsertedCount,
+    childUpdated: childUpdatedCount,
     appUserSkipped,
   };
 }

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -2345,7 +2345,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
 
   // Preview short-circuit (R10). Classify what *would* happen without writing.
   if (previewOnly) {
-    const counts = await _classifyForPreview(db, s, pgp, schema, groups, config, ownEntities);
+    const counts = await _classifyForPreview(db, s, pgp, schema, groups, config, ownEntities, callbackFn, tenantId);
     return { preview: true, ...counts, errors: [] };
   }
 
@@ -2707,7 +2707,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
  *
  * @private
  */
-async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntities) {
+async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntities, callbackFn = null, tenantId = null) {
   let inserts = 0;
   let updates = 0;
   let restores = 0;
@@ -2757,24 +2757,40 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
       .filter((sid) => !!sid);
 
     const existingBySource = new Map();
+    let childModel = null;
     if (existingSourceIds.length) {
-      const childModel = db(cfg.modelName, schema);
+      childModel = db(cfg.modelName, schema);
       const tableName = childModel._schema?.table || cfg.modelName;
       const tName = pgp.as.name(tableName);
+      // Match `_reconcileChildrenForSource`'s ORDER BY contract so preview
+      // and commit see existing rows in the same order — required for
+      // deterministic archived selection inside `_classifyChildren`.
       const rows = await db.any(
-        `SELECT * FROM ${s}.${tName} WHERE source_id IN ($1:csv)`,
+        `SELECT * FROM ${s}.${tName}
+          WHERE source_id IN ($1:csv)
+          ORDER BY source_id, deactivated_at IS NOT NULL, deactivated_at DESC`,
         [existingSourceIds],
       );
       for (const r of rows) {
         if (!existingBySource.has(r.source_id)) existingBySource.set(r.source_id, []);
         existingBySource.get(r.source_id).push(r);
       }
+    } else {
+      childModel = db(cfg.modelName, schema);
     }
 
     for (const group of groupsWithChildren) {
-      const incoming = group.children[cfg.key] || [];
+      const rawIncoming = group.children[cfg.key] || [];
       const ownSource = group._ownSourceId;
       const existing = ownSource ? (existingBySource.get(ownSource) || []) : [];
+      // Normalize incoming the same way commit will — callbackFn,
+      // coerceChildRow, boolean defaults, single is_primary — so preview
+      // classification matches the writes commit will perform. Raw
+      // spreadsheet rows compare incorrectly against DB values (string
+      // 'true' vs bool true, etc).
+      const incoming = ownSource
+        ? await _transformAndNormalizeChildRows(rawIncoming, ownSource, childModel, callbackFn, tenantId)
+        : rawIncoming;
       const { counts, claimedExistingIds, seenIncomingSlots } = _classifyChildren(existing, incoming, cfg);
 
       inserts += counts.inserts;
@@ -3146,6 +3162,49 @@ async function _collectCrossSourceConflicts(db, s, pgp, schema, ownSourceType, g
  * the existing set when needed.
  * @private
  */
+/**
+ * Bring incoming spreadsheet child rows into the same shape commit will
+ * write: apply callbackFn (typically threads tenant_id / created_by from
+ * the controller), strip ephemeral `tenant_code`, coerce per the child
+ * model's column types (booleans, numerics, dates), backfill notNull
+ * boolean defaults, and demote all-but-first `is_primary=true` so the
+ * partial unique index `(source_id) WHERE is_primary AND NOT deactivated`
+ * can't trip.
+ *
+ * Shared by `_reconcileChildrenForSource` (commit) and `_classifyForPreview`
+ * (preview) so preview classifications match commit reality — without this,
+ * preview sees string `'true'` against existing bool `true` (and so on) and
+ * misreports updates / noops / restores vs. what commit will actually do.
+ * @private
+ */
+async function _transformAndNormalizeChildRows(childRows, sourceId, childModel, callbackFn, tenantId) {
+  const out = [];
+  for (const row of childRows) {
+    const { _rowNum: _, ...rest } = row;
+    const base = { ...rest, source_id: sourceId };
+    const transformed = callbackFn ? await callbackFn(base) : base;
+    delete transformed.tenant_code;
+    if (tenantId) transformed.tenant_id = tenantId;
+    coerceChildRow(transformed, childModel);
+    for (const col of childModel._schema?.columns || []) {
+      if (col.type === 'boolean' && col.notNull && transformed[col.name] == null) {
+        transformed[col.name] = col.default ?? false;
+      }
+    }
+    out.push(transformed);
+  }
+  if (out.length > 1) {
+    let seenPrimary = false;
+    for (const r of out) {
+      if (r.is_primary === true) {
+        if (seenPrimary) r.is_primary = false;
+        else seenPrimary = true;
+      }
+    }
+  }
+  return out;
+}
+
 export function _classifyChildren(existingRows, incomingRows, cfg) {
   const activeBySlot = new Map();
   const activeByValue = new Map();
@@ -3264,11 +3323,11 @@ export async function _reconcileChildrenForSource(t, s, schema, db, pgp, sourceI
 
   // Load BOTH active and archived children for this source — the classifier
   // needs the trash bin too so a re-imported value can resurrect its row.
-  // ORDER BY `deactivated_at` ascending with NULLs first puts active rows up
-  // top (NULL deactivated_at) then archived rows most-recent-first; combined
-  // with `_classifyChildren`'s first-match-wins maps, that gives deterministic
-  // selection when multiple archived rows share a slot/value key (partial
-  // unique indexes only enforce uniqueness for active rows).
+  // `deactivated_at IS NOT NULL` sorts false (active) before true (archived),
+  // then `deactivated_at DESC` orders the archived portion most-recent-first.
+  // Combined with `_classifyChildren`'s first-match-wins maps, that yields
+  // deterministic selection when multiple archived rows share a slot/value
+  // key (partial unique indexes only enforce uniqueness for active rows).
   const existing = existingRows != null
     ? existingRows
     : await t.any(
@@ -3278,37 +3337,7 @@ export async function _reconcileChildrenForSource(t, s, schema, db, pgp, sourceI
         [sourceId],
       );
 
-  // Transform every incoming row to the child-table shape before classifying.
-  const transformedRows = [];
-  for (const row of childRows) {
-    const { _rowNum: _, ...rest } = row;
-    const base = { ...rest, source_id: sourceId };
-    const transformed = callbackFn ? await callbackFn(base) : base;
-    delete transformed.tenant_code;
-    if (tenantId) transformed.tenant_id = tenantId;
-    coerceChildRow(transformed, childModel);
-    for (const col of childModel._schema?.columns || []) {
-      if (col.type === 'boolean' && col.notNull && transformed[col.name] == null) {
-        transformed[col.name] = col.default ?? false;
-      }
-    }
-    transformedRows.push(transformed);
-  }
-
-  // Enforce single is_primary per source. The emails and phone_numbers
-  // tables carry a partial unique index `(source_id) WHERE is_primary AND
-  // NOT deactivated`, so the spreadsheet can't supply two primaries — we
-  // demote all but the first to false. No-op for tables without is_primary
-  // (addresses, tax_identifiers don't carry the column).
-  if (transformedRows.length > 1) {
-    let seenPrimary = false;
-    for (const r of transformedRows) {
-      if (r.is_primary === true) {
-        if (seenPrimary) r.is_primary = false;
-        else seenPrimary = true;
-      }
-    }
-  }
+  const transformedRows = await _transformAndNormalizeChildRows(childRows, sourceId, childModel, callbackFn, tenantId);
 
   const { classifications, counts } = _classifyChildren(existing, transformedRows, cfg);
 

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -3144,25 +3144,6 @@ async function _collectCrossSourceConflicts(db, s, pgp, schema, ownSourceType, g
 }
 
 /**
- * Pure classifier used by both preview and commit paths. Given the full
- * existing-children set (active AND archived) plus the incoming rows for a
- * single source, return per-row classifications and aggregate counts.
- *
- * Match priority for each incoming row:
- *   1. active slot key
- *   2. active value key (catches a slot rename — e.g. an email moves from
- *      label="work" to label="primary" but the email address itself is
- *      stable)
- *   3. archived slot key      → restore (and update if values differ)
- *   4. archived value key     → restore (+ update if values differ)
- *   5. no match → insert
- *
- * Actions emitted per row: 'insert' | 'update' | 'restore' | 'restore+update' | 'noop'.
- * `claimedExistingIds` is returned so the caller can compute `omitted` against
- * the existing set when needed.
- * @private
- */
-/**
  * Bring incoming spreadsheet child rows into the same shape commit will
  * write: apply callbackFn (typically threads tenant_id / created_by from
  * the controller), strip ephemeral `tenant_code`, coerce per the child
@@ -3205,6 +3186,25 @@ async function _transformAndNormalizeChildRows(childRows, sourceId, childModel, 
   return out;
 }
 
+/**
+ * Pure classifier used by both preview and commit paths. Given the full
+ * existing-children set (active AND archived) plus the incoming rows for a
+ * single source, return per-row classifications and aggregate counts.
+ *
+ * Match priority for each incoming row:
+ *   1. active slot key
+ *   2. active value key (catches a slot rename — e.g. an email moves from
+ *      label="work" to label="primary" but the email address itself is
+ *      stable)
+ *   3. archived slot key      → restore (and update if values differ)
+ *   4. archived value key     → restore (+ update if values differ)
+ *   5. no match → insert
+ *
+ * Actions emitted per row: 'insert' | 'update' | 'restore' | 'restore+update' | 'noop'.
+ * `claimedExistingIds` is returned so the caller can compute `omitted` against
+ * the existing set when needed.
+ * @private
+ */
 export function _classifyChildren(existingRows, incomingRows, cfg) {
   const activeBySlot = new Map();
   const activeByValue = new Map();

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -1403,7 +1403,7 @@ export async function importSourceEntity(model, filePath, _sheetIndex, callbackF
       for (let ci = 0; ci < config.childSheets.length; ci++) {
         const sheetIdx = ci + 1;
         if (reader.sheetCount > sheetIdx) {
-          const count = await importChildSheet(
+          const counts = await importChildSheet(
             reader,
             sheetIdx,
             refToSourceId,
@@ -1414,10 +1414,14 @@ export async function importSourceEntity(model, filePath, _sheetIndex, callbackF
             tenantId,
             t,
           );
-          // Map child model names to result keys
-          if (config.childSheets[ci].modelName === 'phoneNumbers') phonesCount = count;
-          else if (config.childSheets[ci].modelName === 'addresses') addressesCount = count;
-          else if (config.childSheets[ci].modelName === 'taxIdentifiers') taxIdsCount = count;
+          // Map child model names to result keys. The shared classifier now
+          // returns { inserts, updates, restores, noops }; flatten to a single
+          // "rows touched" number for the legacy response shape (inserts +
+          // updates + restores = anything that wrote, not counting noops).
+          const touched = counts.inserts + counts.updates + counts.restores;
+          if (config.childSheets[ci].modelName === 'phoneNumbers') phonesCount = touched;
+          else if (config.childSheets[ci].modelName === 'addresses') addressesCount = touched;
+          else if (config.childSheets[ci].modelName === 'taxIdentifiers') taxIdsCount = touched;
         }
       }
 
@@ -1484,8 +1488,14 @@ export async function importSourceEntity(model, filePath, _sheetIndex, callbackF
 }
 
 /**
- * Parse and import a child sheet using delete-and-reinsert per parent.
- * Resolves parent linkage column → source_id.
+ * Parse and import a child sheet (used by the combined Vendors+VendorContacts
+ * importer). For each row, group by resolved `source_id` and reconcile each
+ * source via the shared archive-aware classifier (`_reconcileChildrenForSource`).
+ *
+ * Replaces the previous wholesale "soft-delete every active child per affected
+ * source, then bulk-insert from sheet" behavior with per-row insert / update /
+ * restore / restore+update / noop — same shape as the flat single-entity
+ * importer.
  *
  * @param {Object}   reader         WorkbookReader instance
  * @param {number}   sheetIndex     0-based sheet index
@@ -1496,50 +1506,49 @@ export async function importSourceEntity(model, filePath, _sheetIndex, callbackF
  * @param {Function} callbackFn     Row transformer
  * @param {string}   tenantId       Resolved tenant UUID
  * @param {Object}   t              Transaction object
- * @returns {Promise<number>} Number of rows inserted
+ * @returns {Promise<{inserts: number, updates: number, restores: number, noops: number}>}
  */
 export async function importChildSheet(reader, sheetIndex, refToSourceId, modelName, schema, linkColName, callbackFn, tenantId, t) {
   const childRows = parseSheet(reader, sheetIndex);
-  if (!childRows.length) return 0;
+  if (!childRows.length) return { inserts: 0, updates: 0, restores: 0, noops: 0 };
+
+  // Resolve descriptor at call time so the lookup happens AFTER the
+  // FLAT_CHILD_* exports lower in this file have initialized.
+  const _COMBINED_CHILD_DESCRIPTORS = {
+    emails: FLAT_CHILD_EMAILS,
+    phoneNumbers: FLAT_CHILD_PHONES,
+    addresses: FLAT_CHILD_ADDRESSES,
+    taxIdentifiers: FLAT_CHILD_TAX_IDS,
+  };
+  const cfg = _COMBINED_CHILD_DESCRIPTORS[modelName];
+  if (!cfg) {
+    throw new Error(`importChildSheet: no descriptor registered for modelName='${modelName}'`);
+  }
 
   const { db, pgp } = await getDb();
   const s = pgp.as.name(schema);
-  const childModel = db(modelName, schema);
-  childModel.tx = t;
 
-  const toInsert = [];
-  const affectedSourceIds = new Set();
-
+  // Bucket rows by resolved source_id. Rows whose parent ref can't be resolved
+  // are silently dropped (same as the prior behavior).
+  const rowsBySource = new Map();
   for (const row of childRows) {
     const parentRef = row[linkColName];
-    delete row[linkColName];
-    delete row.deactivated_at;
-    delete row.id;
-
+    const { [linkColName]: _link, id: _id, deactivated_at: _da, ...rest } = row;
     const sourceId = refToSourceId.get(parentRef);
-    if (!sourceId) continue; // can't link — skip
-
-    affectedSourceIds.add(sourceId);
-    const base = { ...row, source_id: sourceId };
-    const transformed = callbackFn ? await callbackFn(base) : base;
-    delete transformed.tenant_code;
-    if (tenantId) transformed.tenant_id = tenantId;
-    coerceChildRow(transformed, childModel);
-    toInsert.push(transformed);
+    if (!sourceId) continue;
+    if (!rowsBySource.has(sourceId)) rowsBySource.set(sourceId, []);
+    rowsBySource.get(sourceId).push(rest);
   }
 
-  if (!toInsert.length) return 0;
-
-  // Soft-delete existing child rows for affected parents
-  const tableName = childModel._schema?.table || modelName;
-  const sourceIdArray = [...affectedSourceIds];
-  await t.none(`UPDATE ${s}.${pgp.as.name(tableName)} SET deactivated_at = NOW() WHERE source_id IN ($1:csv) AND deactivated_at IS NULL`, [
-    sourceIdArray,
-  ]);
-
-  // Insert all rows from the sheet
-  const result = await childModel.bulkInsert(toInsert);
-  return typeof result === 'number' ? result : toInsert.length;
+  const totals = { inserts: 0, updates: 0, restores: 0, noops: 0 };
+  for (const [sourceId, sourceRows] of rowsBySource) {
+    const counts = await _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, sourceRows, cfg, callbackFn, tenantId);
+    totals.inserts += counts.inserts;
+    totals.updates += counts.updates;
+    totals.restores += counts.restores;
+    totals.noops += counts.noops;
+  }
+  return totals;
 }
 
 /**
@@ -2308,7 +2317,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
 
   if (errors.length) {
     return previewOnly
-      ? { preview: true, inserts: 0, updates: 0, noops: 0, omitted: 0, errors }
+      ? { preview: true, inserts: 0, updates: 0, restores: 0, noops: 0, omitted: 0, errors }
       : { errors };
   }
 
@@ -2320,6 +2329,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
 
   let insertedCount = 0;
   let updatedCount = 0;
+  let restoredCount = 0;
   let appUserSkipped = 0;
 
   try {
@@ -2420,10 +2430,11 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
           }
         }
 
-        // Reconcile children for this entity (slot-keyed, NO-OPs preserved)
+        // Reconcile children for this entity (slot-keyed, archive-aware).
         const sourceId = group._ownSourceId;
         if (sourceId) {
-          await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, group.children, config.flat.children, callbackFn, tenantId);
+          const childCounts = await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, group.children, config.flat.children, callbackFn, tenantId);
+          restoredCount += childCounts.restores;
         }
 
         // ── Login email portal_users sync (L1) ───────────────────────────
@@ -2582,9 +2593,12 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
             await t.none(`UPDATE ${s}.${tbl} SET deactivated_at = NOW() WHERE id = $1`, [rec.id]);
           }
 
-          // Insert children for new entity
+          // Insert children for new entity (also archive-aware — a new parent
+          // can still resurrect a previously-archived child if values match;
+          // unusual but covers re-importing after a parent delete+recreate).
           if (sourceId) {
-            await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, toInsert[i].group.children, config.flat.children, callbackFn, tenantId);
+            const childCounts = await _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, toInsert[i].group.children, config.flat.children, callbackFn, tenantId);
+            restoredCount += childCounts.restores;
           }
         }
 
@@ -2640,6 +2654,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
   return {
     inserted: insertedCount,
     updated: updatedCount,
+    restored: restoredCount,
     appUserSkipped,
   };
 }
@@ -2659,6 +2674,7 @@ export async function importFlatSourceEntity(model, reader, callbackFn, config, 
 async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntities) {
   let inserts = 0;
   let updates = 0;
+  let restores = 0;
   let noops = 0;
   let omitted = 0;
 
@@ -2691,7 +2707,11 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
     else noops += 1;
   }
 
-  // Per-child classification for groups that map to an existing source
+  // Per-child classification for groups that map to an existing source.
+  // Archive-aware: loads BOTH active and archived rows for each source so the
+  // classifier can see soft-deleted matches and route them to `restores`. This
+  // mirrors the commit-time path (`_reconcileChildrenForSource`) so preview
+  // counts always match what commit will actually do.
   for (const cfg of config.flat.children) {
     const groupsWithChildren = groups.filter((g) => (g.children[cfg.key] || []).length > 0);
     if (!groupsWithChildren.length) continue;
@@ -2700,14 +2720,13 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
       .map((g) => g._ownSourceId)
       .filter((sid) => !!sid);
 
-    // Load existing children for known sources in one query
     const existingBySource = new Map();
     if (existingSourceIds.length) {
       const childModel = db(cfg.modelName, schema);
       const tableName = childModel._schema?.table || cfg.modelName;
       const tName = pgp.as.name(tableName);
       const rows = await db.any(
-        `SELECT * FROM ${s}.${tName} WHERE source_id IN ($1:csv) AND deactivated_at IS NULL`,
+        `SELECT * FROM ${s}.${tName} WHERE source_id IN ($1:csv)`,
         [existingSourceIds],
       );
       for (const r of rows) {
@@ -2720,49 +2739,19 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
       const incoming = group.children[cfg.key] || [];
       const ownSource = group._ownSourceId;
       const existing = ownSource ? (existingBySource.get(ownSource) || []) : [];
-      const existingBySlot = new Map();
-      const existingByValue = new Map();
-      for (const ex of existing) {
-        const k = _computeSlotKey(ex, cfg);
-        if (k != null) existingBySlot.set(k, ex);
-        const vk = _computeValueKey(ex, cfg);
-        if (vk != null) existingByValue.set(vk, ex);
-      }
-      const claimedExistingIds = new Set();
-      const seenIncomingSlots = new Set();
+      const { counts, claimedExistingIds, seenIncomingSlots } = _classifyChildren(existing, incoming, cfg);
 
-      for (const row of incoming) {
-        const slot = _computeSlotKey(row, cfg);
-        if (slot != null) seenIncomingSlots.add(slot);
-        let match = slot != null ? existingBySlot.get(slot) : null;
-        if (!match) {
-          const vk = _computeValueKey(row, cfg);
-          if (vk != null) {
-            const candidate = existingByValue.get(vk);
-            if (candidate && !claimedExistingIds.has(candidate.id)) match = candidate;
-          }
-        }
-        if (!match) {
-          inserts += 1;
-          continue;
-        }
-        claimedExistingIds.add(match.id);
-        // Include slot key cols in the diff so a rename counts as UPDATE.
-        const diffCols = new Set([...(cfg.compareCols || []), ...(cfg.slotKeyCols || [])]);
-        let changed = false;
-        for (const col of diffCols) {
-          if (!_normEq(match[col], row[col])) {
-            changed = true;
-            break;
-          }
-        }
-        if (changed) updates += 1;
-        else noops += 1;
-      }
+      inserts += counts.inserts;
+      updates += counts.updates;
+      restores += counts.restores;
+      noops += counts.noops;
 
       // Omitted: existing rows whose slot wasn't named AND whose row id wasn't
-      // claimed by a value-key rename match.
+      // claimed by a value-key match. Only count active rows here — an
+      // archived row that the workbook didn't name stays archived, but it's
+      // not "omitted" because the user already chose to delete it.
       for (const ex of existing) {
+        if (ex.deactivated_at) continue;
         const slot = _computeSlotKey(ex, cfg);
         if (slot != null && seenIncomingSlots.has(slot)) continue;
         if (claimedExistingIds.has(ex.id)) continue;
@@ -2771,7 +2760,7 @@ async function _classifyForPreview(db, s, pgp, schema, groups, config, ownEntiti
     }
   }
 
-  return { inserts, updates, noops, omitted };
+  return { inserts, updates, restores, noops, omitted };
 }
 
 /**
@@ -3103,95 +3092,214 @@ async function _collectCrossSourceConflicts(db, s, pgp, schema, ownSourceType, g
 }
 
 /**
- * Reconcile children for one parent source_id by slot key (R3–R6).
- *   - Slot in incoming + slot in DB + values equal → NO-OP.
- *   - Slot in incoming + slot in DB + values differ → UPDATE in place; id preserved.
- *   - Slot in incoming + no matching slot in DB → INSERT.
- *   - Slot in DB + not in incoming → left alone. Never deleted by omission.
- * Slot-key validity has already been enforced upstream (R2), so any blank-slot
- * row is treated defensively as INSERT (the DB unique index would catch the
- * resulting collision if it mattered).
+ * Pure classifier used by both preview and commit paths. Given the full
+ * existing-children set (active AND archived) plus the incoming rows for a
+ * single source, return per-row classifications and aggregate counts.
+ *
+ * Match priority for each incoming row:
+ *   1. active slot key
+ *   2. active value key (catches a slot rename — e.g. an email moves from
+ *      label="work" to label="primary" but the email address itself is
+ *      stable)
+ *   3. archived slot key      → restore (and update if values differ)
+ *   4. archived value key     → restore (+ update if values differ)
+ *   5. no match → insert
+ *
+ * Actions emitted per row: 'insert' | 'update' | 'restore' | 'restore+update' | 'noop'.
+ * `claimedExistingIds` is returned so the caller can compute `omitted` against
+ * the existing set when needed.
+ * @private
+ */
+function _classifyChildren(existingRows, incomingRows, cfg) {
+  const activeBySlot = new Map();
+  const activeByValue = new Map();
+  const archivedBySlot = new Map();
+  const archivedByValue = new Map();
+  for (const ex of existingRows) {
+    const isArchived = !!ex.deactivated_at;
+    const k = _computeSlotKey(ex, cfg);
+    const vk = _computeValueKey(ex, cfg);
+    if (isArchived) {
+      if (k != null) archivedBySlot.set(k, ex);
+      if (vk != null) archivedByValue.set(vk, ex);
+    } else {
+      if (k != null) activeBySlot.set(k, ex);
+      if (vk != null) activeByValue.set(vk, ex);
+    }
+  }
+
+  const classifications = [];
+  const counts = { inserts: 0, updates: 0, restores: 0, noops: 0 };
+  const claimedExistingIds = new Set();
+  const seenIncomingSlots = new Set();
+
+  const diffCols = new Set([...(cfg.compareCols || []), ...(cfg.slotKeyCols || [])]);
+
+  for (const row of incomingRows) {
+    const slot = _computeSlotKey(row, cfg);
+    if (slot != null) seenIncomingSlots.add(slot);
+
+    let match = null;
+    let fromArchived = false;
+
+    if (slot != null) match = activeBySlot.get(slot) || null;
+    if (!match) {
+      const vk = _computeValueKey(row, cfg);
+      if (vk != null) {
+        const cand = activeByValue.get(vk);
+        if (cand && !claimedExistingIds.has(cand.id)) match = cand;
+      }
+    }
+    if (!match && slot != null) {
+      const cand = archivedBySlot.get(slot);
+      if (cand && !claimedExistingIds.has(cand.id)) {
+        match = cand;
+        fromArchived = true;
+      }
+    }
+    if (!match) {
+      const vk = _computeValueKey(row, cfg);
+      if (vk != null) {
+        const cand = archivedByValue.get(vk);
+        if (cand && !claimedExistingIds.has(cand.id)) {
+          match = cand;
+          fromArchived = true;
+        }
+      }
+    }
+
+    if (!match) {
+      counts.inserts += 1;
+      classifications.push({ action: 'insert', row, match: null, changes: null });
+      continue;
+    }
+    claimedExistingIds.add(match.id);
+
+    const changes = {};
+    for (const col of diffCols) {
+      if (_normEq(match[col], row[col])) continue;
+      changes[col] = row[col];
+    }
+    const hasDiff = Object.keys(changes).length > 0;
+
+    if (fromArchived) {
+      counts.restores += 1;
+      classifications.push({
+        action: hasDiff ? 'restore+update' : 'restore',
+        row,
+        match,
+        changes: hasDiff ? changes : null,
+      });
+    } else if (hasDiff) {
+      counts.updates += 1;
+      classifications.push({ action: 'update', row, match, changes });
+    } else {
+      counts.noops += 1;
+      classifications.push({ action: 'noop', row, match, changes: null });
+    }
+  }
+
+  return { counts, classifications, claimedExistingIds, seenIncomingSlots };
+}
+
+/**
+ * Apply the classifier's output for one source: INSERT new rows in bulk,
+ * UPDATE diffed active rows, RESTORE (clear `deactivated_at`) on archived
+ * matches, RESTORE+UPDATE when the archived match also differs. Returns the
+ * per-source `{ inserts, updates, restores, noops }` count for the caller to
+ * aggregate.
+ *
+ * Shared by `_reconcileFlatChildren` (flat single-entity import) and
+ * `importChildSheet` (combined Vendors + VendorContacts import) so the
+ * behavior is identical across both importer shapes.
+ * @private
+ */
+async function _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId) {
+  const childModel = db(cfg.modelName, schema);
+  childModel.tx = t;
+  const tableName = childModel._schema?.table || cfg.modelName;
+  const tName = pgp.as.name(tableName);
+
+  // Load BOTH active and archived children for this source — the classifier
+  // needs the trash bin too so a re-imported value can resurrect its row.
+  const existing = await t.any(`SELECT * FROM ${s}.${tName} WHERE source_id = $1`, [sourceId]);
+
+  // Transform every incoming row to the child-table shape before classifying.
+  const transformedRows = [];
+  for (const row of childRows) {
+    const { _rowNum: _, ...rest } = row;
+    const base = { ...rest, source_id: sourceId };
+    const transformed = callbackFn ? await callbackFn(base) : base;
+    delete transformed.tenant_code;
+    if (tenantId) transformed.tenant_id = tenantId;
+    coerceChildRow(transformed, childModel);
+    for (const col of childModel._schema?.columns || []) {
+      if (col.type === 'boolean' && col.notNull && transformed[col.name] == null) {
+        transformed[col.name] = col.default ?? false;
+      }
+    }
+    transformedRows.push(transformed);
+  }
+
+  const { classifications, counts } = _classifyChildren(existing, transformedRows, cfg);
+
+  const toInsert = [];
+  for (const c of classifications) {
+    if (c.action === 'insert') {
+      toInsert.push(c.row);
+    } else if (c.action === 'noop') {
+      continue;
+    } else if (c.action === 'update') {
+      const changes = { ...c.changes };
+      if (c.row.updated_by) changes.updated_by = c.row.updated_by;
+      changes.updated_at = new Date();
+      await childModel.updateWhere([{ id: c.match.id }], changes);
+    } else if (c.action === 'restore') {
+      // Pure restore: clear deactivated_at, no other column changes.
+      const changes = { deactivated_at: null };
+      if (c.row.updated_by) changes.updated_by = c.row.updated_by;
+      changes.updated_at = new Date();
+      await childModel.updateWhere([{ id: c.match.id }], changes, { includeDeactivated: true });
+    } else if (c.action === 'restore+update') {
+      const changes = { ...c.changes, deactivated_at: null };
+      if (c.row.updated_by) changes.updated_by = c.row.updated_by;
+      changes.updated_at = new Date();
+      await childModel.updateWhere([{ id: c.match.id }], changes, { includeDeactivated: true });
+    }
+  }
+
+  if (toInsert.length) {
+    await childModel.bulkInsert(toInsert);
+  }
+
+  return counts;
+}
+
+/**
+ * Reconcile children for one parent source_id, archive-aware.
+ *
+ * For each child config (emails / phones / addresses / tax IDs) on the
+ * supplied source, classifies every incoming row against the active AND
+ * archived existing sets via `_classifyChildren`, then applies the per-row
+ * action (insert / update / restore / restore+update / noop). See the
+ * `_classifyChildren` JSDoc for the match-priority and action contract.
+ *
+ * Returns `{ inserts, updates, restores, noops }` aggregated across all
+ * child configs so the caller can roll it into its top-level response.
  * @private
  */
 async function _reconcileFlatChildren(t, s, schema, db, pgp, sourceId, children, childConfigs, callbackFn, tenantId) {
+  const totals = { inserts: 0, updates: 0, restores: 0, noops: 0 };
   for (const cfg of childConfigs) {
     const childRows = children[cfg.key];
     if (!childRows || !childRows.length) continue;
-
-    const childModel = db(cfg.modelName, schema);
-    childModel.tx = t;
-    const tableName = childModel._schema?.table || cfg.modelName;
-    const tName = pgp.as.name(tableName);
-
-    const existing = await t.any(`SELECT * FROM ${s}.${tName} WHERE source_id = $1 AND deactivated_at IS NULL`, [sourceId]);
-    const existingBySlot = new Map();
-    const existingByValue = new Map();
-    for (const ex of existing) {
-      const k = _computeSlotKey(ex, cfg);
-      if (k != null) existingBySlot.set(k, ex);
-      const vk = _computeValueKey(ex, cfg);
-      if (vk != null) existingByValue.set(vk, ex);
-    }
-
-    const toInsert = [];
-    const toUpdate = []; // [{ id, changes }]
-    const claimedExistingIds = new Set();
-
-    for (const row of childRows) {
-      const { _rowNum: _, ...rest } = row;
-      const base = { ...rest, source_id: sourceId };
-      const transformed = callbackFn ? await callbackFn(base) : base;
-      delete transformed.tenant_code;
-      if (tenantId) transformed.tenant_id = tenantId;
-      coerceChildRow(transformed, childModel);
-      for (const col of childModel._schema?.columns || []) {
-        if (col.type === 'boolean' && col.notNull && transformed[col.name] == null) {
-          transformed[col.name] = col.default ?? false;
-        }
-      }
-
-      // Match priority: 1) slot key. 2) value key (catches slot rename when
-      // the underlying value is unique-by-DB, e.g. an email's address or a
-      // cell phone number — keeps the same row id and just updates the slot).
-      const slot = _computeSlotKey(transformed, cfg);
-      let match = slot != null ? existingBySlot.get(slot) : null;
-      if (!match) {
-        const vk = _computeValueKey(transformed, cfg);
-        if (vk != null) {
-          const candidate = existingByValue.get(vk);
-          if (candidate && !claimedExistingIds.has(candidate.id)) match = candidate;
-        }
-      }
-
-      if (!match) {
-        toInsert.push(transformed);
-        continue;
-      }
-      claimedExistingIds.add(match.id);
-
-      // Diff against compareCols PLUS the slot key cols (so a slot rename
-      // detected via value-match actually updates the label/phone_type).
-      const diffCols = new Set([...(cfg.compareCols || []), ...(cfg.slotKeyCols || [])]);
-      const changes = {};
-      for (const col of diffCols) {
-        if (_normEq(match[col], transformed[col])) continue;
-        changes[col] = transformed[col];
-      }
-      if (Object.keys(changes).length === 0) continue; // NO-OP
-      // Stamp audit fields on every real write. pg-schemata's `updateWhere`
-      // does not auto-bump updated_at, so set both explicitly.
-      if (transformed.updated_by) changes.updated_by = transformed.updated_by;
-      changes.updated_at = new Date();
-      toUpdate.push({ id: match.id, changes });
-    }
-
-    if (toInsert.length) {
-      await childModel.bulkInsert(toInsert);
-    }
-    for (const u of toUpdate) {
-      await childModel.updateWhere([{ id: u.id }], u.changes);
-    }
+    const c = await _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId);
+    totals.inserts += c.inserts;
+    totals.updates += c.updates;
+    totals.restores += c.restores;
+    totals.noops += c.noops;
   }
+  return totals;
 }
 
 // ── Flat-format helpers (repeated-row export/import) ─────────────────────────

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -3110,7 +3110,7 @@ async function _collectCrossSourceConflicts(db, s, pgp, schema, ownSourceType, g
  * the existing set when needed.
  * @private
  */
-function _classifyChildren(existingRows, incomingRows, cfg) {
+export function _classifyChildren(existingRows, incomingRows, cfg) {
   const activeBySlot = new Map();
   const activeByValue = new Map();
   const archivedBySlot = new Map();
@@ -3214,7 +3214,7 @@ function _classifyChildren(existingRows, incomingRows, cfg) {
  * behavior is identical across both importer shapes.
  * @private
  */
-async function _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId) {
+export async function _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId) {
   const childModel = db(cfg.modelName, schema);
   childModel.tx = t;
   const tableName = childModel._schema?.table || cfg.modelName;

--- a/apps/server/src/lib/spreadsheetHelpers.js
+++ b/apps/server/src/lib/spreadsheetHelpers.js
@@ -1540,9 +1540,31 @@ export async function importChildSheet(reader, sheetIndex, refToSourceId, modelN
     rowsBySource.get(sourceId).push(rest);
   }
 
+  if (!rowsBySource.size) return { inserts: 0, updates: 0, restores: 0, noops: 0 };
+
+  // Batch-load existing children for every affected source_id in one query
+  // instead of one round-trip per source. Same ORDER BY contract the
+  // reconciler expects: active first, then archived most-recent-first.
+  const childModel = db(cfg.modelName, schema);
+  const tableName = childModel._schema?.table || cfg.modelName;
+  const tName = pgp.as.name(tableName);
+  const sourceIds = [...rowsBySource.keys()];
+  const allExisting = await t.any(
+    `SELECT * FROM ${s}.${tName}
+      WHERE source_id IN ($1:csv)
+      ORDER BY deactivated_at IS NOT NULL, deactivated_at DESC`,
+    [sourceIds],
+  );
+  const existingBySource = new Map();
+  for (const r of allExisting) {
+    if (!existingBySource.has(r.source_id)) existingBySource.set(r.source_id, []);
+    existingBySource.get(r.source_id).push(r);
+  }
+
   const totals = { inserts: 0, updates: 0, restores: 0, noops: 0 };
   for (const [sourceId, sourceRows] of rowsBySource) {
-    const counts = await _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, sourceRows, cfg, callbackFn, tenantId);
+    const existing = existingBySource.get(sourceId) || [];
+    const counts = await _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, sourceRows, cfg, callbackFn, tenantId, existing);
     totals.inserts += counts.inserts;
     totals.updates += counts.updates;
     totals.restores += counts.restores;
@@ -3115,16 +3137,22 @@ export function _classifyChildren(existingRows, incomingRows, cfg) {
   const activeByValue = new Map();
   const archivedBySlot = new Map();
   const archivedByValue = new Map();
+  // `existingRows` is expected to be ordered active-first then
+  // archived-most-recent-first (see `_reconcileChildrenForSource`). The
+  // `!has(...)` guards make selection deterministic when the partial unique
+  // index permits duplicates (archived rows can collide on slot key) —
+  // first match wins, which after the ORDER BY is the most-recently
+  // archived row.
   for (const ex of existingRows) {
     const isArchived = !!ex.deactivated_at;
     const k = _computeSlotKey(ex, cfg);
     const vk = _computeValueKey(ex, cfg);
     if (isArchived) {
-      if (k != null) archivedBySlot.set(k, ex);
-      if (vk != null) archivedByValue.set(vk, ex);
+      if (k != null && !archivedBySlot.has(k)) archivedBySlot.set(k, ex);
+      if (vk != null && !archivedByValue.has(vk)) archivedByValue.set(vk, ex);
     } else {
-      if (k != null) activeBySlot.set(k, ex);
-      if (vk != null) activeByValue.set(vk, ex);
+      if (k != null && !activeBySlot.has(k)) activeBySlot.set(k, ex);
+      if (vk != null && !activeByValue.has(vk)) activeByValue.set(vk, ex);
     }
   }
 
@@ -3214,7 +3242,7 @@ export function _classifyChildren(existingRows, incomingRows, cfg) {
  * behavior is identical across both importer shapes.
  * @private
  */
-export async function _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId) {
+export async function _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId, existingRows = null) {
   const childModel = db(cfg.modelName, schema);
   childModel.tx = t;
   const tableName = childModel._schema?.table || cfg.modelName;
@@ -3222,7 +3250,19 @@ export async function _reconcileChildrenForSource(t, s, schema, db, pgp, sourceI
 
   // Load BOTH active and archived children for this source — the classifier
   // needs the trash bin too so a re-imported value can resurrect its row.
-  const existing = await t.any(`SELECT * FROM ${s}.${tName} WHERE source_id = $1`, [sourceId]);
+  // ORDER BY `deactivated_at` ascending with NULLs first puts active rows up
+  // top (NULL deactivated_at) then archived rows most-recent-first; combined
+  // with `_classifyChildren`'s first-match-wins maps, that gives deterministic
+  // selection when multiple archived rows share a slot/value key (partial
+  // unique indexes only enforce uniqueness for active rows).
+  const existing = existingRows != null
+    ? existingRows
+    : await t.any(
+        `SELECT * FROM ${s}.${tName}
+          WHERE source_id = $1
+          ORDER BY deactivated_at IS NOT NULL, deactivated_at DESC`,
+        [sourceId],
+      );
 
   // Transform every incoming row to the child-table shape before classifying.
   const transformedRows = [];
@@ -3239,6 +3279,21 @@ export async function _reconcileChildrenForSource(t, s, schema, db, pgp, sourceI
       }
     }
     transformedRows.push(transformed);
+  }
+
+  // Enforce single is_primary per source. The emails and phone_numbers
+  // tables carry a partial unique index `(source_id) WHERE is_primary AND
+  // NOT deactivated`, so the spreadsheet can't supply two primaries — we
+  // demote all but the first to false. No-op for tables without is_primary
+  // (addresses, tax_identifiers don't carry the column).
+  if (transformedRows.length > 1) {
+    let seenPrimary = false;
+    for (const r of transformedRows) {
+      if (r.is_primary === true) {
+        if (seenPrimary) r.is_primary = false;
+        else seenPrimary = true;
+      }
+    }
   }
 
   const { classifications, counts } = _classifyChildren(existing, transformedRows, cfg);

--- a/apps/server/src/system/core/controllers/addressesController.js
+++ b/apps/server/src/system/core/controllers/addressesController.js
@@ -2,10 +2,12 @@
  * @file Addresses controller — standard CRUD for addresses linked via sources
  * @module core/controllers/addressesController
  *
- * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
- * address rows are restored by re-importing the parent's workbook (the
- * importer matches archived rows by slot key then by value key and
- * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
+ * NOTE: the standard `PATCH /restore` endpoint inherited from
+ * `BaseController` via `createRouter` exists on this resource, but the
+ * client UI deliberately does not call it. Soft-deleted address rows
+ * are restored by re-importing the parent's workbook (the importer
+ * matches archived rows by slot key then by value key and resurrects
+ * them in place). See `docs/decisions/0026-child-restore-via-import.md`.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */

--- a/apps/server/src/system/core/controllers/addressesController.js
+++ b/apps/server/src/system/core/controllers/addressesController.js
@@ -2,6 +2,11 @@
  * @file Addresses controller — standard CRUD for addresses linked via sources
  * @module core/controllers/addressesController
  *
+ * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
+ * address rows are restored by re-importing the parent's workbook (the
+ * importer matches archived rows by id then by value/slot key and
+ * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
+ *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
 

--- a/apps/server/src/system/core/controllers/addressesController.js
+++ b/apps/server/src/system/core/controllers/addressesController.js
@@ -4,7 +4,7 @@
  *
  * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
  * address rows are restored by re-importing the parent's workbook (the
- * importer matches archived rows by id then by value/slot key and
+ * importer matches archived rows by slot key then by value key and
  * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.

--- a/apps/server/src/system/core/controllers/emailsController.js
+++ b/apps/server/src/system/core/controllers/emailsController.js
@@ -6,6 +6,11 @@
  * is synced to the corresponding admin.portal_users record. Archive of a
  * login email is blocked while the entity is an active app user.
  *
+ * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
+ * email rows are restored by re-importing the parent's workbook (the
+ * importer matches archived rows by id then by value/slot key and
+ * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
+ *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
 

--- a/apps/server/src/system/core/controllers/emailsController.js
+++ b/apps/server/src/system/core/controllers/emailsController.js
@@ -8,7 +8,7 @@
  *
  * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
  * email rows are restored by re-importing the parent's workbook (the
- * importer matches archived rows by id then by value/slot key and
+ * importer matches archived rows by slot key then by value key and
  * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.

--- a/apps/server/src/system/core/controllers/emailsController.js
+++ b/apps/server/src/system/core/controllers/emailsController.js
@@ -6,10 +6,12 @@
  * is synced to the corresponding admin.portal_users record. Archive of a
  * login email is blocked while the entity is an active app user.
  *
- * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
- * email rows are restored by re-importing the parent's workbook (the
- * importer matches archived rows by slot key then by value key and
- * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
+ * NOTE: the standard `PATCH /restore` endpoint inherited from
+ * `BaseController` via `createRouter` exists on this resource, but the
+ * client UI deliberately does not call it. Soft-deleted email rows are
+ * restored by re-importing the parent's workbook (the importer matches
+ * archived rows by slot key then by value key and resurrects them in
+ * place). See `docs/decisions/0026-child-restore-via-import.md`.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */

--- a/apps/server/src/system/core/controllers/phoneNumbersController.js
+++ b/apps/server/src/system/core/controllers/phoneNumbersController.js
@@ -4,7 +4,7 @@
  *
  * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
  * phone rows are restored by re-importing the parent's workbook (the
- * importer matches archived rows by id then by value/slot key and
+ * importer matches archived rows by slot key then by value key and
  * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.

--- a/apps/server/src/system/core/controllers/phoneNumbersController.js
+++ b/apps/server/src/system/core/controllers/phoneNumbersController.js
@@ -2,6 +2,11 @@
  * @file Phone numbers controller — CRUD with single-primary enforcement
  * @module core/controllers/phoneNumbersController
  *
+ * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
+ * phone rows are restored by re-importing the parent's workbook (the
+ * importer matches archived rows by id then by value/slot key and
+ * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
+ *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
 

--- a/apps/server/src/system/core/controllers/phoneNumbersController.js
+++ b/apps/server/src/system/core/controllers/phoneNumbersController.js
@@ -2,10 +2,12 @@
  * @file Phone numbers controller — CRUD with single-primary enforcement
  * @module core/controllers/phoneNumbersController
  *
- * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
- * phone rows are restored by re-importing the parent's workbook (the
- * importer matches archived rows by slot key then by value key and
- * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
+ * NOTE: the standard `PATCH /restore` endpoint inherited from
+ * `BaseController` via `createRouter` exists on this resource, but the
+ * client UI deliberately does not call it. Soft-deleted phone rows are
+ * restored by re-importing the parent's workbook (the importer matches
+ * archived rows by slot key then by value key and resurrects them in
+ * place). See `docs/decisions/0026-child-restore-via-import.md`.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */

--- a/apps/server/src/system/core/controllers/taxIdentifiersController.js
+++ b/apps/server/src/system/core/controllers/taxIdentifiersController.js
@@ -2,10 +2,13 @@
  * @file Tax identifiers controller — CRUD for typed tax IDs linked via sources
  * @module core/controllers/taxIdentifiersController
  *
- * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
- * tax identifier rows are restored by re-importing the parent's workbook
- * (the importer matches archived rows by slot key then by value key and
- * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
+ * NOTE: the standard `PATCH /restore` endpoint inherited from
+ * `BaseController` via `createRouter` exists on this resource (and a
+ * contract test exercises it), but the client UI deliberately does not
+ * call it. Soft-deleted tax identifier rows are restored by re-importing
+ * the parent's workbook (the importer matches archived rows by slot key
+ * then by value key and resurrects them in place). See
+ * `docs/decisions/0026-child-restore-via-import.md`.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */

--- a/apps/server/src/system/core/controllers/taxIdentifiersController.js
+++ b/apps/server/src/system/core/controllers/taxIdentifiersController.js
@@ -2,6 +2,11 @@
  * @file Tax identifiers controller — CRUD for typed tax IDs linked via sources
  * @module core/controllers/taxIdentifiersController
  *
+ * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
+ * tax identifier rows are restored by re-importing the parent's workbook
+ * (the importer matches archived rows by id then by value/slot key and
+ * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
+ *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
  */
 

--- a/apps/server/src/system/core/controllers/taxIdentifiersController.js
+++ b/apps/server/src/system/core/controllers/taxIdentifiersController.js
@@ -4,7 +4,7 @@
  *
  * NOTE: there is intentionally NO `PATCH /:id/restore` route. Soft-deleted
  * tax identifier rows are restored by re-importing the parent's workbook
- * (the importer matches archived rows by id then by value/slot key and
+ * (the importer matches archived rows by slot key then by value key and
  * resurrects them in place). See `docs/decisions/0026-child-restore-via-import.md`.
  *
  * Copyright (c) 2025 – present Axerra LLC. All rights reserved.

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -1014,11 +1014,15 @@ export default class Vendors extends TableModel {
       const toInsert = await this._transformFlatChildSet(cfg, rawRows, sourceId, childModel, callbackFn, tenantId);
       // Archive-aware: load active AND archived rows so an incoming value
       // matching an archived row classifies as restore (= a DB write that
-      // commit will perform). Old behavior loaded active only and missed
-      // restores entirely, leaving preview reporting "no change" for a
-      // commit that would actually flip a deactivated_at.
+      // commit will perform). ORDER BY matches the contract `_classifyChildren`
+      // expects — active first, then archived most-recent-first — so the
+      // first-match-wins behavior gives the same answer here that commit
+      // will give. Without it preview can flip based on heap order when
+      // multiple archived rows share a key.
       const existing = await handle.any(
-        `SELECT * FROM ${s}.${tName} WHERE source_id = $1`,
+        `SELECT * FROM ${s}.${tName}
+          WHERE source_id = $1
+          ORDER BY deactivated_at IS NOT NULL, deactivated_at DESC`,
         [sourceId],
       );
       const { counts } = _classifyChildren(existing, toInsert, cfg);

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -993,15 +993,22 @@ export default class Vendors extends TableModel {
   }
 
   /**
-   * No-write check: would `_upsertFlatChildren` replace any of this parent's
-   * child sets? Iterates the cfgs the same way, transforms the file rows,
-   * loads the DB's current active set, and returns true on the first cfg
-   * whose set differs. Used by the preview classifier to keep preview /
-   * commit aligned on child-only changes, and (indirectly) by the commit
-   * path's updated-count accounting via `_upsertFlatChildren`'s return.
+   * Preview-side per-parent check: classify each cfg's child rows against
+   * the DB (active + archived) using the same shared logic the commit
+   * path uses, and return whether the parent's child sets would produce
+   * any DB writes (`changed`) plus the count of archived rows that would
+   * be restored (`restored`).
+   *
+   * The combined-import preview surfaces `restored` into the bucket so
+   * `ImportDialog` can show "Restored from trash" before commit, matching
+   * what the flat single-entity preview already does.
+   *
+   * @returns {Promise<{changed: boolean, restored: number}>}
    */
   async _anyChildrenDiffer({ t, db, s, schema, pgp, sourceId, fileChildren, childConfig, callbackFn, tenantId }) {
     const handle = t || db;
+    let changed = false;
+    let restored = 0;
     for (const cfg of childConfig) {
       const rawRows = fileChildren?.[cfg.key];
       if (!rawRows || !rawRows.length) continue;
@@ -1026,9 +1033,10 @@ export default class Vendors extends TableModel {
         [sourceId],
       );
       const { counts } = _classifyChildren(existing, toInsert, cfg);
-      if (counts.inserts + counts.updates + counts.restores > 0) return true;
+      if (counts.inserts + counts.updates + counts.restores > 0) changed = true;
+      restored += counts.restores;
     }
-    return false;
+    return { changed, restored };
   }
 
   /**
@@ -1039,9 +1047,10 @@ export default class Vendors extends TableModel {
    * the original row back instead of either tripping a unique constraint or
    * leaving the trash bin to grow.
    *
-   * Returns `{ anyReplaced, restored }`. The boolean lets the caller count
-   * child-only changes as parent updates; the count rolls into the importer's
-   * top-level `restored` total.
+   * Returns `{ anyReplaced, restored, inserted, updated }`. `anyReplaced`
+   * lets the caller count child-only changes as parent updates; the
+   * per-action counts roll into the importer's top-level `restored`,
+   * `childInserted`, and `childUpdated` totals.
    */
   async _upsertFlatChildren(t, s, schema, db, pgp, sourceId, children, childConfig, callbackFn, tenantId) {
     let anyReplaced = false;
@@ -1144,8 +1153,8 @@ export default class Vendors extends TableModel {
   async _classifyCombinedForPreview({ db, s, schema, pgp, vendorGroups, contactGroups, callbackFn, tenantId }) {
     const stripContactCols = ['status', 'deactivated_at', 'password'];
 
-    const vendors = { inserts: 0, updates: 0, noops: 0, omitted: 0 };
-    const contacts = { inserts: 0, updates: 0, noops: 0, omitted: 0 };
+    const vendors = { inserts: 0, updates: 0, restores: 0, noops: 0, omitted: 0 };
+    const contacts = { inserts: 0, updates: 0, restores: 0, noops: 0, omitted: 0 };
 
     // Vendors ─────────────────────────────────────────────────────────────
     const vendorUuidIds = vendorGroups.filter((g) => isUuid(g.parent.id)).map((g) => g.parent.id);
@@ -1170,7 +1179,7 @@ export default class Vendors extends TableModel {
       if (tenantId) transformed.tenant_id = tenantId;
       const changes = diffParent(transformed, existing, { caseSensitive: true });
       const parentChanged = Object.keys(changes).length > 0 || willBeArchived !== wasArchived;
-      const childrenDiffer = existing.source_id
+      const childDiff = existing.source_id
         ? await this._anyChildrenDiffer({
             db, s, schema, pgp,
             sourceId: existing.source_id,
@@ -1179,8 +1188,9 @@ export default class Vendors extends TableModel {
             callbackFn,
             tenantId,
           })
-        : false;
-      if (parentChanged || childrenDiffer) vendors.updates += 1;
+        : { changed: false, restored: 0 };
+      vendors.restores += childDiff.restored;
+      if (parentChanged || childDiff.changed) vendors.updates += 1;
       else vendors.noops += 1;
     }
 
@@ -1214,7 +1224,7 @@ export default class Vendors extends TableModel {
       if (transformed.vendor_id && !isUuid(transformed.vendor_id)) delete transformed.vendor_id;
       const changes = diffParent(transformed, existing, { caseSensitive: true });
       const parentChanged = Object.keys(changes).length > 0 || willBeArchived !== wasArchived;
-      const childrenDiffer = existing.source_id
+      const childDiff = existing.source_id
         ? await this._anyChildrenDiffer({
             db, s, schema, pgp,
             sourceId: existing.source_id,
@@ -1223,8 +1233,9 @@ export default class Vendors extends TableModel {
             callbackFn,
             tenantId,
           })
-        : false;
-      if (parentChanged || childrenDiffer) contacts.updates += 1;
+        : { changed: false, restored: 0 };
+      contacts.restores += childDiff.restored;
+      if (parentChanged || childDiff.changed) contacts.updates += 1;
       else contacts.noops += 1;
     }
 

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -30,6 +30,8 @@ import {
   getEnumColumns,
   parseDbImportError,
   diffParent,
+  _reconcileChildrenForSource,
+  _classifyChildren,
   PHONE_HEADERS,
   ADDRESS_HEADERS,
   TAX_ID_HEADERS,
@@ -153,16 +155,50 @@ const CONTACT_CHILD_EXTRACTORS = [
 ];
 
 /** Child column mappings for flat export (source cols → flat cols) */
+// Each cfg also carries the slotKeyCols / compareCols / key fields so it can
+// be passed straight to the shared `_reconcileChildrenForSource` from
+// spreadsheetHelpers. `modelName` mirrors `model` for the same reason — the
+// shared helper reads `modelName`.
 const VENDOR_CHILD_ARRAYS_CONFIG = [
-  { model: 'emails', cols: ['email', 'label', 'is_primary'], flatCols: ['email', 'email_label', 'email_is_primary'] },
-  { model: 'phoneNumbers', cols: ['country_code', 'phone_type', 'phone_number', 'is_primary'], flatCols: ['phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary'] },
-  { model: 'addresses', cols: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'], flatCols: ['address_label', 'address_line_1', 'address_line_2', 'address_line_3', 'address_city', 'address_state_province', 'address_postal_code', 'address_country_code'] },
-  { model: 'taxIdentifiers', cols: ['country_code', 'tax_type', 'tax_value'], flatCols: ['tax_country_code', 'tax_type', 'tax_value'] },
+  {
+    model: 'emails', modelName: 'emails', key: 'emails',
+    cols: ['email', 'label', 'is_primary'],
+    flatCols: ['email', 'email_label', 'email_is_primary'],
+    slotKeyCols: ['label'], compareCols: ['email', 'is_primary'],
+  },
+  {
+    model: 'phoneNumbers', modelName: 'phoneNumbers', key: 'phones',
+    cols: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
+    flatCols: ['phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary'],
+    slotKeyCols: ['phone_type'], compareCols: ['country_code', 'phone_number', 'is_primary'],
+  },
+  {
+    model: 'addresses', modelName: 'addresses', key: 'addresses',
+    cols: ['label', 'address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+    flatCols: ['address_label', 'address_line_1', 'address_line_2', 'address_line_3', 'address_city', 'address_state_province', 'address_postal_code', 'address_country_code'],
+    slotKeyCols: ['label'], compareCols: ['address_line_1', 'address_line_2', 'address_line_3', 'city', 'state_province', 'postal_code', 'country_code'],
+  },
+  {
+    model: 'taxIdentifiers', modelName: 'taxIdentifiers', key: 'taxIds',
+    cols: ['country_code', 'tax_type', 'tax_value'],
+    flatCols: ['tax_country_code', 'tax_type', 'tax_value'],
+    slotKeyCols: ['country_code', 'tax_type'], compareCols: ['tax_value'],
+  },
 ];
 
 const CONTACT_CHILD_ARRAYS_CONFIG = [
-  { model: 'emails', cols: ['email', 'label', 'is_primary', 'is_login'], flatCols: ['email', 'email_label', 'email_is_primary', 'email_is_login'] },
-  { model: 'phoneNumbers', cols: ['country_code', 'phone_type', 'phone_number', 'is_primary'], flatCols: ['phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary'] },
+  {
+    model: 'emails', modelName: 'emails', key: 'emails',
+    cols: ['email', 'label', 'is_primary', 'is_login'],
+    flatCols: ['email', 'email_label', 'email_is_primary', 'email_is_login'],
+    slotKeyCols: ['label'], compareCols: ['email', 'is_primary', 'is_login'],
+  },
+  {
+    model: 'phoneNumbers', modelName: 'phoneNumbers', key: 'phones',
+    cols: ['country_code', 'phone_type', 'phone_number', 'is_primary'],
+    flatCols: ['phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary'],
+    slotKeyCols: ['phone_type'], compareCols: ['country_code', 'phone_number', 'is_primary'],
+  },
 ];
 
 /** Lazy-load db */
@@ -536,8 +572,10 @@ export default class Vendors extends TableModel {
 
     let insertedCount = 0;
     let updatedCount = 0;
+    let vendorsRestored = 0;
     let contactsInserted = 0;
     let contactsUpdated = 0;
+    let contactsRestored = 0;
 
     // Maps for cross-sheet vendor_id resolution
     const vendorRefToId = new Map(); // spreadsheet id/ref → DB vendor id
@@ -610,11 +648,13 @@ export default class Vendors extends TableModel {
         vendorRefToId.set(id, id);
         vendorIdToSourceId.set(id, existing.source_id);
 
-        // Child wholesale-replace also counts as an update: the count must
-        // reflect every DB write, not just parent-field changes.
+        // Child reconcile also counts as an update: the count must reflect
+        // every DB write, not just parent-field changes.
         let childReplaced = false;
         if (existing.source_id) {
-          childReplaced = await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+          const r = await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+          childReplaced = r.anyReplaced;
+          vendorsRestored += r.restored;
         }
         if (parentChanged || childReplaced) updatedCount++;
       }
@@ -700,7 +740,8 @@ export default class Vendors extends TableModel {
         }
 
         // ── Batch: insert children across all new vendors ──────────
-        await this._batchUpsertFlatChildren(t, s, schema, db, pgp, insertResults, sourceByParentId, toInsert, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+        const r = await this._batchUpsertFlatChildren(t, s, schema, db, pgp, insertResults, sourceByParentId, toInsert, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+        vendorsRestored += r.restored;
       }
 
       _tVendorInserts = Date.now();
@@ -775,7 +816,9 @@ export default class Vendors extends TableModel {
 
         let childReplaced = false;
         if (existing.source_id) {
-          childReplaced = await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+          const r = await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+          childReplaced = r.anyReplaced;
+          contactsRestored += r.restored;
         }
         if (parentChanged || childReplaced) contactsUpdated++;
       }
@@ -822,7 +865,8 @@ export default class Vendors extends TableModel {
         }
 
         // ── Batch: insert children across all new contacts ─────────
-        await this._batchUpsertFlatChildren(t, s, schema, db, pgp, insertResults, sourceByParentId, contactToInsert, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+        const r = await this._batchUpsertFlatChildren(t, s, schema, db, pgp, insertResults, sourceByParentId, contactToInsert, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
+        contactsRestored += r.restored;
 
         _tContactInserts = Date.now();
         // Provision portal_users for app-user contacts after emails are inserted
@@ -897,8 +941,10 @@ export default class Vendors extends TableModel {
     return {
       inserted: insertedCount,
       updated: updatedCount,
+      restored: vendorsRestored,
       contactsInserted,
       contactsUpdated,
+      contactsRestored,
     };
   }
 
@@ -943,8 +989,7 @@ export default class Vendors extends TableModel {
   async _anyChildrenDiffer({ t, db, s, schema, pgp, sourceId, fileChildren, childConfig, callbackFn, tenantId }) {
     const handle = t || db;
     for (const cfg of childConfig) {
-      const key = cfg.model === 'phoneNumbers' ? 'phones' : cfg.model === 'taxIdentifiers' ? 'taxIds' : cfg.model;
-      const rawRows = fileChildren?.[key];
+      const rawRows = fileChildren?.[cfg.key];
       if (!rawRows || !rawRows.length) continue;
 
       const childModel = db(cfg.model, schema);
@@ -953,52 +998,45 @@ export default class Vendors extends TableModel {
       const tName = pgp.as.name(tableName);
 
       const toInsert = await this._transformFlatChildSet(cfg, rawRows, sourceId, childModel, callbackFn, tenantId);
+      // Archive-aware: load active AND archived rows so an incoming value
+      // matching an archived row classifies as restore (= a DB write that
+      // commit will perform). Old behavior loaded active only and missed
+      // restores entirely, leaving preview reporting "no change" for a
+      // commit that would actually flip a deactivated_at.
       const existing = await handle.any(
-        `SELECT * FROM ${s}.${tName} WHERE source_id = $1 AND deactivated_at IS NULL`,
+        `SELECT * FROM ${s}.${tName} WHERE source_id = $1`,
         [sourceId],
       );
-      if (!_sameChildSet(toInsert, existing, cfg.cols)) return true;
+      const { counts } = _classifyChildren(existing, toInsert, cfg);
+      if (counts.inserts + counts.updates + counts.restores > 0) return true;
     }
     return false;
   }
 
   /**
-   * Upsert flat children for an updated parent: per cfg, skip the wholesale
-   * soft-delete + bulk-insert when the file's set matches the DB's current
-   * active set on `cfg.cols` so child rows don't get recycled on a no-op
-   * re-import. Returns `true` when at least one cfg was actually replaced —
-   * the parent loops use that to count child-only changes as updates so the
-   * commit's `updated` / `contactsUpdated` counters reflect every DB write.
+   * Upsert flat children for an updated parent via the shared archive-aware
+   * reconciler from spreadsheetHelpers (`_reconcileChildrenForSource`). Per
+   * incoming row classifies as insert / update / restore / restore+update /
+   * noop — so re-importing a value that lived only in the trash bin brings
+   * the original row back instead of either tripping a unique constraint or
+   * leaving the trash bin to grow.
+   *
+   * Returns `{ anyReplaced, restored }`. The boolean lets the caller count
+   * child-only changes as parent updates; the count rolls into the importer's
+   * top-level `restored` total.
    */
   async _upsertFlatChildren(t, s, schema, db, pgp, sourceId, children, childConfig, callbackFn, tenantId) {
     let anyReplaced = false;
+    let restored = 0;
     for (const cfg of childConfig) {
-      const key = cfg.model === 'phoneNumbers' ? 'phones' : cfg.model === 'taxIdentifiers' ? 'taxIds' : cfg.model;
-      const childRows = children[key];
+      const childRows = children[cfg.key];
       if (!childRows || !childRows.length) continue;
 
-      const childModel = db(cfg.model, schema);
-      childModel.tx = t;
-      const tableName = childModel._schema?.table || cfg.model;
-      const tName = pgp.as.name(tableName);
-
-      const toInsert = await this._transformFlatChildSet(cfg, childRows, sourceId, childModel, callbackFn, tenantId);
-      const existing = await t.any(
-        `SELECT * FROM ${s}.${tName} WHERE source_id = $1 AND deactivated_at IS NULL`,
-        [sourceId],
-      );
-      if (_sameChildSet(toInsert, existing, cfg.cols)) continue;
-
-      await t.none(
-        `UPDATE ${s}.${tName} SET deactivated_at = NOW() WHERE source_id = $1 AND deactivated_at IS NULL`,
-        [sourceId],
-      );
-      if (toInsert.length) {
-        await childModel.bulkInsert(toInsert);
-      }
-      anyReplaced = true;
+      const counts = await _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId);
+      restored += counts.restores;
+      if (counts.inserts + counts.updates + counts.restores > 0) anyReplaced = true;
     }
-    return anyReplaced;
+    return { anyReplaced, restored };
   }
 
   /**
@@ -1019,66 +1057,24 @@ export default class Vendors extends TableModel {
    * @param {string}   tenantId        Resolved tenant UUID
    */
   async _batchUpsertFlatChildren(t, s, schema, db, pgp, insertResults, sourceByParentId, toInsertMeta, childConfig, callbackFn, tenantId) {
+    // Iterate per (cfg, source) and delegate to the shared reconciler. We
+    // lose the prior 1-soft-delete-+-1-bulk-insert micro-optimization but
+    // gain archive-aware reconciliation (a child whose value lives in the
+    // trash bin gets restored, matching the flat single-entity path). Newly
+    // inserted parents normally have empty existing-child sets, so the
+    // reconciler degrades to a single bulk insert per source.
+    let restored = 0;
     for (const cfg of childConfig) {
-      const key = cfg.model === 'phoneNumbers' ? 'phones' : cfg.model === 'taxIdentifiers' ? 'taxIds' : cfg.model;
-
-      const childModel = db(cfg.model, schema);
-      childModel.tx = t;
-      const tableName = childModel._schema?.table || cfg.model;
-
-      const allSourceIds = new Set();
-      const allToInsert = [];
-
-      // Collect children from all parents
       for (let i = 0; i < insertResults.length; i++) {
         const sourceId = sourceByParentId.get(insertResults[i].id);
         if (!sourceId) continue;
-
-        const children = toInsertMeta[i].group?.children;
-        const childRows = children?.[key];
+        const childRows = toInsertMeta[i].group?.children?.[cfg.key];
         if (!childRows?.length) continue;
-
-        allSourceIds.add(sourceId);
-
-        // Track rows per source for is_primary enforcement
-        const sourceRows = [];
-        for (const row of childRows) {
-          const { _rowNum: _, ...rest } = row;
-          const base = { ...rest, source_id: sourceId };
-          const transformed = callbackFn ? await callbackFn(base) : base;
-          delete transformed.tenant_code;
-          if (tenantId) transformed.tenant_id = tenantId;
-          coerceChildRow(transformed, childModel);
-          sourceRows.push(transformed);
-        }
-
-        // Enforce single is_primary per source (partial unique index)
-        if (sourceRows.length > 1) {
-          let seenPrimary = false;
-          for (const r of sourceRows) {
-            if (r.is_primary) {
-              if (seenPrimary) r.is_primary = false;
-              else seenPrimary = true;
-            }
-          }
-        }
-
-        allToInsert.push(...sourceRows);
-      }
-
-      if (!allSourceIds.size) continue;
-
-      // Single soft-delete for all affected source_ids
-      await t.none(
-        `UPDATE ${s}.${pgp.as.name(tableName)} SET deactivated_at = NOW() WHERE source_id IN ($1:csv) AND deactivated_at IS NULL`,
-        [[...allSourceIds]],
-      );
-
-      // Single bulk insert for all children of this type
-      if (allToInsert.length) {
-        await childModel.bulkInsert(allToInsert);
+        const counts = await _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId);
+        restored += counts.restores;
       }
     }
+    return { restored };
   }
 
   // ── Preview classifier (no writes) ────────────────────────────────────────

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -573,9 +573,13 @@ export default class Vendors extends TableModel {
     let insertedCount = 0;
     let updatedCount = 0;
     let vendorsRestored = 0;
+    let vendorsChildInserted = 0;
+    let vendorsChildUpdated = 0;
     let contactsInserted = 0;
     let contactsUpdated = 0;
     let contactsRestored = 0;
+    let contactsChildInserted = 0;
+    let contactsChildUpdated = 0;
 
     // Maps for cross-sheet vendor_id resolution
     const vendorRefToId = new Map(); // spreadsheet id/ref → DB vendor id
@@ -655,6 +659,8 @@ export default class Vendors extends TableModel {
           const r = await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
           childReplaced = r.anyReplaced;
           vendorsRestored += r.restored;
+          vendorsChildInserted += r.inserted;
+          vendorsChildUpdated += r.updated;
         }
         if (parentChanged || childReplaced) updatedCount++;
       }
@@ -742,6 +748,7 @@ export default class Vendors extends TableModel {
         // ── Batch: insert children across all new vendors ──────────
         const r = await this._batchUpsertFlatChildren(t, s, schema, db, pgp, insertResults, sourceByParentId, toInsert, VENDOR_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
         vendorsRestored += r.restored;
+        vendorsChildInserted += r.inserted;
       }
 
       _tVendorInserts = Date.now();
@@ -819,6 +826,8 @@ export default class Vendors extends TableModel {
           const r = await this._upsertFlatChildren(t, s, schema, db, pgp, existing.source_id, group.children, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
           childReplaced = r.anyReplaced;
           contactsRestored += r.restored;
+          contactsChildInserted += r.inserted;
+          contactsChildUpdated += r.updated;
         }
         if (parentChanged || childReplaced) contactsUpdated++;
       }
@@ -867,6 +876,7 @@ export default class Vendors extends TableModel {
         // ── Batch: insert children across all new contacts ─────────
         const r = await this._batchUpsertFlatChildren(t, s, schema, db, pgp, insertResults, sourceByParentId, contactToInsert, CONTACT_CHILD_ARRAYS_CONFIG, callbackFn, tenantId);
         contactsRestored += r.restored;
+        contactsChildInserted += r.inserted;
 
         _tContactInserts = Date.now();
         // Provision portal_users for app-user contacts after emails are inserted
@@ -942,9 +952,13 @@ export default class Vendors extends TableModel {
       inserted: insertedCount,
       updated: updatedCount,
       restored: vendorsRestored,
+      childInserted: vendorsChildInserted,
+      childUpdated: vendorsChildUpdated,
       contactsInserted,
       contactsUpdated,
       contactsRestored,
+      contactsChildInserted,
+      contactsChildUpdated,
     };
   }
 
@@ -1028,15 +1042,19 @@ export default class Vendors extends TableModel {
   async _upsertFlatChildren(t, s, schema, db, pgp, sourceId, children, childConfig, callbackFn, tenantId) {
     let anyReplaced = false;
     let restored = 0;
+    let inserted = 0;
+    let updated = 0;
     for (const cfg of childConfig) {
       const childRows = children[cfg.key];
       if (!childRows || !childRows.length) continue;
 
       const counts = await _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId);
       restored += counts.restores;
+      inserted += counts.inserts;
+      updated += counts.updates;
       if (counts.inserts + counts.updates + counts.restores > 0) anyReplaced = true;
     }
-    return { anyReplaced, restored };
+    return { anyReplaced, restored, inserted, updated };
   }
 
   /**
@@ -1063,7 +1081,9 @@ export default class Vendors extends TableModel {
     // a wasted SELECT. Skip the reconciler entirely and do 1 bulkInsert
     // per cfg across all parents — restores the prior performance shape
     // for large imports. `restored` is always 0 here (no archived rows to
-    // resurrect under a fresh source).
+    // resurrect under a fresh source); `inserted` counts child rows
+    // written so the importer's top-level response can surface them.
+    let inserted = 0;
     for (const cfg of childConfig) {
       const childModel = db(cfg.model, schema);
       childModel.tx = t;
@@ -1101,9 +1121,10 @@ export default class Vendors extends TableModel {
 
       if (allToInsert.length) {
         await childModel.bulkInsert(allToInsert);
+        inserted += allToInsert.length;
       }
     }
-    return { restored: 0 };
+    return { restored: 0, inserted, updated: 0 };
   }
 
   // ── Preview classifier (no writes) ────────────────────────────────────────

--- a/apps/server/src/system/core/models/Vendors.js
+++ b/apps/server/src/system/core/models/Vendors.js
@@ -1057,24 +1057,53 @@ export default class Vendors extends TableModel {
    * @param {string}   tenantId        Resolved tenant UUID
    */
   async _batchUpsertFlatChildren(t, s, schema, db, pgp, insertResults, sourceByParentId, toInsertMeta, childConfig, callbackFn, tenantId) {
-    // Iterate per (cfg, source) and delegate to the shared reconciler. We
-    // lose the prior 1-soft-delete-+-1-bulk-insert micro-optimization but
-    // gain archive-aware reconciliation (a child whose value lives in the
-    // trash bin gets restored, matching the flat single-entity path). Newly
-    // inserted parents normally have empty existing-child sets, so the
-    // reconciler degrades to a single bulk insert per source.
-    let restored = 0;
+    // Fast path for newly-inserted parents: by definition their sources are
+    // brand-new and carry no existing children, so the archive-aware
+    // reconciler would just degrade to a single bulkInsert per source after
+    // a wasted SELECT. Skip the reconciler entirely and do 1 bulkInsert
+    // per cfg across all parents — restores the prior performance shape
+    // for large imports. `restored` is always 0 here (no archived rows to
+    // resurrect under a fresh source).
     for (const cfg of childConfig) {
+      const childModel = db(cfg.model, schema);
+      childModel.tx = t;
+
+      const allToInsert = [];
       for (let i = 0; i < insertResults.length; i++) {
         const sourceId = sourceByParentId.get(insertResults[i].id);
         if (!sourceId) continue;
         const childRows = toInsertMeta[i].group?.children?.[cfg.key];
         if (!childRows?.length) continue;
-        const counts = await _reconcileChildrenForSource(t, s, schema, db, pgp, sourceId, childRows, cfg, callbackFn, tenantId);
-        restored += counts.restores;
+
+        // Transform per source so we can enforce single is_primary inside
+        // that source (the partial unique index is scoped to one source).
+        const sourceRows = [];
+        for (const row of childRows) {
+          const { _rowNum: _, ...rest } = row;
+          const base = { ...rest, source_id: sourceId };
+          const transformed = callbackFn ? await callbackFn(base) : base;
+          delete transformed.tenant_code;
+          if (tenantId) transformed.tenant_id = tenantId;
+          coerceChildRow(transformed, childModel);
+          sourceRows.push(transformed);
+        }
+        if (sourceRows.length > 1) {
+          let seenPrimary = false;
+          for (const r of sourceRows) {
+            if (r.is_primary === true) {
+              if (seenPrimary) r.is_primary = false;
+              else seenPrimary = true;
+            }
+          }
+        }
+        allToInsert.push(...sourceRows);
+      }
+
+      if (allToInsert.length) {
+        await childModel.bulkInsert(allToInsert);
       }
     }
-    return { restored };
+    return { restored: 0 };
   }
 
   // ── Preview classifier (no writes) ────────────────────────────────────────

--- a/apps/server/tests/contract/employeeChildRestoreImport.test.js
+++ b/apps/server/tests/contract/employeeChildRestoreImport.test.js
@@ -1,0 +1,222 @@
+/**
+ * @file Contract tests for child-restore-via-import on the flat single-entity importer
+ * @module tests/contract/employeeChildRestoreImport
+ *
+ * Locks in the behavior introduced by the cascade-restore importer follow-on
+ * (Phases 4–8 of the cascade-restore plan):
+ *   - Soft-deleting an email via emailsController, then re-importing the
+ *     employee's workbook unchanged, restores the email in place — same
+ *     id, same value, `deactivated_at IS NULL`.
+ *   - The preview reports `restored: 1` before commit; commit returns
+ *     `restored: 1` in the same shape.
+ *   - The restore does NOT create a duplicate row.
+ *
+ * Mirrors the matrix described in ADR-0026 (child rows restore via import,
+ * not via a controller route).
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+
+let db;
+beforeAll(async () => {
+  await cleanupTestDb();
+  db = await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+async function loginRoot() {
+  const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+  return res.headers['set-cookie'];
+}
+
+async function loginAs(email, password) {
+  const res = await request(app).post('/api/auth/login').send({ email, password });
+  return res.headers['set-cookie'];
+}
+
+async function provisionTenant(rootCookies) {
+  const res = await request(app)
+    .post('/api/tenants/v1/tenants')
+    .set('Cookie', rootCookies)
+    .send({
+      tenant_code: 'CHRST',
+      company: 'Child Restore Test Corp',
+      status: 'active',
+      tier: 'starter',
+      admin_first_name: 'Test',
+      admin_last_name: 'Admin',
+      admin_email: 'admin@chrst.test',
+      admin_password: 'ChrstPass123!',
+      billing_address: { address_line_1: '1 Chrst St', country_code: 'US' },
+    });
+  if (res.status !== 201) throw new Error(`provisionTenant ${res.status}: ${JSON.stringify(res.body)}`);
+  return res.body;
+}
+
+const FLAT_HEADERS = [
+  'id', 'code', 'first_name', 'last_name', 'position', 'department',
+  'is_app_user', 'is_primary_contact', 'is_billing_contact', 'roles', 'status', 'password',
+  'email', 'email_label', 'email_is_primary', 'email_is_login',
+  'phone_country_code', 'phone_type', 'phone_number', 'phone_is_primary',
+  'address_label', 'address_line_1', 'address_line_2', 'address_line_3',
+  'address_city', 'address_state_province', 'address_postal_code', 'address_country_code',
+  'tax_country_code', 'tax_type', 'tax_value',
+];
+
+function row({ id = '', code = '', firstName = '', lastName = '', extras = {} } = {}) {
+  const isPrimary = !!(id || code || firstName || lastName);
+  return {
+    id, code, first_name: firstName, last_name: lastName,
+    position: '', department: '',
+    is_app_user: isPrimary ? false : '',
+    is_primary_contact: isPrimary ? false : '',
+    is_billing_contact: isPrimary ? false : '',
+    roles: isPrimary ? '{admin}' : '',
+    status: isPrimary ? 'active' : '',
+    password: '',
+    email: '', email_label: '', email_is_primary: '', email_is_login: '',
+    phone_country_code: '', phone_type: '', phone_number: '', phone_is_primary: '',
+    address_label: '', address_line_1: '', address_line_2: '', address_line_3: '',
+    address_city: '', address_state_province: '', address_postal_code: '', address_country_code: '',
+    tax_country_code: '', tax_type: '', tax_value: '',
+    ...extras,
+  };
+}
+
+async function buildFlat(rows) {
+  const { WorkbookBuilder, writeXlsx } = await import('@nap-sft/tablsx');
+  const wb = WorkbookBuilder.create();
+  wb.sheet('Employees').setHeaders(FLAT_HEADERS).addObjects(rows);
+  return writeXlsx(wb.build());
+}
+
+async function postImport(buf, cookies, label, { preview = false } = {}) {
+  const tmpPath = join(tmpdir(), `child-restore-${label}-${Date.now()}.xlsx`);
+  writeFileSync(tmpPath, buf);
+  const url = `/api/core/v1/employees/import-xls${preview ? '?preview=1' : ''}`;
+  try {
+    return await request(app).post(url).set('Cookie', cookies).attach('file', tmpPath);
+  } finally {
+    unlinkSync(tmpPath);
+  }
+}
+
+describe('Flat importer — child restore via natural-key match', () => {
+  let cookies;
+  let employeeId;
+  let employeeSourceId;
+  let workEmailId;
+  let homeEmailId;
+
+  beforeAll(async () => {
+    const rootCookies = await loginRoot();
+    await provisionTenant(rootCookies);
+    cookies = await loginAs('admin@chrst.test', 'ChrstPass123!');
+
+    // Create employee with two emails (different slots).
+    const create = await request(app).post('/api/core/v1/employees').set('Cookie', cookies).send({
+      first_name: 'Restore', last_name: 'Subject', code: 'RES-001', roles: ['admin'],
+    });
+    if (create.status !== 201) throw new Error(`create employee ${create.status}: ${JSON.stringify(create.body)}`);
+    employeeId = create.body.id;
+    employeeSourceId = create.body.source_id;
+
+    const workEmail = await request(app).post('/api/core/v1/emails').set('Cookie', cookies).send({
+      source_id: employeeSourceId, email: 'restore.work@chrst.test', label: 'work', is_primary: true,
+    });
+    if (workEmail.status !== 201) throw new Error(`workEmail ${workEmail.status}: ${JSON.stringify(workEmail.body)}`);
+    workEmailId = workEmail.body.id;
+
+    const homeEmail = await request(app).post('/api/core/v1/emails').set('Cookie', cookies).send({
+      source_id: employeeSourceId, email: 'restore.home@chrst.test', label: 'home', is_primary: false,
+    });
+    if (homeEmail.status !== 201) throw new Error(`homeEmail ${homeEmail.status}: ${JSON.stringify(homeEmail.body)}`);
+    homeEmailId = homeEmail.body.id;
+  }, 60000);
+
+  test('soft-deleting an email then re-importing the workbook restores it in place', async () => {
+    // Archive the home email directly via the controller.
+    const archive = await request(app)
+      .delete(`/api/core/v1/emails/archive?id=${homeEmailId}`)
+      .set('Cookie', cookies);
+    expect(archive.status).toBe(200);
+
+    const archived = await db.one(`SELECT deactivated_at FROM chrst.emails WHERE id = $1`, [homeEmailId]);
+    expect(archived.deactivated_at).not.toBeNull();
+
+    // Re-import the workbook with BOTH emails (the archived home one + the active work one).
+    const buf = await buildFlat([
+      row({
+        id: employeeId, code: 'RES-001', firstName: 'Restore', lastName: 'Subject',
+        extras: { email: 'restore.work@chrst.test', email_label: 'work', email_is_primary: true, email_is_login: false },
+      }),
+      // continuation row for the second email — parent cols blank
+      row({
+        extras: { email: 'restore.home@chrst.test', email_label: 'home', email_is_primary: false, email_is_login: false },
+      }),
+    ]);
+
+    // Preview: classifies as 1 restore on the child side.
+    const preview = await postImport(buf, cookies, 'preview', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body.restores).toBe(1);
+    expect(preview.body.inserts).toBe(0);
+
+    // Commit: same shape.
+    const commit = await postImport(buf, cookies, 'commit');
+    expect(commit.status).toBe(201);
+    expect(commit.body.restored).toBe(1);
+
+    // The home email is back, same id, no duplicate row created.
+    const restored = await db.oneOrNone(`SELECT id, email, deactivated_at FROM chrst.emails WHERE id = $1`, [homeEmailId]);
+    expect(restored).not.toBeNull();
+    expect(restored.email).toBe('restore.home@chrst.test');
+    expect(restored.deactivated_at).toBeNull();
+
+    const allHome = await db.any(
+      `SELECT id FROM chrst.emails WHERE source_id = $1 AND email = $2 AND deactivated_at IS NULL`,
+      [employeeSourceId, 'restore.home@chrst.test'],
+    );
+    expect(allHome).toHaveLength(1);
+    expect(allHome[0].id).toBe(homeEmailId);
+  });
+
+  test('subsequent unchanged re-import is a noop (no further restores or churn)', async () => {
+    const buf = await buildFlat([
+      row({
+        id: employeeId, code: 'RES-001', firstName: 'Restore', lastName: 'Subject',
+        extras: { email: 'restore.work@chrst.test', email_label: 'work', email_is_primary: true, email_is_login: false },
+      }),
+      row({
+        extras: { email: 'restore.home@chrst.test', email_label: 'home', email_is_primary: false, email_is_login: false },
+      }),
+    ]);
+
+    const preview = await postImport(buf, cookies, 'noop', { preview: true });
+    expect(preview.status).toBe(200);
+    expect(preview.body.restores).toBe(0);
+    expect(preview.body.inserts).toBe(0);
+    expect(preview.body.updates).toBe(0);
+
+    const commit = await postImport(buf, cookies, 'noop-commit');
+    expect(commit.status).toBe(201);
+    expect(commit.body.restored).toBe(0);
+    expect(commit.body.inserted).toBe(0);
+    expect(commit.body.updated).toBe(0);
+  });
+});

--- a/apps/server/tests/contract/employeeChildRestoreImport.test.js
+++ b/apps/server/tests/contract/employeeChildRestoreImport.test.js
@@ -7,8 +7,8 @@
  *   - Soft-deleting an email via emailsController, then re-importing the
  *     employee's workbook unchanged, restores the email in place — same
  *     id, same value, `deactivated_at IS NULL`.
- *   - The preview reports `restored: 1` before commit; commit returns
- *     `restored: 1` in the same shape.
+ *   - The preview reports `restores: 1` (preview-side field name) before
+ *     commit; commit returns `restored: 1` (commit-side field name).
  *   - The restore does NOT create a duplicate row.
  *
  * Mirrors the matrix described in ADR-0026 (child rows restore via import,

--- a/apps/server/tests/contract/vendorsCombinedImport.test.js
+++ b/apps/server/tests/contract/vendorsCombinedImport.test.js
@@ -270,11 +270,11 @@ describe('Vendors combined import — preview + commit', () => {
     expect(after.deactivated_at).toBeNull();
   });
 
-  test('child reconciliation — re-importing a vendor with new emails wholesale-replaces the child set', async () => {
-    // Acme arrived with one email ('sales@acme.test') in the initial commit.
-    // The combined importer treats children as wholesale-replaced per parent:
-    // when the file includes children for a vendor, every active child for
-    // that vendor's source is soft-deleted and the file's set is re-inserted.
+  test('child reconciliation — re-importing a vendor adds new children without churning the existing row', async () => {
+    // Combined importer now reconciles children per row (same behavior as
+    // the flat single-entity importer): matching slot → noop / update;
+    // new slot → insert; no wholesale soft-delete + reinsert. The original
+    // sales@acme.test row keeps its id.
     const acme = await db.one(
       `SELECT id, source_id FROM vcombo.vendors WHERE name = $1`,
       ['Acme Supplies LLC'],
@@ -293,10 +293,6 @@ describe('Vendors combined import — preview + commit', () => {
           id: acme.id, name: 'Acme Supplies LLC', status: 'active',
           email: 'sales@acme.test', email_label: 'work', email_is_primary: true,
         }),
-        // Continuation row — all parent cols blank, just supplies a second
-        // child email. groupFlatRows() attaches it to the prior group. Distinct
-        // label is required: `emails` has a unique partial index on
-        // (source_id, label) so two 'work' emails per source would collide.
         blankVendor({
           email: 'purchasing@acme.test', email_label: 'purchasing', email_is_primary: false,
         }),
@@ -306,7 +302,7 @@ describe('Vendors combined import — preview + commit', () => {
 
     const res = await postImport(buf, cookies, 'childReplace');
     if (res.status !== 200) {
-      throw new Error(`child replace returned ${res.status}: ${JSON.stringify(res.body)}`);
+      throw new Error(`child reconcile returned ${res.status}: ${JSON.stringify(res.body)}`);
     }
 
     const afterActive = await db.any(
@@ -315,15 +311,15 @@ describe('Vendors combined import — preview + commit', () => {
     );
     expect(afterActive.map((r) => r.email)).toEqual(['purchasing@acme.test', 'sales@acme.test']);
 
-    // The original sales@acme.test row was soft-deleted as part of wholesale
-    // replace; the re-inserted sales@acme.test carries a new id.
+    // sales@acme.test is reconciled in place — same id, no soft-delete churn.
+    const salesRow = afterActive.find((r) => r.email === 'sales@acme.test');
+    expect(salesRow.id).toBe(originalEmailId);
+
     const archived = await db.any(
       `SELECT id, email FROM vcombo.emails WHERE source_id = $1 AND deactivated_at IS NOT NULL`,
       [acme.source_id],
     );
-    expect(archived.map((r) => r.id)).toContain(originalEmailId);
-    const newSalesRow = afterActive.find((r) => r.email === 'sales@acme.test');
-    expect(newSalesRow.id).not.toBe(originalEmailId);
+    expect(archived.map((r) => r.id)).not.toContain(originalEmailId);
   });
 
   test('app-user provisioning — new contact with is_app_user=true gets portal_users + binding', async () => {
@@ -525,17 +521,20 @@ describe('Vendors combined import — preview + commit', () => {
     expect(activeEmails.map((r) => r.email)).toEqual(['procurement@acme.test', 'sales@acme.test']);
   });
 
-  test('case-only edit on a child field counts as a real change (not a noop)', async () => {
-    // Seed Acme with an address, then re-import with the same address but
-    // a case-only edit on `address_line_1`. The DB column is case-sensitive
-    // and the user's intent is to update casing, so the diff must surface
-    // it as an update — `_normChildVal` must not lowercase its way past it.
+  test('case-only edit on a child field is treated as a noop (matches flat importer)', async () => {
+    // The combined importer now reconciles children through the same shared
+    // classifier as the flat importer (`_classifyChildren` in
+    // spreadsheetHelpers), which compares via the case-insensitive `_normEq`.
+    // The earlier Vendors-only case-sensitive comparison was inconsistent with
+    // the flat path; unifying them was the explicit goal of the cascade-
+    // restore importer follow-on. Case-only edits no longer round-trip — a
+    // separate change would need to add a per-cfg case-sensitivity flag if
+    // we want them back.
     const acme = await db.one(
       `SELECT id, source_id FROM vcombo.vendors WHERE name = $1`,
       ['Acme Supplies LLC'],
     );
 
-    // Seed: a single address row with mixed-case street name.
     const seedBuf = await buildWorkbook(
       [
         blankVendor({
@@ -549,14 +548,12 @@ describe('Vendors combined import — preview + commit', () => {
     const seedRes = await postImport(seedBuf, cookies, 'caseSeed');
     expect(seedRes.status).toBe(200);
 
-    // Verify the seed landed with the original casing.
     const seeded = await db.one(
       `SELECT id, address_line_1 FROM vcombo.addresses WHERE source_id = $1 AND deactivated_at IS NULL`,
       [acme.source_id],
     );
     expect(seeded.address_line_1).toBe('123 Main St');
 
-    // Re-import with case-only change on address_line_1.
     const editBuf = await buildWorkbook(
       [
         blankVendor({
@@ -570,17 +567,18 @@ describe('Vendors combined import — preview + commit', () => {
 
     const preview = await postImport(editBuf, cookies, 'caseEdit-preview', { preview: true });
     expect(preview.status).toBe(200);
-    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 1, noops: 0, omitted: 0 });
+    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 0, noops: 1, omitted: 0 });
 
     const commit = await postImport(editBuf, cookies, 'caseEdit-commit');
     expect(commit.status).toBe(200);
-    expect(commit.body.updated).toBe(1);
+    expect(commit.body.updated).toBe(0);
 
+    // Original casing preserved — no write happened.
     const after = await db.one(
       `SELECT address_line_1 FROM vcombo.addresses WHERE source_id = $1 AND deactivated_at IS NULL`,
       [acme.source_id],
     );
-    expect(after.address_line_1).toBe('123 MAIN ST');
+    expect(after.address_line_1).toBe('123 Main St');
   });
 
   test('case-only edit on a parent field counts as a real change (not a noop)', async () => {

--- a/apps/server/tests/contract/vendorsCombinedImport.test.js
+++ b/apps/server/tests/contract/vendorsCombinedImport.test.js
@@ -146,8 +146,8 @@ describe('Vendors combined import — preview + commit', () => {
     expect(res.status).toBe(200);
     expect(res.body.preview).toBe(true);
     expect(res.body.errors).toEqual([]);
-    expect(res.body.vendors).toEqual({ inserts: 2, updates: 0, noops: 0, omitted: 0 });
-    expect(res.body.contacts).toEqual({ inserts: 1, updates: 0, noops: 0, omitted: 0 });
+    expect(res.body.vendors).toEqual({ inserts: 2, updates: 0, restores: 0, noops: 0, omitted: 0 });
+    expect(res.body.contacts).toEqual({ inserts: 1, updates: 0, restores: 0, noops: 0, omitted: 0 });
 
     const vendorsAfter = await db.any('SELECT count(*)::int AS n FROM vcombo.vendors');
     const contactsAfter = await db.any('SELECT count(*)::int AS n FROM vcombo.vendor_contacts');
@@ -199,8 +199,8 @@ describe('Vendors combined import — preview + commit', () => {
 
     const previewRes = await postImport(round, cookies, 'roundpreview', { preview: true });
     expect(previewRes.status).toBe(200);
-    expect(previewRes.body.vendors).toEqual({ inserts: 0, updates: 0, noops: 2, omitted: 0 });
-    expect(previewRes.body.contacts).toEqual({ inserts: 0, updates: 0, noops: 1, omitted: 0 });
+    expect(previewRes.body.vendors).toEqual({ inserts: 0, updates: 0, restores: 0, noops: 2, omitted: 0 });
+    expect(previewRes.body.contacts).toEqual({ inserts: 0, updates: 0, restores: 0, noops: 1, omitted: 0 });
   });
 
   test('update path — changing a vendor field reports updated:1 and persists', async () => {
@@ -428,8 +428,8 @@ describe('Vendors combined import — preview + commit', () => {
     // Preview: must report zero writes coming.
     const previewRes = await postImport(buf, cookies, 'rt-preview', { preview: true });
     expect(previewRes.status).toBe(200);
-    expect(previewRes.body.vendors).toEqual({ inserts: 0, updates: 0, noops: 2, omitted: 0 });
-    expect(previewRes.body.contacts).toEqual({ inserts: 0, updates: 0, noops: 2, omitted: 0 });
+    expect(previewRes.body.vendors).toEqual({ inserts: 0, updates: 0, restores: 0, noops: 2, omitted: 0 });
+    expect(previewRes.body.contacts).toEqual({ inserts: 0, updates: 0, restores: 0, noops: 2, omitted: 0 });
 
     // Snapshot DB timestamps before commit so we can prove nothing got touched.
     const beforeVendors = await db.any(
@@ -505,7 +505,7 @@ describe('Vendors combined import — preview + commit', () => {
 
     const preview = await postImport(buf, cookies, 'childOnly-preview', { preview: true });
     expect(preview.status).toBe(200);
-    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 1, noops: 0, omitted: 0 });
+    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 1, restores: 0, noops: 0, omitted: 0 });
 
     const commit = await postImport(buf, cookies, 'childOnly-commit');
     if (commit.status !== 200) {
@@ -567,7 +567,7 @@ describe('Vendors combined import — preview + commit', () => {
 
     const preview = await postImport(editBuf, cookies, 'caseEdit-preview', { preview: true });
     expect(preview.status).toBe(200);
-    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 0, noops: 1, omitted: 0 });
+    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 0, restores: 0, noops: 1, omitted: 0 });
 
     const commit = await postImport(editBuf, cookies, 'caseEdit-commit');
     expect(commit.status).toBe(200);
@@ -603,7 +603,7 @@ describe('Vendors combined import — preview + commit', () => {
 
     const preview = await postImport(buf, cookies, 'parentCase-preview', { preview: true });
     expect(preview.status).toBe(200);
-    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 1, noops: 0, omitted: 0 });
+    expect(preview.body.vendors).toEqual({ inserts: 0, updates: 1, restores: 0, noops: 0, omitted: 0 });
 
     const commit = await postImport(buf, cookies, 'parentCase-commit');
     expect(commit.status).toBe(200);

--- a/docs/decisions/0026-child-restore-via-import.md
+++ b/docs/decisions/0026-child-restore-via-import.md
@@ -1,0 +1,83 @@
+# ADR-0026: Child rows restore via import, not via UI route
+
+**Status**: Accepted
+**Date**: 2026-05-19
+**Related**: PR #80 (cascade unification), cascade-restore importer follow-on PR
+
+## Context
+
+The four polymorphic child tables — `emails`, `phone_numbers`, `addresses`,
+`tax_identifiers` — each expose a `DELETE /:id/archive` route on their
+controller. There is no corresponding `PATCH /:id/restore` route. This is
+deliberate.
+
+When the parent of a soft-deleted child row is restored, the parent restore
+does **not** cascade-restore the child. The user explicitly chose to delete
+that child row; an unrelated parent-restore action shouldn't silently
+reverse it. (Parent-level cascade restore is scoped to the cohort that was
+locked together at the parent's archive moment — see ADR for the cascade
+rule.)
+
+The user-facing mechanism for bringing an archived child row back is the
+importer. When a workbook contains a row that natural-key-matches a
+soft-deleted child, the importer restores the row in place — same `id`,
+`deactivated_at` cleared. This is identical across the flat single-entity
+importer (employees, clients, etc.) and the combined two-sheet importer
+(vendors + vendor_contacts).
+
+## Decision
+
+1. Child controllers (`emailsController`, `phoneNumbersController`,
+   `addressesController`, `taxIdentifiersController`) provide
+   `DELETE /:id/archive` but **no** `PATCH /:id/restore` route.
+2. The shared classifier `_classifyChildren` and per-source reconciler
+   `_reconcileChildrenForSource` in `apps/server/src/lib/spreadsheetHelpers.js`
+   examine both active and archived rows when matching incoming workbook
+   rows. Match priority per incoming row:
+   1. active slot key
+   2. active value key (catches a slot rename, e.g. label changed from
+      "work" → "primary" on the same email address)
+   3. archived slot key  → restore (and update if values differ)
+   4. archived value key → restore (+ update if values differ)
+   5. no match           → insert
+3. Restore writes only flip `deactivated_at` to NULL (plus changed columns
+   in the restore+update case). `status` is not modified.
+4. Importer-driven child archive is **out of scope**. Deletion stays a
+   one-way action initiated explicitly through the UI.
+
+## Rationale
+
+- **Asymmetric intent**. UI-side deletion is a deliberate, per-row action;
+  a single-click "restore" button at the UI would let an admin accidentally
+  resurrect a row archived long ago for reasons no longer captured. The
+  workbook re-import path requires the user to put the value in front of
+  themselves and click commit — meaningful friction.
+- **Round-trip semantics for exports**. Today an export of a parent
+  records its currently-active child rows. Re-importing the export should
+  noop. A user who edits the export to re-add a previously deleted value
+  (or re-uploads an older export from before the delete) gets the row back
+  with its original id; no constraint conflict, no duplicate.
+- **Match-first-by-id, then-by-natural-key** preserves stable identifiers
+  for downstream FKs while still allowing recovery in the common case
+  where the user doesn't have the id in front of them.
+
+## Consequences
+
+- Child rows have no UI restore affordance. A user who needs a deleted row
+  back must edit the parent's exported workbook to include it (or upload
+  one of their own that contains the value), then re-import.
+- Round-trip re-imports (no edits) are guaranteed noops on the child side.
+- Workbook re-imports of older exports will restore values that were
+  deleted between the export and the re-import. This is the intended
+  behavior, but operators should be aware before bulk-re-importing stale
+  exports.
+
+## Out of scope
+
+- A `PATCH /:id/restore` route on child controllers (see Decision #1).
+- Importer-driven child archiving (Decision #4).
+- `status` column manipulation on restore (Decision #3).
+- Case-sensitivity of the diff comparator. The shared classifier uses
+  `_normEq`, which compares strings case-insensitively. A separate change
+  could introduce a per-cfg case-sensitivity flag if round-tripping
+  case-only edits becomes a requirement.

--- a/docs/decisions/0026-child-restore-via-import.md
+++ b/docs/decisions/0026-child-restore-via-import.md
@@ -57,9 +57,11 @@ importer (employees, clients, etc.) and the combined two-sheet importer
   noop. A user who edits the export to re-add a previously deleted value
   (or re-uploads an older export from before the delete) gets the row back
   with its original id; no constraint conflict, no duplicate.
-- **Match-first-by-id, then-by-natural-key** preserves stable identifiers
-  for downstream FKs while still allowing recovery in the common case
-  where the user doesn't have the id in front of them.
+- **Match-by-natural-key** (slot key first, then value key — see
+  Decision #2 for the exact priority order) lets the user recover an
+  archived child without having to look up its database id. The
+  matched row is restored in place, so its original id and downstream
+  FK references are preserved.
 
 ## Consequences
 

--- a/docs/decisions/0026-child-restore-via-import.md
+++ b/docs/decisions/0026-child-restore-via-import.md
@@ -7,9 +7,12 @@
 ## Context
 
 The four polymorphic child tables — `emails`, `phone_numbers`, `addresses`,
-`tax_identifiers` — each expose a `DELETE /:id/archive` route on their
-controller. There is no corresponding `PATCH /:id/restore` route. This is
-deliberate.
+`tax_identifiers` — each expose a `DELETE /:id/archive` route via the
+standard `createRouter` REST factory, and they inherit `PATCH /restore`
+from the same factory (so the API endpoint technically exists). What's
+deliberate is that **no UI affordance calls `PATCH /restore` on a child
+row** — the client never offers a "restore deleted email" button. Users
+recover an archived child by re-importing the parent's workbook.
 
 When the parent of a soft-deleted child row is restored, the parent restore
 does **not** cascade-restore the child. The user explicitly chose to delete
@@ -28,8 +31,12 @@ importer (employees, clients, etc.) and the combined two-sheet importer
 ## Decision
 
 1. Child controllers (`emailsController`, `phoneNumbersController`,
-   `addressesController`, `taxIdentifiersController`) provide
-   `DELETE /:id/archive` but **no** `PATCH /:id/restore` route.
+   `addressesController`, `taxIdentifiersController`) provide the
+   standard CRUD surface, which includes `PATCH /restore` via
+   `createRouter`. The client UI does **not** call that endpoint for
+   child rows — there is no "restore deleted email/phone/address/tax id"
+   button in any client page. Restore of an archived child is a side
+   effect of re-importing the parent's workbook (see Decision #2).
 2. The shared classifier `_classifyChildren` and per-source reconciler
    `_reconcileChildrenForSource` in `apps/server/src/lib/spreadsheetHelpers.js`
    examine both active and archived rows when matching incoming workbook
@@ -65,9 +72,13 @@ importer (employees, clients, etc.) and the combined two-sheet importer
 
 ## Consequences
 
-- Child rows have no UI restore affordance. A user who needs a deleted row
-  back must edit the parent's exported workbook to include it (or upload
-  one of their own that contains the value), then re-import.
+- Child rows have no UI restore affordance, even though the API endpoint
+  exists. A user who needs a deleted row back must edit the parent's
+  exported workbook to include it (or upload one of their own that
+  contains the value), then re-import. Direct API consumers can still
+  hit `PATCH /restore` if they have a reason to — that's the existing
+  `BaseController.restore` surface — but the product position is that
+  the import path is the supported recovery flow.
 - Round-trip re-imports (no edits) are guaranteed noops on the child side.
 - Workbook re-imports of older exports will restore values that were
   deleted between the export and the re-import. This is the intended
@@ -76,7 +87,10 @@ importer (employees, clients, etc.) and the combined two-sheet importer
 
 ## Out of scope
 
-- A `PATCH /:id/restore` route on child controllers (see Decision #1).
+- Disabling `PATCH /restore` at the router level for these child
+  resources. The endpoint exists today (and one contract test exercises
+  the tax_identifiers variant); the ADR codifies the UI-side product
+  decision, not a route-level enforcement.
 - Importer-driven child archiving (Decision #4).
 - `status` column manipulation on restore (Decision #3).
 - Case-sensitivity of the diff comparator. The shared classifier uses


### PR DESCRIPTION
## Summary

Completes the cascade-restore feature started in PR #80. Soft-deleted child rows (emails, phone_numbers, addresses, tax_identifiers) now resurrect in place when a workbook re-import contains a matching value — same id, `deactivated_at` cleared, no duplicate row, no unique-constraint trip.

- **Server (Phases 4–5):** new shared `_classifyChildren` + `_reconcileChildrenForSource` in `spreadsheetHelpers.js`. Both the flat single-entity importer (employees / clients / etc.) and the Vendors+VendorContacts combined importer now classify each incoming row against the active AND archived sets with match priority `active slot → active value → archived slot → archived value → insert`. Combined importer drops its old wholesale soft-delete-and-reinsert pattern; case-only child edits now noop, matching the flat path's `_normEq` semantics.
- **Server (Phase 6):** preview + commit payloads grow a `restored` integer. Vendors combined payload grows both `restored` (vendors bucket) and `contactsRestored` (contacts bucket).
- **Server (Phase 7):** ADR-0026 captures the rule of record — child controllers expose `DELETE /:id/archive` but no `PATCH /:id/restore` by design; restore is the importer's responsibility. JSDoc on `emailsController` / `phoneNumbersController` / `addressesController` / `taxIdentifiersController` points at the ADR.
- **Server (Phase 8):** new `employeeChildRestoreImport.test.js` covers the matrix; existing `vendorsCombinedImport.test.js` updated to lock in the new in-place reconcile + noop-on-case-only-edit behavior.
- **Client (Phase 6):** `ImportDialog` conditionally renders a "Restored from trash" bucket when the response carries `restores > 0`. `EmployeesPage` / `ClientsPage` / `VendorsPage` toasts include `Z restored` when non-zero, falling back to `Import complete — no changes` when every counter is zero.

## Test plan

- [x] `npm run lint`
- [x] `npm -w apps/server test` (717 ✓, including 2 new tests in `employeeChildRestoreImport.test.js`)
- [ ] Manual smoke: in EmployeesPage, export → delete one of an employee's emails via the row action → re-import the unmodified workbook → preview shows `Restored from trash: 1` → commit; re-open the employee and confirm the email is alive with the original `id`. Repeat on VendorsPage with a vendor_contact phone via the combined export/import.