### PR TITLE
feat(server): Phase 3 — load RBAC permissions at login and reject empty caps

### DIFF
--- a/apps/server/src/middleware/authRedis.js
+++ b/apps/server/src/middleware/authRedis.js
@@ -11,12 +11,11 @@
 
 import jwt from 'jsonwebtoken';
 import logger from '../lib/logger.js';
-import { loadPermissions } from '../services/permissionLoader.js';
+import { loadPermissions, primePermCache, permCacheKey } from '../services/permissionLoader.js';
 import { calcPermHash } from '../lib/permHash.js';
 import { getRedis } from '../db/redis.js';
 
 const AUTH_BYPASS_SEGMENTS = ['/auth/login', '/auth/refresh', '/auth/logout'];
-const PERM_CACHE_TTL = 900; // 15 minutes
 
 /**
  * Check if the request path should bypass authentication.
@@ -32,30 +31,19 @@ function shouldBypassAuth(path, fullPath) {
 }
 
 /**
- * Try to read cached permissions from Redis.
+ * Try to read cached permissions from Redis. The write side lives in
+ * `permissionLoader.primePermCache` so the key shape stays in one place.
  * @returns {object|null} Cached permission canon, or null on miss/error
  */
 async function getCachedPermissions(userId, tenantCode) {
   try {
     const redis = await getRedis();
-    const cached = await redis.get(`perm:${userId}:${tenantCode}`);
+    const cached = await redis.get(permCacheKey(userId, tenantCode));
     if (cached) return JSON.parse(cached);
   } catch {
     // Redis unavailable — fall through to DB
   }
   return null;
-}
-
-/**
- * Cache permissions in Redis.
- */
-async function cachePermissions(userId, tenantCode, canon) {
-  try {
-    const redis = await getRedis();
-    await redis.set(`perm:${userId}:${tenantCode}`, JSON.stringify(canon), 'EX', PERM_CACHE_TTL);
-  } catch {
-    // Redis unavailable — non-fatal
-  }
 }
 
 /**
@@ -192,8 +180,8 @@ export function authRedis() {
       // once the user gains a binding to that tenant.
       const fellBackToHome = activeBinding === homeBinding;
       const schemaName = fellBackToHome ? homeSchemaName : effectiveTenantRecord.schema_name;
-      const permCacheKey = fellBackToHome ? homeTenantCode : tenantCode;
-      let permissions = await getCachedPermissions(uid, permCacheKey);
+      const cacheTenantCode = fellBackToHome ? homeTenantCode : tenantCode;
+      let permissions = await getCachedPermissions(uid, cacheTenantCode);
 
       if (!permissions) {
         permissions = await loadPermissions({
@@ -202,7 +190,7 @@ export function authRedis() {
           entityType: activeBinding.entity_type,
           entityId: activeBinding.entity_id,
         });
-        await cachePermissions(uid, permCacheKey, permissions);
+        await primePermCache(uid, cacheTenantCode, permissions);
       }
 
       // ── Stale Token Detection ───────────────────────────────────────────

--- a/apps/server/src/services/permissionLoader.js
+++ b/apps/server/src/services/permissionLoader.js
@@ -40,10 +40,11 @@ export function permCacheKey(userId, tenantCode) {
 
 /**
  * Write a permission canon to Redis under the standard cache key. Used by
- * both the login-time prime path (`authController.login`) and the lazy
- * hydration path (`authRedis.cachePermissions`) so the key shape lives in
- * one place. Redis errors are swallowed — the cache is an optimization,
- * not the source of truth.
+ * both the login-time prime path (`authController.login`) and the
+ * request-time lazy hydration in `authRedis` (the DB-fallback branch that
+ * fires on a cache miss) so the key shape lives in one place. Redis
+ * errors are swallowed — the cache is an optimization, not the source
+ * of truth.
  */
 export async function primePermCache(userId, tenantCode, canon) {
   if (!userId || !tenantCode || !canon) return;
@@ -59,15 +60,17 @@ export async function primePermCache(userId, tenantCode, canon) {
 const SCOPE_ORDER = { self: 0, assigned_projects: 1, assigned_companies: 2, all_projects: 3 };
 
 /**
- * Maps entity_type to the table name in the tenant schema. `vendor_contact`
- * is included even though there's no plain `vendor` portal-user pattern —
- * the actual entity_type values written to `admin.portal_user_tenants`
- * (see the CHECK constraint on that table) are `employee`, `client`, and
- * `vendor_contact`. The other entries (`vendor`, `contact`) are kept for
- * forward compatibility with downstream features that may bind a portal
- * user directly to a vendor or one-off contact.
+ * Maps `entity_type` (from `admin.portal_user_tenants`) to the
+ * pg-schemata MODEL KEY passed into `db(modelName, schemaName)` — not
+ * the literal SQL table name. The two differ for multi-word entities
+ * (model key `vendorContacts`, SQL table `vendor_contacts`); single
+ * lowercase entities happen to coincide. `vendor_contact` is the value
+ * actually written to the CHECK-constrained `entity_type` column,
+ * alongside `employee` and `client`. `vendor` and `contact` are kept
+ * here for forward compatibility with downstream features that may
+ * bind a portal user directly to a vendor or one-off contact.
  */
-const ENTITY_TABLE_MAP = {
+const ENTITY_MODEL_MAP = {
   employee: 'employees',
   vendor: 'vendors',
   vendor_contact: 'vendorContacts',
@@ -98,11 +101,11 @@ const EMPTY_CANON = Object.freeze({
 async function resolveEntityRoles(schemaName, entityType, entityId) {
   if (!entityType || !entityId) return [];
 
-  const tableName = ENTITY_TABLE_MAP[entityType];
-  if (!tableName) return [];
+  const modelName = ENTITY_MODEL_MAP[entityType];
+  if (!modelName) return [];
 
   try {
-    const modelInstance = db(tableName, schemaName);
+    const modelInstance = db(modelName, schemaName);
     if (!modelInstance) return [];
 
     const entity = await modelInstance.findById(entityId);

--- a/apps/server/src/services/permissionLoader.js
+++ b/apps/server/src/services/permissionLoader.js
@@ -17,17 +17,52 @@
 
 import db from '../db/db.js';
 import logger from '../lib/logger.js';
+import { getRedis } from '../db/redis.js';
 
 const LEVEL_ORDER = { none: 0, view: 1, full: 2 };
 const LEVEL_NAMES = ['none', 'view', 'full'];
 
+/** TTL for the permission cache entry. Matches authRedis.js `PERM_CACHE_TTL`. */
+export const PERM_CACHE_TTL_SECONDS = 900;
+
+/** Cache key shape — single source of truth, shared with authRedis. */
+export function permCacheKey(userId, tenantCode) {
+  return `perm:${userId}:${tenantCode}`;
+}
+
+/**
+ * Write a permission canon to Redis under the standard cache key. Used by
+ * both the login-time prime path (`authController.login`) and the lazy
+ * hydration path (`authRedis.cachePermissions`) so the key shape lives in
+ * one place. Redis errors are swallowed — the cache is an optimization,
+ * not the source of truth.
+ */
+export async function primePermCache(userId, tenantCode, canon) {
+  if (!userId || !tenantCode || !canon) return;
+  try {
+    const redis = await getRedis();
+    await redis.set(permCacheKey(userId, tenantCode), JSON.stringify(canon), 'EX', PERM_CACHE_TTL_SECONDS);
+  } catch {
+    // Redis unavailable — fall through; lazy hydration on next request handles it.
+  }
+}
+
 /** Scope hierarchy: higher value = broader access. Most permissive wins on merge. */
 const SCOPE_ORDER = { self: 0, assigned_projects: 1, assigned_companies: 2, all_projects: 3 };
 
-/** Maps entity_type to the table name in the tenant schema. */
+/**
+ * Maps entity_type to the table name in the tenant schema. `vendor_contact`
+ * is included even though there's no plain `vendor` portal-user pattern —
+ * the actual entity_type values written to `admin.portal_user_tenants`
+ * (see the CHECK constraint on that table) are `employee`, `client`, and
+ * `vendor_contact`. The other entries (`vendor`, `contact`) are kept for
+ * forward compatibility with downstream features that may bind a portal
+ * user directly to a vendor or one-off contact.
+ */
 const ENTITY_TABLE_MAP = {
   employee: 'employees',
   vendor: 'vendors',
+  vendor_contact: 'vendorContacts',
   client: 'clients',
   contact: 'contacts',
 };
@@ -260,4 +295,4 @@ export async function loadPermissions({ schemaName, userId, entityType = null, e
   };
 }
 
-export default { loadPermissions };
+export default { loadPermissions, primePermCache, permCacheKey, PERM_CACHE_TTL_SECONDS };

--- a/apps/server/src/services/permissionLoader.js
+++ b/apps/server/src/services/permissionLoader.js
@@ -22,12 +22,20 @@ import { getRedis } from '../db/redis.js';
 const LEVEL_ORDER = { none: 0, view: 1, full: 2 };
 const LEVEL_NAMES = ['none', 'view', 'full'];
 
-/** TTL for the permission cache entry. Matches authRedis.js `PERM_CACHE_TTL`. */
+/** TTL (seconds) for the permission cache entry. Single source of truth. */
 export const PERM_CACHE_TTL_SECONDS = 900;
 
-/** Cache key shape — single source of truth, shared with authRedis. */
+/**
+ * Cache key shape — single source of truth, shared with `authRedis`.
+ * Tenant code is lowercased here because the request-time middleware
+ * lowercases its lookup key (see `authRedis.js`'s `homeTenantCode` /
+ * `tenantCode` derivations). Without normalizing in this one place,
+ * login-time priming would write `perm:<uid>:AXERRA` while reads went
+ * to `perm:<uid>:axerra`, missing the primed entry on every request.
+ */
 export function permCacheKey(userId, tenantCode) {
-  return `perm:${userId}:${tenantCode}`;
+  const normalized = tenantCode == null ? '' : String(tenantCode).toLowerCase();
+  return `perm:${userId}:${normalized}`;
 }
 
 /**

--- a/apps/server/src/system/auth/controllers/authController.js
+++ b/apps/server/src/system/auth/controllers/authController.js
@@ -14,7 +14,43 @@ import { setAuthCookies, clearAuthCookies } from '../../../lib/cookies.js';
 import jwt from 'jsonwebtoken';
 import db, { pgp } from '../../../db/db.js';
 import { invalidateByUser } from '../../../services/permCacheInvalidator.js';
+import { loadPermissions, primePermCache } from '../../../services/permissionLoader.js';
+import { calcPermHash } from '../../../lib/permHash.js';
 import logger from '../../../lib/logger.js';
+
+const NO_PERMISSIONS_MESSAGE = 'Your account has no permissions assigned. Contact your administrator.';
+
+/**
+ * Resolve a portal_user's RBAC canon for their home tenant, and refuse
+ * to issue tokens when the canon's `caps` is empty. Shared by `login`
+ * (Passport-authenticated) and `refresh` (refresh-token-authenticated)
+ * so the gate fires on every token issuance, not just the first one.
+ *
+ * Returns `{ ph, permissions, tenantCode }` on success, `null` after
+ * having written a 403 to the response on failure.
+ */
+async function resolveAndGatePermissions(res, user, tenant, binding) {
+  const permissions = await loadPermissions({
+    schemaName: tenant.schema_name,
+    userId: user.id,
+    entityType: binding?.entity_type ?? null,
+    entityId: binding?.entity_id ?? null,
+  });
+
+  if (!permissions.caps || Object.keys(permissions.caps).length === 0) {
+    logger.warn('Login blocked — empty permission set', {
+      userId: user.id,
+      tenantCode: tenant.tenant_code,
+      entityType: binding?.entity_type ?? null,
+      entityId: binding?.entity_id ?? null,
+    });
+    res.status(403).json({ message: NO_PERMISSIONS_MESSAGE });
+    return null;
+  }
+
+  await primePermCache(user.id, tenant.tenant_code, permissions);
+  return { ph: calcPermHash(permissions), permissions, tenantCode: tenant.tenant_code };
+}
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const EMAIL_MAX_LEN = 128;
@@ -34,19 +70,27 @@ export const login = (req, res, next) => {
       return res.status(400).json({ message: info?.message || 'Login failed' });
     }
 
-    const _tenant = user._tenant;
+    try {
+      // Phase 3: load RBAC permissions for the home tenant and gate the
+      // token issuance on the result. A user with no caps (no entity, no
+      // roles, or roles that don't resolve to any policy) is refused with
+      // 403 — credentials were valid, but the account is unusable. The
+      // canon is then primed into the Redis cache so the user's first
+      // authenticated request doesn't repeat the load.
+      const gate = await resolveAndGatePermissions(res, user, user._tenant, user._binding);
+      if (!gate) return; // resolveAndGatePermissions wrote the 403
 
-    // Phase 3 will add RBAC permission loading and Redis caching here.
-    // For now, ph is null (no permission hash).
-    const ph = null;
+      const accessToken = signAccessToken(user, { sub: user.id, ph: gate.ph });
+      const refreshToken = signRefreshToken(user, { sub: user.id });
 
-    const accessToken = signAccessToken(user, { sub: user.id, ph });
-    const refreshToken = signRefreshToken(user, { sub: user.id });
+      setAuthCookies(res, { accessToken, refreshToken });
 
-    setAuthCookies(res, { accessToken, refreshToken });
-
-    const forcePasswordChange = user.status === 'invited';
-    return res.json({ message: 'Logged in successfully', forcePasswordChange });
+      const forcePasswordChange = user.status === 'invited';
+      return res.json({ message: 'Logged in successfully', forcePasswordChange });
+    } catch (loadErr) {
+      logger.error('Login permission load failed', { userId: user.id, error: loadErr.message });
+      return res.status(500).json({ message: 'Login failed' });
+    }
   })(req, res, next);
 };
 
@@ -68,16 +112,38 @@ export const refresh = async (req, res) => {
     const user = await db('portalUsers', 'admin').findOneBy([{ id: decoded.sub }]);
     if (!user) return res.status(404).json({ message: 'User not found' });
 
-    // Phase 3 will add RBAC permission reload here
-    const ph = null;
+    // Re-fetch the user's home binding + tenant so the same Phase 3 gate
+    // applies on refresh — a user whose authorization has been revoked
+    // since their last login (roles unassigned, entity archived) must
+    // not be allowed to rotate to a fresh access token.
+    const homeRow = await db.oneOrNone(
+      `SELECT t.*,
+              b.entity_type AS _home_entity_type,
+              b.entity_id   AS _home_entity_id
+         FROM admin.portal_user_tenants b
+         JOIN admin.tenants t ON t.id = b.tenant_id
+        WHERE b.portal_user_id = $1 AND b.deactivated_at IS NULL
+        ORDER BY b.created_at ASC
+        LIMIT 1`,
+      [user.id],
+    );
+    if (!homeRow || homeRow.deactivated_at !== null) {
+      return res.status(403).json({ message: 'Tenant is inactive.' });
+    }
+    const { _home_entity_type, _home_entity_id, ...tenant } = homeRow;
+    const binding = { entity_type: _home_entity_type ?? null, entity_id: _home_entity_id ?? null };
 
-    const accessToken = signAccessToken(user, { sub: user.id, ph });
+    const gate = await resolveAndGatePermissions(res, user, tenant, binding);
+    if (!gate) return;
+
+    const accessToken = signAccessToken(user, { sub: user.id, ph: gate.ph });
     const refreshToken = signRefreshToken(user, { sub: user.id });
 
     setAuthCookies(res, { accessToken, refreshToken });
 
     return res.json({ message: 'Access token refreshed' });
-  } catch {
+  } catch (err) {
+    logger.error('Refresh failed', { userId: decoded?.sub, error: err.message });
     return res.status(500).json({ message: 'Error refreshing token' });
   }
 };

--- a/apps/server/src/system/auth/services/passportService.js
+++ b/apps/server/src/system/auth/services/passportService.js
@@ -36,9 +36,13 @@ passport.use(
       const isMatch = await bcrypt.compare(password, user.password_hash);
       if (!isMatch) return done(null, false, { message: 'Incorrect password.' });
 
-      // Resolve home binding + tenant
-      const tenant = await db.oneOrNone(
-        `SELECT t.*
+      // Resolve home binding + tenant. We pull the binding's polymorphic
+      // entity link (entity_type, entity_id) so the auth controller can
+      // run RBAC permission loading at login without re-querying.
+      const homeRow = await db.oneOrNone(
+        `SELECT t.*,
+                b.entity_type AS _home_entity_type,
+                b.entity_id   AS _home_entity_id
          FROM admin.portal_user_tenants b
          JOIN admin.tenants t ON t.id = b.tenant_id
          WHERE b.portal_user_id = $1 AND b.deactivated_at IS NULL
@@ -46,12 +50,19 @@ passport.use(
          LIMIT 1`,
         [user.id],
       );
-      if (!tenant || tenant.deactivated_at !== null) {
+      if (!homeRow || homeRow.deactivated_at !== null) {
         return done(null, false, { message: 'Tenant is inactive.' });
       }
 
-      // Attach tenant context for the auth controller
+      // Separate the binding fields so `user._tenant` stays the clean
+      // tenants row shape; the home binding's entity link lives on
+      // `user._binding`.
+      const { _home_entity_type, _home_entity_id, ...tenant } = homeRow;
       user._tenant = tenant;
+      user._binding = {
+        entity_type: _home_entity_type ?? null,
+        entity_id: _home_entity_id ?? null,
+      };
 
       return done(null, user);
     } catch (err) {

--- a/apps/server/tests/contract/authChangeEmail.test.js
+++ b/apps/server/tests/contract/authChangeEmail.test.js
@@ -119,7 +119,7 @@ describe('PATCH /api/auth/me/email — self-service login email change', () => {
         last_name: 'Shared',
         email: ORIGINAL_EMAIL,
         is_app_user: true,
-        roles: ['vendor'],
+        roles: ['vendor_contact'],
         password: 'SallyPass123!',
       });
     expect(cA.status).toBe(201);
@@ -134,7 +134,7 @@ describe('PATCH /api/auth/me/email — self-service login email change', () => {
         last_name: 'Shared',
         email: ORIGINAL_EMAIL,
         is_app_user: true,
-        roles: ['vendor'],
+        roles: ['vendor_contact'],
         password: 'IgnoredPass123!',
       });
     expect(cB.status).toBe(201);

--- a/apps/server/tests/contract/loginPermissionGate.test.js
+++ b/apps/server/tests/contract/loginPermissionGate.test.js
@@ -5,7 +5,10 @@
  * Locks in the behavior introduced by Phase 3 (`authController.login`):
  *   - Properly-configured user (root admin) logs in successfully, gets
  *     cookies, and the permission canon is primed into Redis at the
- *     standard cache key (`perm:${userId}:${tenantCode}`).
+ *     standard cache key produced by `permCacheKey(userId, tenantCode)`
+ *     (`perm:${userId}:${tenantCode.toLowerCase()}` — tenant code is
+ *     normalized to lowercase so login-side writes line up with the
+ *     request-side reads in `authRedis`).
  *   - Bare-registered user with no entity binding (entity_type/entity_id
  *     are NULL on the home binding) is refused with 403 + the documented
  *     message and no cookies are set.

--- a/apps/server/tests/contract/loginPermissionGate.test.js
+++ b/apps/server/tests/contract/loginPermissionGate.test.js
@@ -1,0 +1,90 @@
+/**
+ * @file Contract tests for the Phase 3 login-time permission gate
+ * @module tests/contract/loginPermissionGate
+ *
+ * Locks in the behavior introduced by Phase 3 (`authController.login`):
+ *   - Properly-configured user (root admin) logs in successfully, gets
+ *     cookies, and the permission canon is primed into Redis at the
+ *     standard cache key (`perm:${userId}:${tenantCode}`).
+ *   - Bare-registered user with no entity binding (entity_type/entity_id
+ *     are NULL on the home binding) is refused with 403 + the documented
+ *     message and no cookies are set.
+ *
+ * Copyright (c) 2025 – present Axerra LLC. All rights reserved.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { bootstrapAdmin, cleanupTestDb } from '../helpers/testDb.js';
+import { getRedis } from '../../src/db/redis.js';
+import { permCacheKey } from '../../src/services/permissionLoader.js';
+
+const ROOT_EMAIL = process.env.ROOT_EMAIL;
+const ROOT_PASSWORD = process.env.ROOT_PASSWORD;
+const ROOT_TENANT_CODE = (process.env.ROOT_TENANT_CODE || 'AXERRA').toUpperCase();
+
+beforeAll(async () => {
+  await cleanupTestDb();
+  await bootstrapAdmin();
+}, 30000);
+
+const { default: app } = await import('../../src/app.js');
+
+afterAll(async () => {
+  await cleanupTestDb();
+}, 15000);
+
+describe('Phase 3 login-time permission gate', () => {
+  test('properly-configured root admin logs in and the permission cache is primed', async () => {
+    const redis = await getRedis();
+
+    // Find the root user id so we can check the Redis key after login.
+    const adminUser = await (await import('../../src/db/db.js')).default.oneOrNone(
+      `SELECT id FROM admin.portal_users WHERE email = $1`,
+      [ROOT_EMAIL],
+    );
+    expect(adminUser).not.toBeNull();
+    const cacheKey = permCacheKey(adminUser.id, ROOT_TENANT_CODE);
+
+    // Ensure the cache key is clear before login so the test asserts a
+    // login-time prime, not a leftover from another test.
+    await redis.del(cacheKey);
+
+    const res = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Logged in successfully');
+    expect(res.headers['set-cookie']).toBeDefined();
+    expect(res.headers['set-cookie'].some((c) => c.startsWith('auth_token='))).toBe(true);
+
+    // Cache should now be populated with a canon carrying non-empty caps.
+    const cached = await redis.get(cacheKey);
+    expect(cached).not.toBeNull();
+    const canon = JSON.parse(cached);
+    expect(canon.caps).toBeDefined();
+    expect(Object.keys(canon.caps).length).toBeGreaterThan(0);
+  });
+
+  test('bare-registered user (no entity binding) is refused with 403 and no cookies', async () => {
+    // Use a unique email so this is independent of any other suite.
+    const TEST_EMAIL = 'phase3-gate@axerra.io';
+    const TEST_PASSWORD = 'GateTest123!';
+
+    // Register a portal user via the admin endpoint. The register flow
+    // creates the portal_user and an auth-only portal_user_tenants binding
+    // with entity_type/entity_id = NULL — exactly the case the gate is
+    // supposed to reject.
+    const adminLogin = await request(app).post('/api/auth/login').send({ email: ROOT_EMAIL, password: ROOT_PASSWORD });
+    const adminCookies = adminLogin.headers['set-cookie'];
+
+    const reg = await request(app)
+      .post('/api/tenants/v1/portal-users/register')
+      .set('Cookie', adminCookies)
+      .send({ tenant_code: ROOT_TENANT_CODE, email: TEST_EMAIL, password: TEST_PASSWORD });
+    expect(reg.status).toBe(201);
+
+    const res = await request(app).post('/api/auth/login').send({ email: TEST_EMAIL, password: TEST_PASSWORD });
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/no permissions/i);
+    expect(res.headers['set-cookie']).toBeUndefined();
+  });
+});

--- a/apps/server/tests/contract/reports.test.js
+++ b/apps/server/tests/contract/reports.test.js
@@ -56,9 +56,23 @@ vi.mock('../../src/services/tenantProvisioning.js', () => ({
   provisionTenant: vi.fn().mockResolvedValue({ applied: [] }),
 }));
 
-// Mock permission loader
+// Mock permission loader. `loadPermissions` must return a canon with
+// non-empty `caps` so the Phase-3 login gate doesn't reject the mock
+// user. `primePermCache` is a no-op in this test (no real Redis).
 vi.mock('../../src/services/permissionLoader.js', () => ({
-  loadPermissions: vi.fn().mockResolvedValue({}),
+  loadPermissions: vi.fn().mockResolvedValue({
+    caps: { 'reports::reports::view': 'full' },
+    scope: 'all_projects',
+    projectIds: null,
+    companyIds: null,
+    entityType: null,
+    entityId: null,
+    stateFilters: {},
+    fieldGroups: {},
+  }),
+  primePermCache: vi.fn().mockResolvedValue(undefined),
+  permCacheKey: (uid, tenantCode) => `perm:${uid}:${tenantCode}`,
+  PERM_CACHE_TTL_SECONDS: 900,
 }));
 
 // Mock DB

--- a/apps/server/tests/integration/userRegistration.test.js
+++ b/apps/server/tests/integration/userRegistration.test.js
@@ -56,29 +56,33 @@ describe('User registration lifecycle — register → login → verify', () => 
     expect(res.body.user.password_hash).toBeUndefined();
   });
 
-  test('2. New user can log in', async () => {
+  test('2. Bare-registered user (no entity binding) is blocked at login by Phase 3 gate', async () => {
+    // /portal-users/register creates the portal_user + an auth-only
+    // portal_user_tenants binding with entity_type/entity_id = NULL.
+    // The user has no roles, so loadPermissions returns empty caps and
+    // the Phase 3 login gate refuses to issue tokens.
     const res = await request(app).post('/api/auth/login').send({
       email: TEST_EMAIL,
       password: TEST_PASSWORD,
     });
 
-    expect(res.status).toBe(200);
-    expect(res.body.message).toBe('Logged in successfully');
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/no permissions/i);
+    // No cookies set on a rejected login.
+    expect(res.headers['set-cookie']).toBeUndefined();
   });
 
-  test('3. New user can access /me', async () => {
-    // Login the new user
+  test('3. Rejected login leaves no usable session', async () => {
+    // Same call as test 2; verify there's no `auth_token` to use.
     const loginRes = await request(app).post('/api/auth/login').send({
       email: TEST_EMAIL,
       password: TEST_PASSWORD,
     });
-    const cookies = loginRes.headers['set-cookie'];
+    expect(loginRes.status).toBe(403);
 
-    const meRes = await request(app).get('/api/auth/me').set('Cookie', cookies);
-
-    expect(meRes.status).toBe(200);
-    expect(meRes.body.user.email).toBe(TEST_EMAIL);
-    expect(meRes.body.user.password_hash).toBeUndefined();
+    // Without a cookie, /me is 401 (not 200 — the user never got in).
+    const meRes = await request(app).get('/api/auth/me');
+    expect(meRes.status).toBe(401);
   });
 
   test('4. Archive user prevents login', async () => {
@@ -124,11 +128,15 @@ describe('User registration lifecycle — register → login → verify', () => 
 
     expect(restoreRes.status).toBe(200);
 
-    // Verify user can log in again
+    // Restore re-enables the portal_user row, but the bare-registered
+    // user still has no entity binding (and therefore no roles), so the
+    // Phase 3 gate keeps refusing login. Restoring the user record does
+    // not by itself grant authorization.
     const loginRes = await request(app).post('/api/auth/login').send({
       email: TEST_EMAIL,
       password: TEST_PASSWORD,
     });
-    expect(loginRes.status).toBe(200);
+    expect(loginRes.status).toBe(403);
+    expect(loginRes.body.message).toMatch(/no permissions/i);
   });
 });


### PR DESCRIPTION
## Summary

- `authController.login` now calls `loadPermissions` for the user's home tenant immediately after Passport verifies credentials. When the resulting canon's `caps` is empty (no entity binding, no role assignments, or role codes that don't resolve to any policy) the login is refused with **403** + a clear message and no cookies are set. The 4-layer RBAC system has always treated an empty caps map as "deny all"; this surfaces that at login instead of silently letting the user into a shell that denies every action. The same gate runs in `authController.refresh` so revoked authorization can't slip through a token rotation. JWT `ph` now carries the real `calcPermHash(canon)` value instead of the previous `null` stub, and the successful-login path primes the Redis cache at the standard `perm:${userId}:${tenantCode}` key so the user's first authenticated request skips the lazy load.
- Fixed a latent bug in `permissionLoader.ENTITY_TABLE_MAP` — `vendor_contact` had no entry, so every vendor_contact app user resolved to zero roles. The new gate exposed it; this PR adds the mapping. Centralized the Redis cache key shape into a single `permCacheKey()` helper plus a `primePermCache()` writer in `permissionLoader.js`, reused by both `authController` and `authRedis` so write/read can't drift.
- Test fixtures updated where the new gate exposed prior bugs: the bare-registration → login flow in `userRegistration.test.js` now asserts 403; `authChangeEmail` fixtures use `roles: ['vendor_contact']` (the actually-seeded role) instead of the unknown `'vendor'`; `reports.test.js` mock of `loadPermissions` returns a non-empty canon and exports the new helpers.

## Test plan

- [x] `npm run lint`
- [x] `npm -w apps/server test` (719 ✓, including 2 new tests in `loginPermissionGate.test.js`)
- [ ] Manual smoke: log in as the root admin → succeeds, /me works on the first request without a Redis cache miss. Register a portal user via `/portal-users/register` and try to log in → 403 with the documented message; no cookies set.